### PR TITLE
fix(memory): harden credential boundaries

### DIFF
--- a/src/plugin_bundle/omh/_governance_evaluation.py
+++ b/src/plugin_bundle/omh/_governance_evaluation.py
@@ -146,12 +146,12 @@ def evaluate_memory_replay(
         return result
     
     admission_state = admission.get("state")
-    result["admission_state"] = admission_state
-    
+
     from .memory_governance import ADMISSION_STATES
     if admission_state not in ADMISSION_STATES:
         result["reason_code"] = "admission_state_invalid"
         return result
+    result["admission_state"] = admission_state
     
     if admission_state in ("blocked", "rejected", "pending_review"):
         result["reason_code"] = {

--- a/src/plugin_bundle/omh/_governance_evaluation.py
+++ b/src/plugin_bundle/omh/_governance_evaluation.py
@@ -71,6 +71,7 @@ def evaluate_memory_replay(
         MEMORY_BLOCK_SCHEMA_VERSION,
         canonical_memory_scope,
         canonical_payload_digest,
+        contains_credential_like_material,
     )
     
     if now is None:
@@ -86,7 +87,11 @@ def evaluate_memory_replay(
         "admission_state": None,
         "admission_mode": None,
         "payload_digest": None,
-        "source_class": artifact.get('source_class'),
+        "source_class": (
+            "redacted"
+            if contains_credential_like_material(str(artifact.get("source_class", "")))
+            else artifact.get("source_class")
+        ),
         "retention_class": None,
     }
     

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -9,6 +9,70 @@ from __future__ import annotations
 import re
 
 
+_BLOCKED_PATTERNS = (
+    re.compile(r"password\s*=", re.IGNORECASE),
+    re.compile(r"secret\s*=", re.IGNORECASE),
+    re.compile(r"token\s*=", re.IGNORECASE),
+    # Secret-token hyphen compounds (e.g. token-secret, secret-token,
+    # abc-secret-token). Keep this narrow so ordinary prose such as
+    # "token-based parsing" remains usable.
+    re.compile(
+        r"(?:password|passwd|secret|token|key)s?-(?:password|passwd|secret|token|key)s?",
+        re.IGNORECASE,
+    ),
+    re.compile(r"api[_-]key", re.IGNORECASE),
+    re.compile(r"auth[_-]header", re.IGNORECASE),
+    re.compile(r"Bearer\s+", re.IGNORECASE),
+    # High-confidence credential formats that carry no descriptive keyword.
+    re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", re.IGNORECASE),
+    re.compile(r"\b(?:gh[oprs]|github_pat|glpat|npm|hf)[_-][A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\bAIza[A-Za-z0-9_-]{20,}\b", re.IGNORECASE),
+    re.compile(r"\bxox[a-z]?-[A-Za-z0-9-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\b[a-z][a-z0-9+.-]{1,31}://[^/\s:@]+:[^@\s/]+@", re.IGNORECASE),
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE),
+)
+
+_NEEDS_REVIEW_PATTERNS = (
+    re.compile(r"ignore\s+previous", re.IGNORECASE),
+    re.compile(r"reveal\s+the\s+system\s+prompt", re.IGNORECASE),
+    re.compile(r"disregard\s+instructions", re.IGNORECASE),
+    re.compile(r"this\s+is\s+temporary", re.IGNORECASE),
+    re.compile(r"workaround\s+while", re.IGNORECASE),
+    re.compile(r"(temporary|temp|hack|quick\s+fix)\s+", re.IGNORECASE),
+    # A credential-like value with an unknown prefix is not auto-safe. The
+    # character-class and uniqueness checks below avoid treating normal prose
+    # as an opaque value while keeping this gate deterministic.
+    re.compile(
+        r"\b(?:credential|access[_ -]?token|private[_ -]?key|secret|token|api[_ -]?key)\s*[:=]\s*\S{12,}",
+        re.IGNORECASE,
+    ),
+)
+_OPAQUE_TOKEN_PATTERN = re.compile(r"(?<![A-Za-z0-9])[A-Za-z0-9+/=_-]{32,}(?![A-Za-z0-9])")
+
+
+def _looks_like_opaque_token(content: str) -> bool:
+    """Recognize unknown long opaque values conservatively for review."""
+    for match in _OPAQUE_TOKEN_PATTERN.finditer(content):
+        token = match.group(0)
+        # Keep ordinary assignment labels and low-entropy hyphenated prose
+        # out of the opaque-value heuristic (for example sha256=aaaa... or
+        # human-definition-source-only-sentinel).
+        if "=" in token:
+            continue
+        character_classes = sum(
+            (
+                any(char.islower() for char in token),
+                any(char.isupper() for char in token),
+                any(char.isdigit() for char in token),
+                any(char in "+/=_-" for char in token),
+            )
+        )
+        if character_classes >= 3 or ("_-" not in token and len(set(token)) >= 12):
+            return True
+    return False
+
+
 def classify_memory_admission(content: str) -> dict[str, object]:
     """Classify memory content for safety admission.
     
@@ -20,39 +84,17 @@ def classify_memory_admission(content: str) -> dict[str, object]:
     if not isinstance(content, str):
         return {"status": "blocked"}
     
-    # Blocked patterns: explicit secrets/passwords, raw logs, transcripts, protected markers
-    blocked_patterns = [
-        r"password\s*=",
-        r"secret\s*=",
-        r"token\s*=",
-        # Secret-token hyphen compounds (e.g. token-secret, secret-token,
-        # abc-secret-token): two secret-class words joined by one hyphen.
-        # Narrow on purpose: no arbitrary hyphen chains, so ordinary prose
-        # like "token-based parsing" or "secret-management policy" never matches.
-        r"(?:password|passwd|secret|token|key)s?-(?:password|passwd|secret|token|key)s?",
-        r"api[_-]key",
-        r"auth[_-]header",
-        r"Bearer\s+",
-    ]
-    
-    for pattern in blocked_patterns:
-        if re.search(pattern, content, re.IGNORECASE):
+    for pattern in _BLOCKED_PATTERNS:
+        if pattern.search(content):
             return {"status": "blocked"}
-    
-    # Needs review patterns: prompt injection, temporary workarounds, credential hints
-    needs_review_patterns = [
-        r"ignore\s+previous",
-        r"reveal\s+the\s+system\s+prompt",
-        r"disregard\s+instructions",
-        r"this\s+is\s+temporary",
-        r"workaround\s+while",
-        r"(temporary|temp|hack|quick\s+fix)\s+",
-    ]
-    
-    for pattern in needs_review_patterns:
-        if re.search(pattern, content, re.IGNORECASE):
+
+    for pattern in _NEEDS_REVIEW_PATTERNS:
+        if pattern.search(content):
             return {"status": "needs_review"}
-    
+
+    if _looks_like_opaque_token(content):
+        return {"status": "needs_review"}
+
     return {"status": "safe"}
 
 

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -68,7 +68,7 @@ def _looks_like_opaque_token(content: str) -> bool:
                 any(char in "+/=_-" for char in token),
             )
         )
-        if character_classes >= 3 or ("_-" not in token and len(set(token)) >= 12):
+        if character_classes >= 3 or (not any(char in "_-" for char in token) and len(set(token)) >= 12):
             return True
     return False
 

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -139,6 +139,13 @@ def _has_opaque_character_mix(token: str) -> bool:
     has_upper = any(char.isupper() for char in token)
     has_digit = any(char.isdigit() for char in token)
     has_encoding_punctuation = any(char in "+=" for char in token)
+    if has_lower and has_upper and token.isalpha():
+        case_transitions = sum(
+            left.islower() != right.islower()
+            for left, right in zip(token, token[1:])
+        )
+        if case_transitions >= 8:
+            return True
     return (has_lower and has_upper and (has_digit or ("_" in token and "-" in token))) or (
         has_encoding_punctuation
         and sum((has_lower, has_upper, has_digit, has_encoding_punctuation)) >= 3
@@ -158,24 +165,33 @@ def _has_single_case_alphanumeric_opaque_mix(token: str) -> bool:
         return False
     letters = [char for char in token if char.isalpha()]
     digits = [char for char in token if char.isdigit()]
-    if not letters or len(digits) < 3:
+    if not letters:
         return False
     if any(char.islower() for char in letters) and any(char.isupper() for char in letters):
+        return False
+    if not digits:
+        return len(token) >= 32 and all(char.isupper() for char in letters)
+    if len(digits) < 3:
         return False
     transitions = sum(
         left.isdigit() != right.isdigit()
         for left, right in zip(token, token[1:])
     )
-    return transitions >= 4
+    return transitions >= 8
 
 
-def _has_embedded_single_case_opaque_value(content: str) -> bool:
+def _has_embedded_opaque_value(content: str) -> bool:
     """Detect opaque runs before a path or URL container can exempt them."""
     for match in re.finditer(r"[A-Za-z0-9]{32,}", content):
         segment = match.group(0)
-        if _HEX_DIGEST_PATTERN.fullmatch(segment):
+        if (
+            _HEX_DIGEST_PATTERN.fullmatch(segment)
+            or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(segment)
+            or _ACRONYM_VERSION_IDENTIFIER_PATTERN.fullmatch(segment)
+            or _looks_like_structured_identifier(segment)
+        ):
             continue
-        if _has_single_case_alphanumeric_opaque_mix(segment):
+        if _has_opaque_character_mix(segment) or _has_single_case_alphanumeric_opaque_mix(segment):
             return True
     return False
 
@@ -196,7 +212,7 @@ def _windows_path_has_split_opaque_value(content: str) -> bool:
 
 def _looks_like_opaque_token(content: str) -> bool:
     """Recognize encoded opaque values without consuming common identifiers."""
-    if _has_embedded_single_case_opaque_value(content):
+    if _has_embedded_opaque_value(content):
         return True
     windows_path = bool(_WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content))
     if windows_path and _windows_path_has_split_opaque_value(content):

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -231,7 +231,12 @@ def _has_separator_split_opaque_value(content: str) -> bool:
                 single_case_with_signal = _has_single_case_alphanumeric_opaque_mix(combined) and (
                     any(char.isdigit() for char in combined) or combined.isupper()
                 )
-                if (mixed and every_fragment_has_uppercase) or single_case_with_signal:
+                lowercase_encoded_split = (
+                    combined.islower()
+                    and combined.isalpha()
+                    and len(set(combined)) * 100 >= len(combined) * 70
+                )
+                if (mixed and every_fragment_has_uppercase) or single_case_with_signal or lowercase_encoded_split:
                     return True
     return False
 

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -145,6 +145,30 @@ def _has_opaque_character_mix(token: str) -> bool:
     )
 
 
+def _has_single_case_alphanumeric_opaque_mix(token: str) -> bool:
+    """Catch base-encoded values that do not mix letter case.
+
+    Long semantic identifiers commonly contain one version run (for example
+    ``project2026memoryhardeningidentifier``). Opaque encodings instead tend
+    to alternate letter and digit runs throughout the value, so require both
+    repeated transitions and several digits before review-gating a single-case
+    token.
+    """
+    if not token.isalnum():
+        return False
+    letters = [char for char in token if char.isalpha()]
+    digits = [char for char in token if char.isdigit()]
+    if not letters or len(digits) < 3:
+        return False
+    if any(char.islower() for char in letters) and any(char.isupper() for char in letters):
+        return False
+    transitions = sum(
+        left.isdigit() != right.isdigit()
+        for left, right in zip(token, token[1:])
+    )
+    return transitions >= 4
+
+
 def _windows_path_has_split_opaque_value(content: str) -> bool:
     unsafe_run: list[str] = []
     for segment in (
@@ -183,7 +207,7 @@ def _looks_like_opaque_token(content: str) -> bool:
         # Mixed-case alphanumeric material is a conservative opaque-value
         # signal. Base64 punctuation can substitute for one alphanumeric
         # class, while ordinary lowercase path/package separators do not.
-        if _has_opaque_character_mix(token):
+        if _has_opaque_character_mix(token) or _has_single_case_alphanumeric_opaque_mix(token):
             return True
     return False
 

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -184,7 +184,9 @@ def _has_single_case_alphanumeric_opaque_mix(token: str) -> bool:
     if any(char.islower() for char in letters) and any(char.isupper() for char in letters):
         return False
     if not digits:
-        return len(token) >= 32 and all(char.isupper() for char in letters)
+        if all(char.isupper() for char in letters):
+            return len(token) >= 32
+        return len(token) >= 32 and len(token) % 4 == 0 and len(set(token)) >= 8
     if len(token) >= 32 and all(char.isupper() for char in letters):
         return True
     if len(digits) < 3:
@@ -208,7 +210,7 @@ def _has_embedded_opaque_value(content: str) -> bool:
 
 
 def _has_separator_split_opaque_value(content: str) -> bool:
-    """Catch one opaque value split into equal-sized path/package fragments."""
+    """Catch one opaque value split into path or package fragments."""
     for match in _SEPARATOR_SPLIT_OPAQUE_PATTERN.finditer(content):
         fragments = re.findall(r"[A-Za-z0-9]+", match.group(0))
         for start in range(len(fragments)):
@@ -216,15 +218,20 @@ def _has_separator_split_opaque_value(content: str) -> bool:
                 window = fragments[start:end]
                 lengths = [len(fragment) for fragment in window]
                 combined = "".join(window)
-                equal_short_chunks = len(window) >= 4 and min(lengths) >= 4 and max(lengths) - min(lengths) <= 2
-                equal_long_chunks = len(window) >= 2 and min(lengths) >= 12 and max(lengths) - min(lengths) <= 4
-                if len(combined) < 32 or not (equal_short_chunks or equal_long_chunks):
+                chunked = (len(window) >= 4 and min(lengths) >= 4) or (
+                    len(window) >= 2 and min(lengths) >= 12
+                )
+                if len(combined) < 32 or not chunked:
                     continue
                 if _HEX_DIGEST_PATTERN.fullmatch(combined) or _looks_like_structured_identifier(combined):
                     continue
                 mixed = _has_opaque_character_mix(combined)
                 uppercase_fragments = sum(any(char.isupper() for char in fragment) for fragment in window)
-                if (mixed and uppercase_fragments >= 2) or _has_single_case_alphanumeric_opaque_mix(combined):
+                every_fragment_has_uppercase = uppercase_fragments == len(window)
+                single_case_with_signal = _has_single_case_alphanumeric_opaque_mix(combined) and (
+                    any(char.isdigit() for char in combined) or combined.isupper()
+                )
+                if (mixed and every_fragment_has_uppercase) or single_case_with_signal:
                     return True
     return False
 

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -70,7 +70,7 @@ _IDENTIFIER_COMPONENT_PATTERN = re.compile(
     r"[A-Z]+(?=[A-Z][a-z]|\d|$)|[A-Z]?[a-z]+|\d+"
 )
 _IDENTIFIER_MORPHOLOGY_SUFFIX = re.compile(
-    r"(?:ation|ition|sion|tion|ions|ment|ness|ity|ence|ance|able|ible|ship|form|ount|point|ish|ary|ives|ents|er|or|al|ic|ive|ous|ful|less|ed|ing)$",
+    r"(?:ation|ition|sion|tion|ions|ment|ness|ity|ence|ance|able|ible|ship|form|ount|point|ish|ary|ives|ents|out|er|or|al|ic|ive|ous|ful|less|ed|ing)$",
     re.IGNORECASE,
 )
 _SEMANTIC_IDENTIFIER_CONNECTORS = frozenset(
@@ -270,7 +270,11 @@ _COMPACT_SPLIT_CREDENTIAL_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _CREDENTIAL_SPLIT_PATTERN = re.compile(
-    r"(?<![A-Za-z0-9])(?:[A-Za-z0-9_-]{2,20}[./\\]){2,}[A-Za-z0-9_-]{2,20}(?![A-Za-z0-9])"
+    r"(?<![A-Za-z0-9])(?:[A-Za-z0-9_-]{2,20}[./\\-]){1,}[A-Za-z0-9_-]{2,20}(?![A-Za-z0-9])"
+)
+_GOOGLE_SPLIT_CREDENTIAL_PATTERN = re.compile(
+    r"\b(?:ya29\.|AIza)(?:[./\\][A-Za-z0-9_-]{2,20})+",
+    re.IGNORECASE,
 )
 _CREDENTIAL_SPLIT_PREFIX_PATTERN = re.compile(
     r"(?:AKIA|ASIA|gh[oprsu][_-]|github_|glpat-|hf_|npm_|sk[-_]|rk_|ya29\.|AIza|xox[a-z]?-)",
@@ -281,6 +285,7 @@ _SAFE_SOURCE_REVISION_URL_PATTERN = re.compile(
     r"https?://[^/\s]+(?:/[^/\s]+)*/(?:blob|tree)/[0-9A-Fa-f]{7,40}/",
     re.IGNORECASE,
 )
+_SAFE_TIMESTAMP_IDENTIFIER_PATTERN = re.compile(r"(?:\d{8}|\d{4}-\d{2}-\d{2})T\d+Z-[a-z0-9-]+(?:\.[a-z0-9]{1,16})?")
 _SAFE_DIGEST_QUERY_KEYS = frozenset(
     {"artifact", "artifact_id", "checksum", "commit", "digest", "hash", "id", "rev", "revision", "sha", "sha1", "sha224", "sha256", "sha384", "sha512"}
 )
@@ -311,12 +316,11 @@ def _looks_like_structured_identifier(segment: str) -> bool:
         )
         and (
             sum(bool(_IDENTIFIER_MORPHOLOGY_SUFFIX.search(component)) for component in title_components) >= 2
+            or title_components[-1] in {"Test", "Tests", "Setup", "Maestro"}
+            or sum(len(component) >= 4 for component in title_components) >= 5
             or (
-                len(title_components) >= 5
-                and any(
-                    component == "V" and index + 1 < len(components) and components[index + 1].isdigit()
-                    for index, component in enumerate(components)
-                )
+                sum(len(component) >= 4 for component in title_components) >= 4
+                and any(len(component) == 3 for component in title_components)
             )
         )
     )
@@ -390,7 +394,16 @@ def _looks_like_safe_windows_path(content: str) -> bool:
     if not _WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content) or any(char in "+=" for char in content):
         return False
     segments = [segment for segment in content.split("\\") if segment and not re.fullmatch(r"[A-Za-z]:", segment)]
-    return bool(segments) and all(_looks_like_safe_path_segment(segment) for segment in segments)
+    return bool(segments) and all(
+        _looks_like_safe_path_segment(segment)
+        and (
+            bool(re.fullmatch(r"[A-Z][a-z]+\d*", segment))
+            or not _has_opaque_character_mix(segment)
+        )
+        and not _has_single_case_alphanumeric_opaque_mix(segment)
+        and not _has_separator_split_opaque_value(segment)
+        for segment in segments
+    )
 
 
 def _looks_like_safe_digest_query_token(token: str, content: str) -> bool:
@@ -401,8 +414,16 @@ def _looks_like_safe_digest_query_token(token: str, content: str) -> bool:
 
 
 def _has_opaque_character_mix(token: str) -> bool:
-    if "=" in token and "/" in token.split("=", 1)[1]:
-        return False
+    if "=" in token:
+        key, value = token.split("=", 1)
+        if "/" in value or (
+            re.fullmatch(r"[a-z][a-z0-9_]*", key)
+            and re.fullmatch(r"[A-Z][A-Z0-9_]*", value)
+        ) or (
+            re.fullmatch(r"[A-Z][A-Z0-9_]*", key)
+            and re.fullmatch(r"[a-z][a-z0-9-]*", value)
+        ):
+            return False
     has_lower = any(char.islower() for char in token)
     has_upper = any(char.isupper() for char in token)
     has_digit = any(char.isdigit() for char in token)
@@ -463,14 +484,16 @@ def _has_embedded_opaque_value(content: str) -> bool:
 
 
 def _has_separator_split_blocked_credential(content: str) -> bool:
-    """Recognize known credential prefixes after three or more split fragments."""
+    """Recognize known credential prefixes after separator-split fragments."""
+    if _GOOGLE_SPLIT_CREDENTIAL_PATTERN.search(content):
+        return True
     for match in _CREDENTIAL_SPLIT_PATTERN.finditer(content):
         matched = match.group(0)
         if not _CREDENTIAL_SPLIT_PREFIX_PATTERN.match(matched):
             continue
         fragments = re.findall(r"[A-Za-z0-9]+", matched)
         for start in range(len(fragments)):
-            for end in range(start + 3, min(len(fragments), start + 8) + 1):
+            for end in range(start + 2, min(len(fragments), start + 8) + 1):
                 compact = "".join(fragments[start:end])
                 if _COMPACT_SPLIT_CREDENTIAL_PATTERN.fullmatch(compact):
                     return True
@@ -483,7 +506,9 @@ def _has_separator_split_opaque_value(content: str) -> bool:
         matched = match.group(0)
         fragment_matches = list(re.finditer(r"[A-Za-z0-9]+", matched))
         fragments = [fragment.group(0) for fragment in fragment_matches]
-        if _looks_like_structured_identifier("".join(fragments)):
+        if _looks_like_structured_identifier("".join(fragments)) or (
+            " " in matched and all(_looks_like_semantic_upper_identifier_word(fragment) for fragment in fragments)
+        ):
             continue
         semantic_snake_spans = [
             snake.span()
@@ -544,6 +569,8 @@ def _windows_path_has_split_opaque_value(content: str) -> bool:
 
 def _looks_like_opaque_token(content: str) -> bool:
     """Recognize encoded opaque values without consuming common identifiers."""
+    if _looks_like_safe_windows_path(content):
+        return False
     if _has_embedded_opaque_value(content) or _has_separator_split_opaque_value(content):
         return True
     windows_path = bool(_WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content))
@@ -556,6 +583,7 @@ def _looks_like_opaque_token(content: str) -> bool:
         # padding marker is not an assignment and must remain review-gated.
         if (
             windows_path
+            or _SAFE_TIMESTAMP_IDENTIFIER_PATTERN.fullmatch(token)
             or _HEX_DIGEST_PATTERN.fullmatch(token)
             or _UUID_PATTERN.fullmatch(token)
             or _DIGEST_ASSIGNMENT_PATTERN.fullmatch(token)

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -65,11 +65,19 @@ _DIGEST_ASSIGNMENT_PATTERN = re.compile(
     r"(?:md5|sha(?:1|224|256|384|512))=(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{56}|[0-9A-Fa-f]{64}|[0-9A-Fa-f]{96}|[0-9A-Fa-f]{128})",
     re.IGNORECASE,
 )
+_CAMEL_WORD = r"[A-Z][a-z]{2,}(?:\d+)?"
+_VERSION_COMPONENT = r"V\d+"
 _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
-    r"(?:(?:[A-Z]{2,}(?=[A-Z][a-z]{2,}))|(?:[A-Z][a-z]{2,}(?:\d+)?)|(?:[A-Z]\d+)){2,}"
+    rf"(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{4,}}"
+)
+_LOWER_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
+    rf"[a-z]{{2,}}(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"
 )
 _ACRONYM_VERSION_IDENTIFIER_PATTERN = re.compile(
-    r"(?:[A-Z]{2,}[0-9]*)(?:[A-Z][a-z]{2,}){2,}(?:V[0-9]+)?"
+    rf"[A-Z]{{2,}}\d*(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"
+)
+_SEPARATOR_SPLIT_OPAQUE_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])(?:[A-Za-z0-9]{4,20}[./\\ _-]){1,}[A-Za-z0-9]{4,20}(?![A-Za-z0-9])"
 )
 _WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[A-Za-z]:\\|\\\\)[^\r\n]+$")
 _SAFE_DIGEST_QUERY_KEYS = frozenset(
@@ -79,10 +87,21 @@ _SAFE_REASON_SEGMENT = re.compile(r"[a-z][a-z0-9_]{0,63}")
 
 
 def _looks_like_structured_identifier(segment: str) -> bool:
-    return bool(_VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(segment)) or bool(
+    return any(
+        pattern.fullmatch(segment)
+        for pattern in (
+            _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN,
+            _LOWER_CAMEL_CASE_IDENTIFIER_PATTERN,
+            _ACRONYM_VERSION_IDENTIFIER_PATTERN,
+        )
+    )
+
+
+def _looks_like_path_identifier(segment: str) -> bool:
+    return _looks_like_structured_identifier(segment) or bool(
         re.fullmatch(r"[A-Za-z][A-Za-z0-9]+", segment)
+        and any(char.islower() for char in segment)
         and any(char.isupper() for char in segment)
-        and len(re.findall(r"[a-z]{2,}", segment)) >= 2
     )
 
 
@@ -92,7 +111,7 @@ def _looks_like_safe_path_segment(segment: str) -> bool:
         return bool(words) and all(_looks_like_safe_path_segment(word) for word in words)
     stem, dot, suffix = segment.rpartition(".")
     if dot and suffix and re.fullmatch(r"[a-z0-9]{1,16}", suffix) and (
-        _looks_like_structured_identifier(stem)
+        _looks_like_path_identifier(stem)
         or bool(re.fullmatch(r"[A-Z][A-Z0-9_]{1,31}", stem))
     ):
         return True
@@ -101,14 +120,14 @@ def _looks_like_safe_path_segment(segment: str) -> bool:
         or re.fullmatch(r"[A-Z][a-z]{2,}", segment)
         or re.fullmatch(r"[A-Z]", segment)
         or _HEX_DIGEST_PATTERN.fullmatch(segment)
-        or _looks_like_structured_identifier(segment)
+        or _looks_like_path_identifier(segment)
         or re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d+Z-[a-z0-9-]+(?:\.[a-z0-9]+)?", segment)
     ):
         return True
     parts = segment.split("-")
     return len(parts) > 1 and all(
         bool(re.fullmatch(r"[a-z0-9][a-z0-9._]*", part))
-        or _looks_like_structured_identifier(part)
+        or _looks_like_path_identifier(part)
         for part in parts
     )
 
@@ -140,12 +159,7 @@ def _has_opaque_character_mix(token: str) -> bool:
     has_digit = any(char.isdigit() for char in token)
     has_encoding_punctuation = any(char in "+=" for char in token)
     if has_lower and has_upper and token.isalpha():
-        case_transitions = sum(
-            left.islower() != right.islower()
-            for left, right in zip(token, token[1:])
-        )
-        if case_transitions >= 8:
-            return True
+        return len(token) >= 32
     return (has_lower and has_upper and (has_digit or ("_" in token and "-" in token))) or (
         has_encoding_punctuation
         and sum((has_lower, has_upper, has_digit, has_encoding_punctuation)) >= 3
@@ -171,6 +185,8 @@ def _has_single_case_alphanumeric_opaque_mix(token: str) -> bool:
         return False
     if not digits:
         return len(token) >= 32 and all(char.isupper() for char in letters)
+    if len(token) >= 32 and all(char.isupper() for char in letters):
+        return True
     if len(digits) < 3:
         return False
     transitions = sum(
@@ -184,16 +200,32 @@ def _has_embedded_opaque_value(content: str) -> bool:
     """Detect opaque runs before a path or URL container can exempt them."""
     for match in re.finditer(r"[A-Za-z0-9]{32,}", content):
         segment = match.group(0)
-        if (
-            _HEX_DIGEST_PATTERN.fullmatch(segment)
-            or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(segment)
-            or _ACRONYM_VERSION_IDENTIFIER_PATTERN.fullmatch(segment)
-        ):
+        if _HEX_DIGEST_PATTERN.fullmatch(segment) or _looks_like_structured_identifier(segment):
             continue
         if _has_opaque_character_mix(segment) or _has_single_case_alphanumeric_opaque_mix(segment):
             return True
-        if _looks_like_structured_identifier(segment):
-            continue
+    return False
+
+
+def _has_separator_split_opaque_value(content: str) -> bool:
+    """Catch one opaque value split into equal-sized path/package fragments."""
+    for match in _SEPARATOR_SPLIT_OPAQUE_PATTERN.finditer(content):
+        fragments = re.findall(r"[A-Za-z0-9]+", match.group(0))
+        for start in range(len(fragments)):
+            for end in range(start + 2, min(len(fragments), start + 8) + 1):
+                window = fragments[start:end]
+                lengths = [len(fragment) for fragment in window]
+                combined = "".join(window)
+                equal_short_chunks = len(window) >= 4 and min(lengths) >= 4 and max(lengths) - min(lengths) <= 2
+                equal_long_chunks = len(window) >= 2 and min(lengths) >= 12 and max(lengths) - min(lengths) <= 4
+                if len(combined) < 32 or not (equal_short_chunks or equal_long_chunks):
+                    continue
+                if _HEX_DIGEST_PATTERN.fullmatch(combined) or _looks_like_structured_identifier(combined):
+                    continue
+                mixed = _has_opaque_character_mix(combined)
+                uppercase_fragments = sum(any(char.isupper() for char in fragment) for fragment in window)
+                if (mixed and uppercase_fragments >= 2) or _has_single_case_alphanumeric_opaque_mix(combined):
+                    return True
     return False
 
 
@@ -213,7 +245,7 @@ def _windows_path_has_split_opaque_value(content: str) -> bool:
 
 def _looks_like_opaque_token(content: str) -> bool:
     """Recognize encoded opaque values without consuming common identifiers."""
-    if _has_embedded_opaque_value(content):
+    if _has_embedded_opaque_value(content) or _has_separator_split_opaque_value(content):
         return True
     windows_path = bool(_WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content))
     if windows_path and _windows_path_has_split_opaque_value(content):
@@ -228,8 +260,7 @@ def _looks_like_opaque_token(content: str) -> bool:
             or _HEX_DIGEST_PATTERN.fullmatch(token)
             or _UUID_PATTERN.fullmatch(token)
             or _DIGEST_ASSIGNMENT_PATTERN.fullmatch(token)
-            or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(token)
-            or _ACRONYM_VERSION_IDENTIFIER_PATTERN.fullmatch(token)
+            or _looks_like_structured_identifier(token)
             or _looks_like_safe_path_token(token)
             or _looks_like_safe_digest_query_token(token, content)
         ):

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -72,11 +72,59 @@ _IDENTIFIER_COMPONENT_PATTERN = re.compile(
 _SEMANTIC_IDENTIFIER_CONNECTORS = frozenset(
     {"a", "an", "and", "as", "at", "by", "for", "from", "in", "is", "not", "of", "on", "or", "the", "to", "v", "with"}
 )
+_SEMANTIC_IDENTIFIER_ACRONYMS = frozenset(
+    {
+        "API",
+        "CI",
+        "CLI",
+        "CPU",
+        "CSS",
+        "DCO",
+        "DNS",
+        "DOM",
+        "FAQ",
+        "FQDN",
+        "GPU",
+        "HTML",
+        "HTTP",
+        "HTTPS",
+        "ID",
+        "IO",
+        "JSON",
+        "JSONRPC",
+        "JWT",
+        "LLM",
+        "MCP",
+        "OMH",
+        "OS",
+        "PR",
+        "RPC",
+        "SDK",
+        "SHA",
+        "SQL",
+        "SSH",
+        "TLS",
+        "TOML",
+        "TTL",
+        "UI",
+        "ULW",
+        "URL",
+        "UUID",
+        "UX",
+        "W3C",
+        "XML",
+        "YAML",
+    }
+)
+_COMMON_IDENTIFIER_BIGRAMS = frozenset(
+    "AC AD AG AI AL AN AP AR AS AT BE BI BO BR CA CE CH CK CO CT DA DE DI DO ED EE EL EM EN ER ES ET EV EX FI FO GE GL GR HA HE HI HO IC ID IE IL IM IN IO IS IT KE LA LD LE LI LL LO LY MA ME MI MO NA NC ND NE NG NI NO NS NT OD OF OL OM ON OP OR OT OU OW PA PE PI PL PO PR QU RA RC RE RI RO RS RT SE SH SI SO SS ST SU TA TE TH TI TO TR TS TT TW UL UN UP UR US UT VE WA WE WH WI YO".split()
+)
 _SEMANTIC_IDENTIFIER_WORDS = frozenset(
     {
         "account",
         "action",
         "adapter",
+        "after",
         "agent",
         "alice",
         "application",
@@ -99,10 +147,12 @@ _SEMANTIC_IDENTIFIER_WORDS = frozenset(
         "controller",
         "data",
         "decision",
+        "declared",
         "deterministic",
         "directory",
         "dispatcher",
         "document",
+        "effect",
         "engine",
         "end",
         "english",
@@ -117,13 +167,14 @@ _SEMANTIC_IDENTIFIER_WORDS = frozenset(
         "file",
         "finder",
         "gateway",
-        "handler",
         "handle",
+        "handler",
         "hermes",
         "identifier",
         "index",
         "input",
         "interview",
+        "job",
         "lifecycle",
         "loader",
         "maintainer",
@@ -133,6 +184,7 @@ _SEMANTIC_IDENTIFIER_WORDS = frozenset(
         "migration",
         "model",
         "observation",
+        "object",
         "operation",
         "output",
         "package",
@@ -141,13 +193,15 @@ _SEMANTIC_IDENTIFIER_WORDS = frozenset(
         "platform",
         "policy",
         "project",
+        "projections",
         "protocol",
         "provenance",
         "provider",
-        "reader",
         "read",
+        "reader",
         "reading",
         "record",
+        "recommendations",
         "recoverable",
         "recovery",
         "reference",
@@ -156,12 +210,17 @@ _SEMANTIC_IDENTIFIER_WORDS = frozenset(
         "response",
         "reviewer",
         "router",
+        "rhythm",
         "runtime",
+        "safety",
         "schema",
+        "seconds",
         "server",
         "service",
         "session",
+        "shipped",
         "source",
+        "stale",
         "state",
         "status",
         "store",
@@ -217,17 +276,30 @@ def _looks_like_semantic_identifier_component(component: str) -> bool:
     if lowered in _SEMANTIC_IDENTIFIER_CONNECTORS or lowered in _SEMANTIC_IDENTIFIER_WORDS:
         return True
     if component.isupper():
-        return 2 <= len(component) <= 8
+        return component in _SEMANTIC_IDENTIFIER_ACRONYMS
     return False
+
+
+def _looks_like_semantic_upper_identifier_word(part: str) -> bool:
+    if part.isdigit() or part in _SEMANTIC_IDENTIFIER_ACRONYMS:
+        return True
+    if not part.isalpha() or not part.isupper():
+        return False
+    if part.lower() in _SEMANTIC_IDENTIFIER_CONNECTORS or part.lower() in _SEMANTIC_IDENTIFIER_WORDS:
+        return True
+    if not any(char in "AEIOUY" for char in part):
+        return False
+    bigram_count = sum(
+        part[index : index + 2] in _COMMON_IDENTIFIER_BIGRAMS
+        for index in range(len(part) - 1)
+    )
+    return bigram_count * 4 >= len(part) - 1
 
 
 def _looks_like_semantic_upper_snake_identifier(segment: str) -> bool:
     if not _UPPER_SNAKE_IDENTIFIER_PATTERN.fullmatch(segment):
         return False
-    parts = segment.split("_")
-    vowel_parts = sum(any(char in "AEIOU" for char in part) for part in parts)
-    letters = "".join(parts)
-    return vowel_parts >= len(parts) - 1 and len(set(letters)) * 100 < len(letters) * 70
+    return all(_looks_like_semantic_upper_identifier_word(part) for part in segment.split("_"))
 
 
 def _looks_like_path_identifier(segment: str) -> bool:
@@ -374,17 +446,7 @@ def _has_separator_split_opaque_value(content: str) -> bool:
                     window_start < snake_end and snake_start < window_end
                     for snake_start, snake_end in semantic_snake_spans
                 )
-                chunked_base32 = (
-                    len(window) >= 4
-                    and len(set(lengths)) == 1
-                    and lengths[0] == 8
-                    and combined.isalpha()
-                    and combined.isupper()
-                    and set(combined) <= set("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
-                )
-                if any(_looks_like_structured_identifier(fragment) for fragment in window) or (
-                    semantic_snake_overlap and not chunked_base32
-                ):
+                if any(_looks_like_structured_identifier(fragment) for fragment in window) or semantic_snake_overlap:
                     continue
                 mixed = _has_opaque_character_mix(combined)
                 uppercase_fragments = sum(any(char.isupper() for char in fragment) for fragment in window)

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -76,6 +76,7 @@ _LOWER_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
 _ACRONYM_VERSION_IDENTIFIER_PATTERN = re.compile(
     rf"[A-Z]{{2,}}\d*(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"
 )
+_UPPER_SNAKE_IDENTIFIER_PATTERN = re.compile(r"[A-Z][A-Z0-9]{1,15}(?:_[A-Z][A-Z0-9]{1,15}){2,}")
 _SEPARATOR_SPLIT_OPAQUE_PATTERN = re.compile(
     r"(?<![A-Za-z0-9])(?:[A-Za-z0-9]{4,20}[./\\ _-]){1,}[A-Za-z0-9]{4,20}(?![A-Za-z0-9])"
 )
@@ -95,6 +96,15 @@ def _looks_like_structured_identifier(segment: str) -> bool:
             _ACRONYM_VERSION_IDENTIFIER_PATTERN,
         )
     )
+
+
+def _looks_like_semantic_upper_snake_identifier(segment: str) -> bool:
+    if not _UPPER_SNAKE_IDENTIFIER_PATTERN.fullmatch(segment):
+        return False
+    parts = segment.split("_")
+    vowel_parts = sum(any(char in "AEIOU" for char in part) for part in parts)
+    letters = "".join(parts)
+    return vowel_parts >= len(parts) - 1 and len(set(letters)) * 100 < len(letters) * 70
 
 
 def _looks_like_path_identifier(segment: str) -> bool:
@@ -212,7 +222,14 @@ def _has_embedded_opaque_value(content: str) -> bool:
 def _has_separator_split_opaque_value(content: str) -> bool:
     """Catch one opaque value split into path or package fragments."""
     for match in _SEPARATOR_SPLIT_OPAQUE_PATTERN.finditer(content):
-        fragments = re.findall(r"[A-Za-z0-9]+", match.group(0))
+        matched = match.group(0)
+        fragment_matches = list(re.finditer(r"[A-Za-z0-9]+", matched))
+        fragments = [fragment.group(0) for fragment in fragment_matches]
+        semantic_snake_spans = [
+            snake.span()
+            for snake in _UPPER_SNAKE_IDENTIFIER_PATTERN.finditer(matched)
+            if _looks_like_semantic_upper_snake_identifier(snake.group(0))
+        ]
         for start in range(len(fragments)):
             for end in range(start + 2, min(len(fragments), start + 8) + 1):
                 window = fragments[start:end]
@@ -224,6 +241,13 @@ def _has_separator_split_opaque_value(content: str) -> bool:
                 if len(combined) < 32 or not chunked:
                     continue
                 if _HEX_DIGEST_PATTERN.fullmatch(combined) or _looks_like_structured_identifier(combined):
+                    continue
+                window_start = fragment_matches[start].start()
+                window_end = fragment_matches[end - 1].end()
+                if any(_looks_like_structured_identifier(fragment) for fragment in window) or any(
+                    window_start < snake_end and snake_start < window_end
+                    for snake_start, snake_end in semantic_snake_spans
+                ):
                     continue
                 mixed = _has_opaque_character_mix(combined)
                 uppercase_fragments = sum(any(char.isupper() for char in fragment) for fragment in window)

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -40,7 +40,7 @@ _BLOCKED_PATTERNS = (
 )
 
 _CREDENTIAL_REVIEW_PATTERN = re.compile(
-    r"\b(?:credential|session|access|key|access[_ -]?token|private[_ -]?key|secret|token|api[_ -]?key)\s*[:=]\s*\S{12,}",
+    r"\b(?:(?:api|access|private|secret)[_ -]?key|(?:session|access)[_ -]?token)\s*[:=]\s*\S{12,}",
     re.IGNORECASE,
 )
 _NEEDS_REVIEW_PATTERNS = (
@@ -68,6 +68,10 @@ _DIGEST_ASSIGNMENT_PATTERN = re.compile(
 )
 _IDENTIFIER_COMPONENT_PATTERN = re.compile(
     r"[A-Z]+(?=[A-Z][a-z]|\d|$)|[A-Z]?[a-z]+|\d+"
+)
+_IDENTIFIER_MORPHOLOGY_SUFFIX = re.compile(
+    r"(?:ation|ition|sion|tion|ions|ment|ness|ity|ence|ance|able|ible|ship|form|ount|point|ish|ary|ives|ents|er|or|al|ic|ive|ous|ful|less|ed|ing)$",
+    re.IGNORECASE,
 )
 _SEMANTIC_IDENTIFIER_CONNECTORS = frozenset(
     {"a", "an", "and", "as", "at", "by", "for", "from", "in", "is", "not", "of", "on", "or", "the", "to", "v", "with"}
@@ -248,7 +252,35 @@ _UPPER_SNAKE_IDENTIFIER_PATTERN = re.compile(r"[A-Z][A-Z0-9]{1,15}(?:_[A-Z][A-Z0
 _SEPARATOR_SPLIT_OPAQUE_PATTERN = re.compile(
     r"(?<![A-Za-z0-9])(?:[A-Za-z0-9]{4,20}[./\\ _-]){1,}[A-Za-z0-9]{4,20}(?![A-Za-z0-9])"
 )
+_COMPACT_SPLIT_CREDENTIAL_PATTERN = re.compile(
+    "(?:" + "|".join(
+        (
+            r"(?:AKIA|ASIA)[A-Z0-9]{16}",
+            r"(?:gh[oprsu]|githubpat|glpat)[A-Za-z0-9]{16,}",
+            r"hf[A-Za-z0-9]{16,}",
+            r"npm[A-Za-z0-9]{16,}",
+            r"sk(?:proj)?[A-Za-z0-9]{16,}",
+            r"rk(?:live|test)[A-Za-z0-9]{16,}",
+            r"sk(?:live|test)[A-Za-z0-9]{16,}",
+            r"ya29[A-Za-z0-9]{20,}",
+            r"AIza[A-Za-z0-9]{20,}",
+            r"xox[a-z]?[A-Za-z0-9]{16,}",
+        )
+    ) + ")",
+    re.IGNORECASE,
+)
+_CREDENTIAL_SPLIT_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9])(?:[A-Za-z0-9_-]{2,20}[./\\]){2,}[A-Za-z0-9_-]{2,20}(?![A-Za-z0-9])"
+)
+_CREDENTIAL_SPLIT_PREFIX_PATTERN = re.compile(
+    r"(?:AKIA|ASIA|gh[oprsu][_-]|github_|glpat-|hf_|npm_|sk[-_]|rk_|ya29\.|AIza|xox[a-z]?-)",
+    re.IGNORECASE,
+)
 _WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[A-Za-z]:\\|\\\\)[^\r\n]+$")
+_SAFE_SOURCE_REVISION_URL_PATTERN = re.compile(
+    r"https?://[^/\s]+(?:/[^/\s]+)*/(?:blob|tree)/[0-9A-Fa-f]{7,40}/",
+    re.IGNORECASE,
+)
 _SAFE_DIGEST_QUERY_KEYS = frozenset(
     {"artifact", "artifact_id", "checksum", "commit", "digest", "hash", "id", "rev", "revision", "sha", "sha1", "sha224", "sha256", "sha384", "sha512"}
 )
@@ -262,23 +294,32 @@ def _looks_like_structured_identifier(segment: str) -> bool:
         return False
     components = _IDENTIFIER_COMPONENT_PATTERN.findall(segment)
     alpha_components = [component for component in components if component.isalpha()]
+    title_components = [
+        component
+        for component in alpha_components
+        if re.fullmatch(r"[A-Z][a-z]{2,}", component)
+    ]
     return (
         "".join(components) == segment
         and len(alpha_components) >= 3
-        and all(_looks_like_semantic_identifier_component(component) for component in components)
+        and len(title_components) >= 2
+        and all(
+            component.isdigit()
+            or component.isupper()
+            or bool(re.fullmatch(r"[A-Z][a-z]+|[a-z]{2,}", component))
+            for component in components
+        )
+        and (
+            sum(bool(_IDENTIFIER_MORPHOLOGY_SUFFIX.search(component)) for component in title_components) >= 2
+            or (
+                len(title_components) >= 5
+                and any(
+                    component == "V" and index + 1 < len(components) and components[index + 1].isdigit()
+                    for index, component in enumerate(components)
+                )
+            )
+        )
     )
-
-
-def _looks_like_semantic_identifier_component(component: str) -> bool:
-    if component.isdigit():
-        return True
-    lowered = component.lower()
-    if lowered in _SEMANTIC_IDENTIFIER_CONNECTORS or lowered in _SEMANTIC_IDENTIFIER_WORDS:
-        return True
-    if component.isupper():
-        return component in _SEMANTIC_IDENTIFIER_ACRONYMS
-    return False
-
 
 def _looks_like_semantic_upper_identifier_word(part: str) -> bool:
     if part.isdigit() or part in _SEMANTIC_IDENTIFIER_ACRONYMS:
@@ -360,10 +401,12 @@ def _looks_like_safe_digest_query_token(token: str, content: str) -> bool:
 
 
 def _has_opaque_character_mix(token: str) -> bool:
+    if "=" in token and "/" in token.split("=", 1)[1]:
+        return False
     has_lower = any(char.islower() for char in token)
     has_upper = any(char.isupper() for char in token)
     has_digit = any(char.isdigit() for char in token)
-    has_encoding_punctuation = any(char in "+=" for char in token)
+    has_encoding_punctuation = "+" in token or token.endswith("=")
     if has_lower and has_upper and token.isalpha():
         return len(token) >= 32
     return (has_lower and has_upper and (has_digit or ("_" in token and "-" in token))) or (
@@ -408,10 +451,29 @@ def _has_embedded_opaque_value(content: str) -> bool:
     """Detect opaque runs before a path or URL container can exempt them."""
     for match in re.finditer(r"[A-Za-z0-9]{32,}", content):
         segment = match.group(0)
-        if _HEX_DIGEST_PATTERN.fullmatch(segment) or _looks_like_structured_identifier(segment):
+        if (
+            _HEX_DIGEST_PATTERN.fullmatch(segment)
+            or _SAFE_SOURCE_REVISION_URL_PATTERN.search(content)
+            or _looks_like_structured_identifier(segment)
+        ):
             continue
         if _has_opaque_character_mix(segment) or _has_single_case_alphanumeric_opaque_mix(segment):
             return True
+    return False
+
+
+def _has_separator_split_blocked_credential(content: str) -> bool:
+    """Recognize known credential prefixes after three or more split fragments."""
+    for match in _CREDENTIAL_SPLIT_PATTERN.finditer(content):
+        matched = match.group(0)
+        if not _CREDENTIAL_SPLIT_PREFIX_PATTERN.match(matched):
+            continue
+        fragments = re.findall(r"[A-Za-z0-9]+", matched)
+        for start in range(len(fragments)):
+            for end in range(start + 3, min(len(fragments), start + 8) + 1):
+                compact = "".join(fragments[start:end])
+                if _COMPACT_SPLIT_CREDENTIAL_PATTERN.fullmatch(compact):
+                    return True
     return False
 
 
@@ -421,6 +483,8 @@ def _has_separator_split_opaque_value(content: str) -> bool:
         matched = match.group(0)
         fragment_matches = list(re.finditer(r"[A-Za-z0-9]+", matched))
         fragments = [fragment.group(0) for fragment in fragment_matches]
+        if _looks_like_structured_identifier("".join(fragments)):
+            continue
         semantic_snake_spans = [
             snake.span()
             for snake in _UPPER_SNAKE_IDENTIFIER_PATTERN.finditer(matched)
@@ -514,6 +578,7 @@ def contains_credential_like_material(content: str) -> bool:
         return True
     return (
         any(pattern.search(content) for pattern in _BLOCKED_PATTERNS)
+        or _has_separator_split_blocked_credential(content)
         or bool(_CREDENTIAL_REVIEW_PATTERN.search(content))
         or _looks_like_opaque_token(content)
     )
@@ -551,6 +616,8 @@ def classify_memory_admission(content: str) -> dict[str, object]:
     for pattern in _BLOCKED_PATTERNS:
         if pattern.search(content):
             return {"status": "blocked"}
+    if _has_separator_split_blocked_credential(content):
+        return {"status": "blocked"}
 
     for pattern in _NEEDS_REVIEW_PATTERNS:
         if pattern.search(content):

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -68,6 +68,9 @@ _DIGEST_ASSIGNMENT_PATTERN = re.compile(
 _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
     r"(?:(?:[A-Z]{2,}(?=[A-Z][a-z]{2,}))|(?:[A-Z][a-z]{2,}(?:\d+)?)|(?:[A-Z]\d+)){2,}"
 )
+_ACRONYM_VERSION_IDENTIFIER_PATTERN = re.compile(
+    r"(?:[A-Z]{2,}[0-9]*)(?:[A-Z][a-z]{2,}){2,}(?:V[0-9]+)?"
+)
 _WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[A-Za-z]:\\|\\\\)[^\r\n]+$")
 _SAFE_DIGEST_QUERY_KEYS = frozenset(
     {"artifact", "artifact_id", "checksum", "commit", "digest", "hash", "id", "rev", "revision", "sha", "sha1", "sha224", "sha256", "sha384", "sha512"}
@@ -172,6 +175,7 @@ def _looks_like_opaque_token(content: str) -> bool:
             or _UUID_PATTERN.fullmatch(token)
             or _DIGEST_ASSIGNMENT_PATTERN.fullmatch(token)
             or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(token)
+            or _ACRONYM_VERSION_IDENTIFIER_PATTERN.fullmatch(token)
             or _looks_like_safe_path_token(token)
             or _looks_like_safe_digest_query_token(token, content)
         ):

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -39,7 +39,7 @@ _BLOCKED_PATTERNS = (
 )
 
 _CREDENTIAL_REVIEW_PATTERN = re.compile(
-    r"\b(?:credential|access[_ -]?token|private[_ -]?key|secret|token|api[_ -]?key)\s*[:=]\s*\S{12,}",
+    r"\b(?:credential|session|access|key|access[_ -]?token|private[_ -]?key|secret|token|api[_ -]?key)\s*[:=]\s*\S{12,}",
     re.IGNORECASE,
 )
 _NEEDS_REVIEW_PATTERNS = (
@@ -69,23 +69,43 @@ _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
     r"(?:(?:[A-Z]{2,}(?=[A-Z][a-z]{2,}))|(?:[A-Z][a-z]{2,}(?:\d+)?)|(?:[A-Z]\d+)){2,}"
 )
 _WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[A-Za-z]:\\|\\\\)[^\r\n]+$")
+_SAFE_DIGEST_QUERY_KEYS = frozenset(
+    {"artifact", "artifact_id", "checksum", "commit", "digest", "hash", "id", "rev", "revision", "sha", "sha1", "sha224", "sha256", "sha384", "sha512"}
+)
 _SAFE_REASON_SEGMENT = re.compile(r"[a-z][a-z0-9_]{0,63}")
 
 
+def _looks_like_structured_identifier(segment: str) -> bool:
+    return bool(_VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(segment)) or bool(
+        re.fullmatch(r"[A-Za-z][A-Za-z0-9]+", segment)
+        and any(char.isupper() for char in segment)
+        and len(re.findall(r"[a-z]{2,}", segment)) >= 2
+    )
+
+
 def _looks_like_safe_path_segment(segment: str) -> bool:
+    if " " in segment:
+        words = segment.split()
+        return bool(words) and all(_looks_like_safe_path_segment(word) for word in words)
+    stem, dot, suffix = segment.rpartition(".")
+    if dot and suffix and re.fullmatch(r"[a-z0-9]{1,16}", suffix) and (
+        _looks_like_structured_identifier(stem)
+        or bool(re.fullmatch(r"[A-Z][A-Z0-9_]{1,31}", stem))
+    ):
+        return True
     if (
         re.fullmatch(r"\.?[a-z0-9][a-z0-9._-]*", segment)
         or re.fullmatch(r"[A-Z][a-z]{2,}", segment)
         or re.fullmatch(r"[A-Z]", segment)
         or _HEX_DIGEST_PATTERN.fullmatch(segment)
-        or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(segment)
+        or _looks_like_structured_identifier(segment)
         or re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d+Z-[a-z0-9-]+(?:\.[a-z0-9]+)?", segment)
     ):
         return True
     parts = segment.split("-")
     return len(parts) > 1 and all(
         bool(re.fullmatch(r"[a-z0-9][a-z0-9._]*", part))
-        or bool(_VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(part))
+        or _looks_like_structured_identifier(part)
         for part in parts
     )
 
@@ -108,15 +128,38 @@ def _looks_like_safe_digest_query_token(token: str, content: str) -> bool:
     if "://" not in content or token.count("=") != 1:
         return False
     key, value = token.split("=", 1)
-    return bool(re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]{0,31}", key)) and bool(
-        _HEX_DIGEST_PATTERN.fullmatch(value)
+    return key.lower() in _SAFE_DIGEST_QUERY_KEYS and bool(_HEX_DIGEST_PATTERN.fullmatch(value))
+
+
+def _has_opaque_character_mix(token: str) -> bool:
+    has_lower = any(char.islower() for char in token)
+    has_upper = any(char.isupper() for char in token)
+    has_digit = any(char.isdigit() for char in token)
+    has_encoding_punctuation = any(char in "+=" for char in token)
+    return (has_lower and has_upper and (has_digit or ("_" in token and "-" in token))) or (
+        has_encoding_punctuation
+        and sum((has_lower, has_upper, has_digit, has_encoding_punctuation)) >= 3
     )
+
+
+def _windows_path_has_split_opaque_value(content: str) -> bool:
+    unsafe_run: list[str] = []
+    for segment in (
+        segment for segment in content.split("\\") if segment and not re.fullmatch(r"[A-Za-z]:", segment)
+    ):
+        if _looks_like_safe_path_segment(segment):
+            if _has_opaque_character_mix("".join(unsafe_run)):
+                return True
+            unsafe_run = []
+        else:
+            unsafe_run.append(segment)
+    return _has_opaque_character_mix("".join(unsafe_run))
 
 
 def _looks_like_opaque_token(content: str) -> bool:
     """Recognize encoded opaque values without consuming common identifiers."""
-    windows_path = _looks_like_safe_windows_path(content)
-    if _WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content) and not windows_path:
+    windows_path = bool(_WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content))
+    if windows_path and _windows_path_has_split_opaque_value(content):
         return True
     for match in _OPAQUE_TOKEN_PATTERN.finditer(content):
         token = match.group(0)
@@ -133,21 +176,10 @@ def _looks_like_opaque_token(content: str) -> bool:
             or _looks_like_safe_digest_query_token(token, content)
         ):
             continue
-        has_lower = any(char.islower() for char in token)
-        has_upper = any(char.isupper() for char in token)
-        has_digit = any(char.isdigit() for char in token)
-        has_encoding_punctuation = any(char in "+=" for char in token)
         # Mixed-case alphanumeric material is a conservative opaque-value
         # signal. Base64 punctuation can substitute for one alphanumeric
         # class, while ordinary lowercase path/package separators do not.
-        if (
-            has_lower
-            and has_upper
-            and (has_digit or ("_" in token and "-" in token))
-        ) or (
-            has_encoding_punctuation
-            and sum((has_lower, has_upper, has_digit, has_encoding_punctuation)) >= 3
-        ):
+        if _has_opaque_character_mix(token):
             return True
     return False
 

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -55,7 +55,7 @@ _NEEDS_REVIEW_PATTERNS = (
 _OPAQUE_TOKEN_PATTERN = re.compile(r"(?<![A-Za-z0-9])[A-Za-z0-9+/=_-]{32,}(?![A-Za-z0-9])")
 _HEX_DIGEST_PATTERN = re.compile(r"(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64}|[0-9A-Fa-f]{96}|[0-9A-Fa-f]{128})")
 _UUID_PATTERN = re.compile(
-    r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[1-5][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"
+    r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[1-8][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"
 )
 _DIGEST_ASSIGNMENT_PATTERN = re.compile(
     r"(?:md5|sha(?:1|224|256|384|512))=(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{56}|[0-9A-Fa-f]{64}|[0-9A-Fa-f]{96}|[0-9A-Fa-f]{128})",
@@ -83,7 +83,8 @@ def _looks_like_opaque_token(content: str) -> bool:
                 "/" in token
                 and not any(char in "+=" for char in token)
                 and (
-                    (token.startswith("/") and token.count("/") >= 2)
+                    "-" in token
+                    or (token.startswith("/") and token.count("/") >= 2)
                     or (
                         match.start() > 0
                         and content[match.start() - 1] == "."

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -64,18 +64,23 @@ _DIGEST_ASSIGNMENT_PATTERN = re.compile(
 _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
     r"(?:[A-Z][a-z]{2,}(?:\d+)*){2,}(?:[A-Z](?:[a-z]{2,})?\d+)?"
 )
+_WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[A-Za-z]:\\|\\\\)[^\r\n]+$")
 _SAFE_REASON_SEGMENT = re.compile(r"[a-z][a-z0-9_]{0,63}")
 
 
 def _looks_like_opaque_token(content: str) -> bool:
     """Recognize encoded opaque values without consuming common identifiers."""
+    windows_path = bool(_WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content)) and not any(
+        char in "+=" for char in content
+    )
     for match in _OPAQUE_TOKEN_PATTERN.finditer(content):
         token = match.group(0)
         # Common immutable identifiers and explicit digest assignments are
         # evidence metadata, not credential evidence. A trailing Base64
         # padding marker is not an assignment and must remain review-gated.
         if (
-            _HEX_DIGEST_PATTERN.fullmatch(token)
+            windows_path
+            or _HEX_DIGEST_PATTERN.fullmatch(token)
             or _UUID_PATTERN.fullmatch(token)
             or _DIGEST_ASSIGNMENT_PATTERN.fullmatch(token)
             or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(token)

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -71,8 +71,8 @@ _VERSION_COMPONENT = r"V\d+"
 _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
     rf"(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{4,}}"
 )
-_THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
-    rf"(?:{_CAMEL_WORD}){{2}}Observation"
+_SAFE_THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIERS = frozenset(
+    {"AuthenticatedMaintainerObservation"}
 )
 _LOWER_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
     rf"[a-z]{{2,}}(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"
@@ -92,11 +92,10 @@ _SAFE_REASON_SEGMENT = re.compile(r"[a-z][a-z0-9_]{0,63}")
 
 
 def _looks_like_structured_identifier(segment: str) -> bool:
-    return any(
+    return segment in _SAFE_THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIERS or any(
         pattern.fullmatch(segment)
         for pattern in (
             _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN,
-            _THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIER_PATTERN,
             _LOWER_CAMEL_CASE_IDENTIFIER_PATTERN,
             _ACRONYM_VERSION_IDENTIFIER_PATTERN,
         )

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -66,14 +66,124 @@ _DIGEST_ASSIGNMENT_PATTERN = re.compile(
     r"(?:md5|sha(?:1|224|256|384|512))=(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{56}|[0-9A-Fa-f]{64}|[0-9A-Fa-f]{96}|[0-9A-Fa-f]{128})",
     re.IGNORECASE,
 )
-_SAFE_THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIERS = frozenset(
-    {"AuthenticatedMaintainerObservation"}
-)
 _IDENTIFIER_COMPONENT_PATTERN = re.compile(
     r"[A-Z]+(?=[A-Z][a-z]|\d|$)|[A-Z]?[a-z]+|\d+"
 )
 _SEMANTIC_IDENTIFIER_CONNECTORS = frozenset(
     {"a", "an", "and", "as", "at", "by", "for", "from", "in", "is", "not", "of", "on", "or", "the", "to", "v", "with"}
+)
+_SEMANTIC_IDENTIFIER_WORDS = frozenset(
+    {
+        "account",
+        "action",
+        "adapter",
+        "agent",
+        "alice",
+        "application",
+        "artifact",
+        "authenticated",
+        "batch",
+        "block",
+        "builder",
+        "cache",
+        "candidate",
+        "canonical",
+        "capability",
+        "client",
+        "command",
+        "component",
+        "configuration",
+        "connection",
+        "context",
+        "contract",
+        "controller",
+        "data",
+        "decision",
+        "deterministic",
+        "directory",
+        "dispatcher",
+        "document",
+        "engine",
+        "end",
+        "english",
+        "error",
+        "evaluator",
+        "event",
+        "evidence",
+        "execution",
+        "executor",
+        "factory",
+        "failure",
+        "file",
+        "finder",
+        "gateway",
+        "handler",
+        "handle",
+        "hermes",
+        "identifier",
+        "index",
+        "input",
+        "interview",
+        "lifecycle",
+        "loader",
+        "maintainer",
+        "manager",
+        "memory",
+        "metadata",
+        "migration",
+        "model",
+        "observation",
+        "operation",
+        "output",
+        "package",
+        "parser",
+        "path",
+        "platform",
+        "policy",
+        "project",
+        "protocol",
+        "provenance",
+        "provider",
+        "reader",
+        "read",
+        "reading",
+        "record",
+        "recoverable",
+        "recovery",
+        "reference",
+        "registry",
+        "request",
+        "response",
+        "reviewer",
+        "router",
+        "runtime",
+        "schema",
+        "server",
+        "service",
+        "session",
+        "source",
+        "state",
+        "status",
+        "store",
+        "stream",
+        "system",
+        "target",
+        "task",
+        "terminal",
+        "test",
+        "tests",
+        "thread",
+        "token",
+        "tool",
+        "update",
+        "user",
+        "validator",
+        "value",
+        "version",
+        "worker",
+        "workflow",
+        "writer",
+    }
 )
 _UPPER_SNAKE_IDENTIFIER_PATTERN = re.compile(r"[A-Z][A-Z0-9]{1,15}(?:_[A-Z][A-Z0-9]{1,15}){2,}")
 _SEPARATOR_SPLIT_OPAQUE_PATTERN = re.compile(
@@ -87,8 +197,6 @@ _SAFE_REASON_SEGMENT = re.compile(r"[a-z][a-z0-9_]{0,63}")
 
 
 def _looks_like_structured_identifier(segment: str) -> bool:
-    if segment in _SAFE_THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIERS:
-        return True
     if not segment.isalnum() or not any(char.islower() for char in segment) or not any(
         char.isupper() for char in segment
     ):
@@ -106,15 +214,11 @@ def _looks_like_semantic_identifier_component(component: str) -> bool:
     if component.isdigit():
         return True
     lowered = component.lower()
-    if lowered in _SEMANTIC_IDENTIFIER_CONNECTORS:
+    if lowered in _SEMANTIC_IDENTIFIER_CONNECTORS or lowered in _SEMANTIC_IDENTIFIER_WORDS:
         return True
     if component.isupper():
         return 2 <= len(component) <= 8
-    if not component.isalpha() or not 4 <= len(component) <= 16:
-        return False
-    if not any(char in "aeiouy" for char in lowered):
-        return False
-    return re.search(r"[^aeiouy]{5,}", lowered) is None
+    return False
 
 
 def _looks_like_semantic_upper_snake_identifier(segment: str) -> bool:

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -169,7 +169,7 @@ def evaluate_renderable_strings(artifact: dict[str, object]) -> dict[str, object
     Returns worst-case result with status and reason_code.
     Fail-closed: any blocked field blocks, any needs_review field needs review.
     """
-    renderable_fields = (
+    prioritized_fields = (
         "summary",
         "value",
         "label",
@@ -191,11 +191,22 @@ def evaluate_renderable_strings(artifact: dict[str, object]) -> dict[str, object
         "perspective",
         "attention",
     )
+    renderable_fields = tuple(dict.fromkeys((*prioritized_fields, *(str(key) for key in artifact))))
 
     worst_status = "safe"
     worst_field = None
 
     for field in renderable_fields:
+        key_status = classify_memory_admission(field).get("status", "safe")
+        if key_status == "blocked":
+            return {
+                "status": "blocked",
+                "field": "metadata_key",
+                "reason_code": "safety_blocked_in_metadata_key",
+            }
+        if key_status == "needs_review" and worst_status != "blocked":
+            worst_status = "needs_review"
+            worst_field = "metadata_key"
         content = artifact.get(field)
         for value_path, value in _iter_renderable_values(content, field):
             result = classify_memory_admission(value)

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -69,7 +69,10 @@ _DIGEST_ASSIGNMENT_PATTERN = re.compile(
 _CAMEL_WORD = r"[A-Z][a-z]{2,}(?:\d+)?"
 _VERSION_COMPONENT = r"V\d+"
 _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
-    rf"(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"
+    rf"(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{4,}}"
+)
+_THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
+    rf"(?:{_CAMEL_WORD}){{2}}Observation"
 )
 _LOWER_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
     rf"[a-z]{{2,}}(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"
@@ -93,6 +96,7 @@ def _looks_like_structured_identifier(segment: str) -> bool:
         pattern.fullmatch(segment)
         for pattern in (
             _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN,
+            _THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIER_PATTERN,
             _LOWER_CAMEL_CASE_IDENTIFIER_PATTERN,
             _ACRONYM_VERSION_IDENTIFIER_PATTERN,
         )

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -18,7 +18,7 @@ _BLOCKED_PATTERNS = (
     # abc-secret-token). Keep this narrow so ordinary prose such as
     # "token-based parsing" remains usable.
     re.compile(
-        r"(?:password|passwd|secret|token|key)s?-(?:password|passwd|secret|token|key)s?",
+        r"(?:password|passwd|secret|token|key)s?-(?:password|passwd|secret|token|key)s?(?![A-Za-z0-9])",
         re.IGNORECASE,
     ),
     re.compile(r"api[_-]key", re.IGNORECASE),
@@ -26,7 +26,8 @@ _BLOCKED_PATTERNS = (
     re.compile(r"Bearer\s+", re.IGNORECASE),
     # High-confidence credential formats that carry no descriptive keyword.
     re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", re.IGNORECASE),
-    re.compile(r"\b(?:gh[oprsu]|github_pat|glpat|hf)[_-][A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\b(?:gh[oprsu]|github_pat|glpat)[_-][A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\bhf_[A-Za-z0-9]{16,}\b", re.IGNORECASE),
     re.compile(r"\bnpm_[A-Za-z0-9]{16,}\b", re.IGNORECASE),
     re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
     re.compile(r"\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b", re.IGNORECASE),
@@ -37,6 +38,10 @@ _BLOCKED_PATTERNS = (
     re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE),
 )
 
+_CREDENTIAL_REVIEW_PATTERN = re.compile(
+    r"\b(?:credential|access[_ -]?token|private[_ -]?key|secret|token|api[_ -]?key)\s*[:=]\s*\S{12,}",
+    re.IGNORECASE,
+)
 _NEEDS_REVIEW_PATTERNS = (
     re.compile(r"ignore\s+previous", re.IGNORECASE),
     re.compile(r"reveal\s+the\s+system\s+prompt", re.IGNORECASE),
@@ -47,13 +52,12 @@ _NEEDS_REVIEW_PATTERNS = (
     # A credential-like value with an unknown prefix is not auto-safe. The
     # character-class and uniqueness checks below avoid treating normal prose
     # as an opaque value while keeping this gate deterministic.
-    re.compile(
-        r"\b(?:credential|access[_ -]?token|private[_ -]?key|secret|token|api[_ -]?key)\s*[:=]\s*\S{12,}",
-        re.IGNORECASE,
-    ),
+    _CREDENTIAL_REVIEW_PATTERN,
 )
 _OPAQUE_TOKEN_PATTERN = re.compile(r"(?<![A-Za-z0-9])[A-Za-z0-9+/=_-]{32,}(?![A-Za-z0-9])")
-_HEX_DIGEST_PATTERN = re.compile(r"(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64}|[0-9A-Fa-f]{96}|[0-9A-Fa-f]{128})")
+_HEX_DIGEST_PATTERN = re.compile(
+    r"(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{56}|[0-9A-Fa-f]{64}|[0-9A-Fa-f]{96}|[0-9A-Fa-f]{128})"
+)
 _UUID_PATTERN = re.compile(
     r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[1-8][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"
 )
@@ -62,17 +66,58 @@ _DIGEST_ASSIGNMENT_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
-    r"(?:[A-Z][a-z]{2,}(?:\d+)*){2,}(?:[A-Z](?:[a-z]{2,})?\d+)?"
+    r"(?:(?:[A-Z]{2,}(?=[A-Z][a-z]{2,}))|(?:[A-Z][a-z]{2,}(?:\d+)?)|(?:[A-Z]\d+)){2,}"
 )
 _WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(r"^(?:[A-Za-z]:\\|\\\\)[^\r\n]+$")
 _SAFE_REASON_SEGMENT = re.compile(r"[a-z][a-z0-9_]{0,63}")
 
 
+def _looks_like_safe_path_segment(segment: str) -> bool:
+    if (
+        re.fullmatch(r"\.?[a-z0-9][a-z0-9._-]*", segment)
+        or re.fullmatch(r"[A-Z][a-z]{2,}", segment)
+        or re.fullmatch(r"[A-Z]", segment)
+        or _HEX_DIGEST_PATTERN.fullmatch(segment)
+        or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(segment)
+        or re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d+Z-[a-z0-9-]+(?:\.[a-z0-9]+)?", segment)
+    ):
+        return True
+    parts = segment.split("-")
+    return len(parts) > 1 and all(
+        bool(re.fullmatch(r"[a-z0-9][a-z0-9._]*", part))
+        or bool(_VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(part))
+        for part in parts
+    )
+
+
+def _looks_like_safe_path_token(token: str) -> bool:
+    if "/" not in token or any(char in "+=" for char in token):
+        return False
+    segments = [segment for segment in token.split("/") if segment]
+    return len(segments) >= 2 and all(_looks_like_safe_path_segment(segment) for segment in segments)
+
+
+def _looks_like_safe_windows_path(content: str) -> bool:
+    if not _WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content) or any(char in "+=" for char in content):
+        return False
+    segments = [segment for segment in content.split("\\") if segment and not re.fullmatch(r"[A-Za-z]:", segment)]
+    return bool(segments) and all(_looks_like_safe_path_segment(segment) for segment in segments)
+
+
+def _looks_like_safe_digest_query_token(token: str, content: str) -> bool:
+    if "://" not in content or token.count("=") != 1:
+        return False
+    key, value = token.split("=", 1)
+    return bool(re.fullmatch(r"[A-Za-z][A-Za-z0-9_-]{0,31}", key)) and bool(
+        _HEX_DIGEST_PATTERN.fullmatch(value)
+    )
+
+
 def _looks_like_opaque_token(content: str) -> bool:
     """Recognize encoded opaque values without consuming common identifiers."""
-    windows_path = bool(_WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content)) and not any(
-        char in "+=" for char in content
-    )
+    windows_path = _looks_like_safe_windows_path(content)
+    if _WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content) and not windows_path:
+        return True
     for match in _OPAQUE_TOKEN_PATTERN.finditer(content):
         token = match.group(0)
         # Common immutable identifiers and explicit digest assignments are
@@ -84,20 +129,8 @@ def _looks_like_opaque_token(content: str) -> bool:
             or _UUID_PATTERN.fullmatch(token)
             or _DIGEST_ASSIGNMENT_PATTERN.fullmatch(token)
             or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(token)
-            or (
-                "/" in token
-                and not any(char in "+=" for char in token)
-                and (
-                    "-" in token
-                    or (token.startswith("/") and token.count("/") >= 2)
-                    or (
-                        match.start() > 0
-                        and content[match.start() - 1] == "."
-                        and match.end() < len(content)
-                        and content[match.end()] == "."
-                    )
-                )
-            )
+            or _looks_like_safe_path_token(token)
+            or _looks_like_safe_digest_query_token(token, content)
         ):
             continue
         has_lower = any(char.islower() for char in token)
@@ -123,7 +156,11 @@ def contains_credential_like_material(content: str) -> bool:
     """Return whether a value must be masked before it can serialize."""
     if not isinstance(content, str):
         return True
-    return any(pattern.search(content) for pattern in _BLOCKED_PATTERNS) or _looks_like_opaque_token(content)
+    return (
+        any(pattern.search(content) for pattern in _BLOCKED_PATTERNS)
+        or bool(_CREDENTIAL_REVIEW_PATTERN.search(content))
+        or _looks_like_opaque_token(content)
+    )
 
 
 def _iter_renderable_values(value: object, path: str) -> Iterator[tuple[str, str]]:

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -186,7 +186,7 @@ def _has_single_case_alphanumeric_opaque_mix(token: str) -> bool:
     if not digits:
         if all(char.isupper() for char in letters):
             return len(token) >= 32
-        return len(token) >= 32 and len(token) % 4 == 0 and len(set(token)) >= 8
+        return len(token) >= 32 and len(set(token)) >= 8
     if len(token) >= 32 and all(char.isupper() for char in letters):
         return True
     if len(digits) < 3:

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -169,6 +169,17 @@ def _has_single_case_alphanumeric_opaque_mix(token: str) -> bool:
     return transitions >= 4
 
 
+def _has_embedded_single_case_opaque_value(content: str) -> bool:
+    """Detect opaque runs before a path or URL container can exempt them."""
+    for match in re.finditer(r"[A-Za-z0-9]{32,}", content):
+        segment = match.group(0)
+        if _HEX_DIGEST_PATTERN.fullmatch(segment):
+            continue
+        if _has_single_case_alphanumeric_opaque_mix(segment):
+            return True
+    return False
+
+
 def _windows_path_has_split_opaque_value(content: str) -> bool:
     unsafe_run: list[str] = []
     for segment in (
@@ -185,6 +196,8 @@ def _windows_path_has_split_opaque_value(content: str) -> bool:
 
 def _looks_like_opaque_token(content: str) -> bool:
     """Recognize encoded opaque values without consuming common identifiers."""
+    if _has_embedded_single_case_opaque_value(content):
+        return True
     windows_path = bool(_WINDOWS_ABSOLUTE_PATH_PATTERN.fullmatch(content))
     if windows_path and _windows_path_has_split_opaque_value(content):
         return True

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -31,6 +31,7 @@ _BLOCKED_PATTERNS = (
     re.compile(r"\bnpm_[A-Za-z0-9]{16,}\b", re.IGNORECASE),
     re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
     re.compile(r"\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b", re.IGNORECASE),
+    re.compile(r"\brk_(?:live|test)_[A-Za-z0-9]{16,}\b", re.IGNORECASE),
     re.compile(r"\bya29\.[A-Za-z0-9_-]{20,}\b", re.IGNORECASE),
     re.compile(r"\bAIza[A-Za-z0-9_-]{20,}\b", re.IGNORECASE),
     re.compile(r"\bxox[a-z]?-[A-Za-z0-9-]{16,}\b", re.IGNORECASE),
@@ -68,7 +69,7 @@ _DIGEST_ASSIGNMENT_PATTERN = re.compile(
 _CAMEL_WORD = r"[A-Z][a-z]{2,}(?:\d+)?"
 _VERSION_COMPONENT = r"V\d+"
 _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
-    rf"(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{4,}}"
+    rf"(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"
 )
 _LOWER_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
     rf"[a-z]{{2,}}(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -7,6 +7,7 @@ progress, and imperative prompt-injection-shaped content.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator, Mapping
 
 
 _BLOCKED_PATTERNS = (
@@ -25,8 +26,11 @@ _BLOCKED_PATTERNS = (
     re.compile(r"Bearer\s+", re.IGNORECASE),
     # High-confidence credential formats that carry no descriptive keyword.
     re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", re.IGNORECASE),
-    re.compile(r"\b(?:gh[oprs]|github_pat|glpat|npm|hf)[_-][A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\b(?:gh[oprsu]|github_pat|glpat|hf)[_-][A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\bnpm_[A-Za-z0-9]{16,}\b", re.IGNORECASE),
     re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{16,}\b", re.IGNORECASE),
+    re.compile(r"\bsk_(?:live|test)_[A-Za-z0-9]{16,}\b", re.IGNORECASE),
+    re.compile(r"\bya29\.[A-Za-z0-9_-]{20,}\b", re.IGNORECASE),
     re.compile(r"\bAIza[A-Za-z0-9_-]{20,}\b", re.IGNORECASE),
     re.compile(r"\bxox[a-z]?-[A-Za-z0-9-]{16,}\b", re.IGNORECASE),
     re.compile(r"\b[a-z][a-z0-9+.-]{1,31}://[^/\s:@]+:[^@\s/]+@", re.IGNORECASE),
@@ -49,28 +53,89 @@ _NEEDS_REVIEW_PATTERNS = (
     ),
 )
 _OPAQUE_TOKEN_PATTERN = re.compile(r"(?<![A-Za-z0-9])[A-Za-z0-9+/=_-]{32,}(?![A-Za-z0-9])")
+_HEX_DIGEST_PATTERN = re.compile(r"(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{64}|[0-9A-Fa-f]{96}|[0-9A-Fa-f]{128})")
+_UUID_PATTERN = re.compile(
+    r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[1-5][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"
+)
+_DIGEST_ASSIGNMENT_PATTERN = re.compile(
+    r"(?:md5|sha(?:1|224|256|384|512))=(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{56}|[0-9A-Fa-f]{64}|[0-9A-Fa-f]{96}|[0-9A-Fa-f]{128})",
+    re.IGNORECASE,
+)
+_VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
+    r"(?:[A-Z][a-z]{2,}(?:\d+)*){2,}(?:[A-Z](?:[a-z]{2,})?\d+)?"
+)
+_SAFE_REASON_SEGMENT = re.compile(r"[a-z][a-z0-9_]{0,63}")
 
 
 def _looks_like_opaque_token(content: str) -> bool:
-    """Recognize unknown long opaque values conservatively for review."""
+    """Recognize encoded opaque values without consuming common identifiers."""
     for match in _OPAQUE_TOKEN_PATTERN.finditer(content):
         token = match.group(0)
-        # Keep ordinary assignment labels and low-entropy hyphenated prose
-        # out of the opaque-value heuristic (for example sha256=aaaa... or
-        # human-definition-source-only-sentinel).
-        if "=" in token:
-            continue
-        character_classes = sum(
-            (
-                any(char.islower() for char in token),
-                any(char.isupper() for char in token),
-                any(char.isdigit() for char in token),
-                any(char in "+/=_-" for char in token),
+        # Common immutable identifiers and explicit digest assignments are
+        # evidence metadata, not credential evidence. A trailing Base64
+        # padding marker is not an assignment and must remain review-gated.
+        if (
+            _HEX_DIGEST_PATTERN.fullmatch(token)
+            or _UUID_PATTERN.fullmatch(token)
+            or _DIGEST_ASSIGNMENT_PATTERN.fullmatch(token)
+            or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(token)
+            or (
+                "/" in token
+                and not any(char in "+=" for char in token)
+                and (
+                    (token.startswith("/") and token.count("/") >= 2)
+                    or (
+                        match.start() > 0
+                        and content[match.start() - 1] == "."
+                        and match.end() < len(content)
+                        and content[match.end()] == "."
+                    )
+                )
             )
-        )
-        if character_classes >= 3 or (not any(char in "_-" for char in token) and len(set(token)) >= 12):
+        ):
+            continue
+        has_lower = any(char.islower() for char in token)
+        has_upper = any(char.isupper() for char in token)
+        has_digit = any(char.isdigit() for char in token)
+        has_encoding_punctuation = any(char in "+=" for char in token)
+        # Mixed-case alphanumeric material is a conservative opaque-value
+        # signal. Base64 punctuation can substitute for one alphanumeric
+        # class, while ordinary lowercase path/package separators do not.
+        if (
+            has_lower
+            and has_upper
+            and (has_digit or ("_" in token and "-" in token))
+        ) or (
+            has_encoding_punctuation
+            and sum((has_lower, has_upper, has_digit, has_encoding_punctuation)) >= 3
+        ):
             return True
     return False
+
+
+def contains_credential_like_material(content: str) -> bool:
+    """Return whether a value must be masked before it can serialize."""
+    if not isinstance(content, str):
+        return True
+    return any(pattern.search(content) for pattern in _BLOCKED_PATTERNS) or _looks_like_opaque_token(content)
+
+
+def _iter_renderable_values(value: object, path: str) -> Iterator[tuple[str, str]]:
+    if isinstance(value, str):
+        if value:
+            yield path, value
+        return
+    if isinstance(value, Mapping):
+        for key, nested in value.items():
+            segment = str(key)
+            nested_path = f"{path}.{segment}" if _SAFE_REASON_SEGMENT.fullmatch(segment) else path
+            if segment:
+                yield f"{path}.key", segment
+            yield from _iter_renderable_values(nested, nested_path)
+        return
+    if isinstance(value, (list, tuple)):
+        for nested in value:
+            yield from _iter_renderable_values(nested, path)
 
 
 def classify_memory_admission(content: str) -> dict[str, object]:
@@ -99,40 +164,59 @@ def classify_memory_admission(content: str) -> dict[str, object]:
 
 
 def evaluate_renderable_strings(artifact: dict[str, object]) -> dict[str, object]:
-    """Evaluate all renderable string fields (summary, value, label).
-    
+    """Evaluate every artifact field that can reach a memory render surface.
+
     Returns worst-case result with status and reason_code.
-    Fail-closed: any blocked field blocks, any needs_review fields need review.
+    Fail-closed: any blocked field blocks, any needs_review field needs review.
     """
-    renderable_fields = ["summary", "value", "label"]
-    
+    renderable_fields = (
+        "summary",
+        "value",
+        "label",
+        "key",
+        "source",
+        "source_ref",
+        "record_type",
+        "retention_class",
+        "retention",
+        "stale_after",
+        "time_sensitivity",
+        "duplicate_of",
+        "safety",
+        "created_at",
+        "scope",
+        "tags",
+        "derived_from",
+        "source_evidence",
+        "perspective",
+        "attention",
+    )
+
     worst_status = "safe"
     worst_field = None
-    
+
     for field in renderable_fields:
         content = artifact.get(field)
-        if not isinstance(content, str) or not content:
-            continue
-        
-        result = classify_memory_admission(content)
-        status = result.get("status", "safe")
-        
-        # Fail closed: blocked > needs_review > safe
-        if status == "blocked":
-            return {
-                "status": "blocked",
-                "field": field,
-                "reason_code": f"safety_blocked_in_{field}",
-            }
-        elif status == "needs_review" and worst_status != "blocked":
-            worst_status = "needs_review"
-            worst_field = field
-    
+        for value_path, value in _iter_renderable_values(content, field):
+            result = classify_memory_admission(value)
+            status = result.get("status", "safe")
+
+            # Fail closed: blocked > needs_review > safe
+            if status == "blocked":
+                return {
+                    "status": "blocked",
+                    "field": value_path,
+                    "reason_code": f"safety_blocked_in_{value_path}",
+                }
+            if status == "needs_review" and worst_status != "blocked":
+                worst_status = "needs_review"
+                worst_field = value_path
+
     if worst_status == "needs_review":
         return {
             "status": "needs_review",
             "field": worst_field,
             "reason_code": f"safety_needs_review_in_{worst_field}",
         }
-    
+
     return {"status": "safe", "reason_code": "eligible"}

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -66,19 +66,14 @@ _DIGEST_ASSIGNMENT_PATTERN = re.compile(
     r"(?:md5|sha(?:1|224|256|384|512))=(?:[0-9A-Fa-f]{32}|[0-9A-Fa-f]{40}|[0-9A-Fa-f]{56}|[0-9A-Fa-f]{64}|[0-9A-Fa-f]{96}|[0-9A-Fa-f]{128})",
     re.IGNORECASE,
 )
-_CAMEL_WORD = r"[A-Z][a-z]{2,}(?:\d+)?"
-_VERSION_COMPONENT = r"V\d+"
-_VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
-    rf"(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{4,}}"
-)
 _SAFE_THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIERS = frozenset(
     {"AuthenticatedMaintainerObservation"}
 )
-_LOWER_CAMEL_CASE_IDENTIFIER_PATTERN = re.compile(
-    rf"[a-z]{{2,}}(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"
+_IDENTIFIER_COMPONENT_PATTERN = re.compile(
+    r"[A-Z]+(?=[A-Z][a-z]|\d|$)|[A-Z]?[a-z]+|\d+"
 )
-_ACRONYM_VERSION_IDENTIFIER_PATTERN = re.compile(
-    rf"[A-Z]{{2,}}\d*(?:{_CAMEL_WORD}|{_VERSION_COMPONENT}){{3,}}"
+_SEMANTIC_IDENTIFIER_CONNECTORS = frozenset(
+    {"a", "an", "and", "as", "at", "by", "for", "from", "in", "is", "not", "of", "on", "or", "the", "to", "v", "with"}
 )
 _UPPER_SNAKE_IDENTIFIER_PATTERN = re.compile(r"[A-Z][A-Z0-9]{1,15}(?:_[A-Z][A-Z0-9]{1,15}){2,}")
 _SEPARATOR_SPLIT_OPAQUE_PATTERN = re.compile(
@@ -92,14 +87,34 @@ _SAFE_REASON_SEGMENT = re.compile(r"[a-z][a-z0-9_]{0,63}")
 
 
 def _looks_like_structured_identifier(segment: str) -> bool:
-    return segment in _SAFE_THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIERS or any(
-        pattern.fullmatch(segment)
-        for pattern in (
-            _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN,
-            _LOWER_CAMEL_CASE_IDENTIFIER_PATTERN,
-            _ACRONYM_VERSION_IDENTIFIER_PATTERN,
-        )
+    if segment in _SAFE_THREE_PART_SEMANTIC_CAMEL_CASE_IDENTIFIERS:
+        return True
+    if not segment.isalnum() or not any(char.islower() for char in segment) or not any(
+        char.isupper() for char in segment
+    ):
+        return False
+    components = _IDENTIFIER_COMPONENT_PATTERN.findall(segment)
+    alpha_components = [component for component in components if component.isalpha()]
+    return (
+        "".join(components) == segment
+        and len(alpha_components) >= 3
+        and all(_looks_like_semantic_identifier_component(component) for component in components)
     )
+
+
+def _looks_like_semantic_identifier_component(component: str) -> bool:
+    if component.isdigit():
+        return True
+    lowered = component.lower()
+    if lowered in _SEMANTIC_IDENTIFIER_CONNECTORS:
+        return True
+    if component.isupper():
+        return 2 <= len(component) <= 8
+    if not component.isalpha() or not 4 <= len(component) <= 16:
+        return False
+    if not any(char in "aeiouy" for char in lowered):
+        return False
+    return re.search(r"[^aeiouy]{5,}", lowered) is None
 
 
 def _looks_like_semantic_upper_snake_identifier(segment: str) -> bool:
@@ -133,6 +148,7 @@ def _looks_like_safe_path_segment(segment: str) -> bool:
         re.fullmatch(r"\.?[a-z0-9][a-z0-9._-]*", segment)
         or re.fullmatch(r"[A-Z][a-z]{2,}", segment)
         or re.fullmatch(r"[A-Z]", segment)
+        or re.fullmatch(r"[A-Z][A-Z0-9_]{1,31}", segment)
         or _HEX_DIGEST_PATTERN.fullmatch(segment)
         or _looks_like_path_identifier(segment)
         or re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d+Z-[a-z0-9-]+(?:\.[a-z0-9]+)?", segment)
@@ -239,7 +255,9 @@ def _has_separator_split_opaque_value(content: str) -> bool:
                 window = fragments[start:end]
                 lengths = [len(fragment) for fragment in window]
                 combined = "".join(window)
-                chunked = (len(window) >= 4 and min(lengths) >= 4) or (
+                chunked = (len(window) >= 3 and min(lengths) >= 8) or (
+                    len(window) >= 4 and min(lengths) >= 4
+                ) or (
                     len(window) >= 2 and min(lengths) >= 12
                 )
                 if len(combined) < 32 or not chunked:
@@ -248,9 +266,20 @@ def _has_separator_split_opaque_value(content: str) -> bool:
                     continue
                 window_start = fragment_matches[start].start()
                 window_end = fragment_matches[end - 1].end()
-                if any(_looks_like_structured_identifier(fragment) for fragment in window) or any(
+                semantic_snake_overlap = any(
                     window_start < snake_end and snake_start < window_end
                     for snake_start, snake_end in semantic_snake_spans
+                )
+                chunked_base32 = (
+                    len(window) >= 4
+                    and len(set(lengths)) == 1
+                    and lengths[0] == 8
+                    and combined.isalpha()
+                    and combined.isupper()
+                    and set(combined) <= set("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+                )
+                if any(_looks_like_structured_identifier(fragment) for fragment in window) or (
+                    semantic_snake_overlap and not chunked_base32
                 ):
                     continue
                 mixed = _has_opaque_character_mix(combined)

--- a/src/plugin_bundle/omh/_governance_safety.py
+++ b/src/plugin_bundle/omh/_governance_safety.py
@@ -188,11 +188,12 @@ def _has_embedded_opaque_value(content: str) -> bool:
             _HEX_DIGEST_PATTERN.fullmatch(segment)
             or _VERSIONED_CAMEL_CASE_IDENTIFIER_PATTERN.fullmatch(segment)
             or _ACRONYM_VERSION_IDENTIFIER_PATTERN.fullmatch(segment)
-            or _looks_like_structured_identifier(segment)
         ):
             continue
         if _has_opaque_character_mix(segment) or _has_single_case_alphanumeric_opaque_mix(segment):
             return True
+        if _looks_like_structured_identifier(segment):
+            continue
     return False
 
 

--- a/src/plugin_bundle/omh/memory_governance.py
+++ b/src/plugin_bundle/omh/memory_governance.py
@@ -44,7 +44,7 @@ PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION = "project_memory_review_record/v2"
 
 # Governance policy and classifier versions
 MEMORY_GOVERNANCE_POLICY_VERSION = "governance/v2"
-MEMORY_CLASSIFIER_VERSION = "classifier/v2"
+MEMORY_CLASSIFIER_VERSION = "classifier/v3"
 
 # Retention classes
 RETENTION_CLASSES = frozenset({"volatile", "standard", "durable"})

--- a/src/plugin_bundle/omh/memory_governance.py
+++ b/src/plugin_bundle/omh/memory_governance.py
@@ -27,6 +27,8 @@ __all__ = [
     "build_retention",
     "canonical_payload_digest",
     "classify_memory_admission",
+    "contains_credential_like_material",
+    "evaluate_renderable_strings",
     "resolve_record_expiry_deadline",
     "stable_artifact_identity",
     "evaluate_memory_replay",
@@ -221,7 +223,11 @@ def canonical_payload_digest(artifact: dict[str, object]) -> str:
 
 
 # Public re-exports from internal modules
-from ._governance_safety import classify_memory_admission  # noqa: F401, E402
+from ._governance_safety import (  # noqa: F401, E402
+    classify_memory_admission,
+    contains_credential_like_material,
+    evaluate_renderable_strings,
+)
 from ._governance_evaluation import (  # noqa: F401, E402
     stable_artifact_identity,
     evaluate_memory_replay,

--- a/src/workflows/_memory_lifecycle_scan.py
+++ b/src/workflows/_memory_lifecycle_scan.py
@@ -6,6 +6,9 @@ from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+
+from ..plugin_bundle.omh.memory_governance import contains_credential_like_material
+
 _SAFE_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$")
 
 
@@ -18,7 +21,11 @@ class ScanFinding:
 
 
 def safe_token(value: object) -> bool:
-    return isinstance(value, str) and bool(_SAFE_TOKEN.fullmatch(value))
+    return (
+        isinstance(value, str)
+        and bool(_SAFE_TOKEN.fullmatch(value))
+        and not contains_credential_like_material(value)
+    )
 
 
 def stamp(value: datetime) -> str:

--- a/src/workflows/_memory_store_validation.py
+++ b/src/workflows/_memory_store_validation.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ..plugin_bundle.omh.memory_governance import contains_credential_like_material
+
 MEMORY_OPERATION_SCHEMA_VERSION = "memory_operation/v1"
 MEMORY_TOMBSTONE_SCHEMA_VERSION = "memory_tombstone/v1"
 MEMORY_OPERATION_STATES = frozenset({"prepared", "applying", "interrupted", "completed", "failed", "corrupt"})
@@ -94,6 +96,10 @@ def safe_token(value: str) -> bool:
     return _safe_token(value)
 
 
+def safe_json_value(value: object) -> bool:
+    return _json_value(value)
+
+
 def relative_memory_json_path(value: str) -> bool:
     return _relative_memory_path(value, ".json")
 
@@ -163,12 +169,19 @@ def _valid_step(step: object, names: set[str]) -> bool:
 
 
 def _json_value(value: object) -> bool:
-    if value is None or isinstance(value, (bool, str, int)):
+    if value is None or isinstance(value, (bool, int)):
         return True
+    if isinstance(value, str):
+        return not contains_credential_like_material(value)
     if isinstance(value, float):
         return value == value and value not in {float("inf"), float("-inf")}
     if isinstance(value, Mapping):
-        return all(isinstance(key, str) and _json_value(item) for key, item in value.items())
+        return all(
+            isinstance(key, str)
+            and not contains_credential_like_material(key)
+            and _json_value(item)
+            for key, item in value.items()
+        )
     return isinstance(value, list) and all(_json_value(item) for item in value)
 
 
@@ -186,4 +199,8 @@ def _metadata_errors(value: Mapping[str, object], allowed: frozenset[str]) -> li
 
 
 def _safe_token(value: object) -> bool:
-    return isinstance(value, str) and bool(_SAFE_TOKEN.fullmatch(value))
+    return (
+        isinstance(value, str)
+        and bool(_SAFE_TOKEN.fullmatch(value))
+        and not contains_credential_like_material(value)
+    )

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -3311,9 +3311,16 @@ def _build_project_memory_candidate(
 ) -> dict[str, object]:
     normalized_type = _normalize_record_type(record_type)
     scope = _scope_for_project_memory(scope_kind, scope_ref)
-    normalized_tags = _normalize_tags(tags)
+    raw_tags = _normalize_tags(tags, redact_sensitive=False)
+    normalized_tags = _normalize_tags(raw_tags)
     content_text = str(content or "")
-    safety = _project_memory_safety(summary, content_text, tags=normalized_tags)
+    safety = _project_memory_safety(
+        summary,
+        content_text,
+        tags=raw_tags,
+        source=str(source or "cli"),
+        source_ref=str(source_ref or ""),
+    )
     now = utc_now()
     if expires_at_value:
         # An absolute expiry carries no day count -- the date IS the policy.
@@ -3357,7 +3364,7 @@ def _build_project_memory_candidate(
         "summary": _redact(summary.strip())[:500],
         "scope": scope,
         "tags": normalized_tags,
-        "source": str(source or "cli"),
+        "source": _redact(str(source or "cli")),
         "source_ref": stored_source_ref,
         **({"source_evidence": source_evidence} if source_evidence else {}),
         "created_at": now,
@@ -3473,7 +3480,7 @@ def _record_from_candidate(
         "summary": _redact(str(candidate.get("summary", "")))[:500],
         "scope": scope,
         "tags": _normalize_tags(candidate.get("tags", [])),
-        "source": str(candidate.get("source", "cli")),
+        "source": _redact(str(candidate.get("source", "cli"))),
         "source_class": "omh_local",
         "source_ref": _redact(str(candidate.get("source_ref", "")))[:160],
         # The digest is carried over as observed at capture, never recomputed
@@ -4088,8 +4095,15 @@ def _source_evidence_state(record: dict[str, Any]) -> str:
     return "unchanged" if current == recorded else "changed"
 
 
-def _project_memory_safety(summary: str, content: str, *, tags: list[str]) -> dict[str, object]:
-    classification = classify_memory_admission("\n".join([summary, content, " ".join(tags)]))
+def _project_memory_safety(
+    summary: str,
+    content: str,
+    *,
+    tags: list[str],
+    source: str = "",
+    source_ref: str = "",
+) -> dict[str, object]:
+    classification = classify_memory_admission("\n".join([summary, content, " ".join(tags), source, source_ref]))
     status = str(classification.get("status", "blocked"))
     return {
         "schema_version": "project_memory_safety/v2",
@@ -4323,7 +4337,7 @@ def _scope_for_project_memory(kind: str, ref: str) -> dict[str, str]:
     return scope
 
 
-def _normalize_tags(values: Any) -> list[str]:
+def _normalize_tags(values: Any, *, redact_sensitive: bool = True) -> list[str]:
     if not isinstance(values, (list, tuple)):
         return []
     tags: list[str] = []
@@ -4332,6 +4346,8 @@ def _normalize_tags(values: Any) -> list[str]:
         tag = unicodedata.normalize("NFC", str(value)).strip().lower()
         if not tag or not _SAFE_TAG.match(tag):
             continue
+        if redact_sensitive and _looks_sensitive(tag):
+            tag = "[redacted]"
         if tag not in seen:
             tags.append(tag)
             seen.add(tag)
@@ -4891,7 +4907,9 @@ def _redact(value: str) -> str:
 
 def _looks_sensitive(value: str) -> bool:
     lowered = value.lower()
-    return any(marker in lowered for marker in ("secret", "token", "password", "private-key", "api_key", "apikey"))
+    if any(marker in lowered for marker in ("secret", "token", "password", "private-key", "api_key", "apikey")):
+        return True
+    return classify_memory_admission(value).get("status") == "blocked"
 
 
 def _validate_allowed_keys(value: dict[str, Any], allowed: set[str], errors: list[str], label: str) -> None:

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -4417,7 +4417,7 @@ def _normalize_tags(values: Any, *, redact_sensitive: bool = True) -> list[str]:
             continue
         if raw_tag == "[redacted]":
             tag = raw_tag
-        elif redact_sensitive and _looks_sensitive(raw_tag):
+        elif redact_sensitive and contains_credential_like_material(raw_tag):
             tag = "[redacted]"
         else:
             tag = raw_tag.lower()

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -1244,11 +1244,15 @@ def build_project_memory_recall_pack(
     query_intent: str | None = None,
 ) -> dict[str, object]:
     policy = read_project_memory_policy(paths)
+    executor_target = _redacted_metadata_label(executor_target)
+    session_id = _redacted_metadata_label(session_id)
+    scope_kind = _redacted_metadata_label(scope_kind) if scope_kind is not None else None
+    scope_ref = _redacted_metadata_label(scope_ref) if scope_ref is not None else None
     # Lens labels normalize exactly like capture labels: capture lowercases
     # and strips, so a raw "--observed Codex" here would silently match
     # nothing and read as "never captured".
-    observer = str(observer or "").strip().lower() or None
-    observed = str(observed or "").strip().lower() or None
+    observer = _redacted_metadata_label(str(observer or "").strip().lower()) or None
+    observed = _redacted_metadata_label(str(observed or "").strip().lower()) or None
     task_ref = {
         "sha256": hashlib.sha256(query.encode("utf-8")).hexdigest() if query else "",
         "length": len(query),

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -1083,9 +1083,7 @@ def _require_review_revision(candidate: dict[str, Any], expected_revision: str) 
     actual = project_memory_review_revision(candidate)
     if expected_revision != actual:
         raise StaleMemoryReviewError(
-            f"stale_review: candidate {candidate.get('candidate_id', '')} is now revision {actual}, "
-            f"not the reviewed revision {expected_revision}; re-read the card with "
-            "`omh memory review --candidate <id>` and decide again on what it shows now"
+            "stale_review: the candidate changed after the reviewed card was rendered; re-read it and decide again"
         )
 
 

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -721,7 +721,7 @@ def build_project_memory_status(paths: OmhPaths) -> dict[str, object]:
     expired_records = sum(1 for evaluation in evaluations if str(evaluation["reason_code"]).startswith("expired_"))
     candidate_status_counts: dict[str, int] = {}
     for candidate in candidates:
-        status = str(candidate.get("status", "unknown"))
+        status = _redact_admitted_text(str(candidate.get("status", "unknown")))
         candidate_status_counts[status] = candidate_status_counts.get(status, 0) + 1
     return {
         "schema_version": PROJECT_MEMORY_STATUS_SCHEMA_VERSION,
@@ -4436,8 +4436,8 @@ def _string_list(value: Any) -> list[str]:
 
 
 def _read_project_memory_candidate(paths: OmhPaths, candidate_id: str) -> dict[str, Any] | None:
-    if not _SAFE_REF.match(candidate_id):
-        raise ValueError(f"unsafe memory candidate id: {candidate_id!r}")
+    if not _SAFE_REF.match(candidate_id) or contains_credential_like_material(candidate_id):
+        raise ValueError("unsafe memory candidate id")
     return read_json_object(_memory_candidate_path(paths, candidate_id))
 
 
@@ -4912,9 +4912,16 @@ def _normalize_wrapper_snapshot(snapshot: dict[str, Any]) -> dict[str, object]:
     if snapshot.get("schema_version") != MEMORY_SNAPSHOT_SCHEMA_VERSION:
         raise ValueError("wrapper memory snapshot schema_version must be memory_snapshot/v1")
     source = "wrapper_snapshot"
-    scope = _normalize_scope(snapshot.get("scope", _scope("project", "default")))
+    scope = _redacted_scope(snapshot.get("scope", _scope("project", "default")))
     items = [_sanitize_item(item, default_scope=scope) for item in snapshot.get("items", []) if isinstance(item, dict)]
-    return _snapshot(source, scope, items, claim_boundary=str(snapshot.get("claim_boundary", "Wrapper supplied memory candidates are not trusted until reviewed.")))
+    return _snapshot(
+        source,
+        scope,
+        items,
+        claim_boundary=_redact_admitted_text(
+            str(snapshot.get("claim_boundary", "Wrapper supplied memory candidates are not trusted until reviewed."))
+        ),
+    )
 
 
 def _snapshot(source: str, scope: Any, items: list[dict[str, object]], *, claim_boundary: str = "") -> dict[str, object]:
@@ -4933,14 +4940,14 @@ def _snapshot(source: str, scope: Any, items: list[dict[str, object]], *, claim_
 
 
 def _sanitize_item(item: dict[str, Any], *, default_scope: dict[str, str]) -> dict[str, object]:
-    item_id = str(item.get("item_id") or _stable_ref(item.get("key", "item")))
-    key = str(item.get("key", item_id))
+    item_id = _redact_admitted_text(str(item.get("item_id") or _stable_ref(item.get("key", "item"))))
+    key = _redact_admitted_text(str(item.get("key", item_id)))
     summary = _safe_summary(item)
     sanitized: dict[str, object] = {
         "item_id": item_id,
         "key": key,
         "summary": summary,
-        "scope": _normalize_scope(item.get("scope", default_scope)),
+        "scope": _redacted_scope(item.get("scope", default_scope)),
         "sensitive": bool(item.get("sensitive", False)),
     }
     value = item.get("value")
@@ -4948,7 +4955,7 @@ def _sanitize_item(item: dict[str, Any], *, default_scope: dict[str, str]) -> di
         sanitized["value"] = str(value)
     replay_evaluation = item.get("replay_evaluation")
     if isinstance(replay_evaluation, dict):
-        sanitized["replay_evaluation"] = replay_evaluation
+        sanitized["replay_evaluation"] = _redact_nested_metadata(replay_evaluation)
     return sanitized
 
 
@@ -5169,7 +5176,11 @@ def _validate_domain_handoff_items(value: Any, errors: list[str], label: str) ->
 
 def _contains_sensitive_text(value: Any) -> bool:
     if isinstance(value, dict):
-        return any(_contains_sensitive_text(item) for item in value.values())
+        return any(
+            (isinstance(key, str) and contains_credential_like_material(key))
+            or _contains_sensitive_text(item)
+            for key, item in value.items()
+        )
     if isinstance(value, list):
         return any(_contains_sensitive_text(item) for item in value)
     if isinstance(value, str):

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -1244,6 +1244,12 @@ def build_project_memory_recall_pack(
     query_intent: str | None = None,
 ) -> dict[str, object]:
     policy = read_project_memory_policy(paths)
+    structural_selectors = (scope_kind, scope_ref, observer, observed)
+    if any(
+        value is not None and contains_credential_like_material(str(value))
+        for value in structural_selectors
+    ):
+        raise ValueError("credential-like recall selector is not allowed")
     executor_target = _redacted_metadata_label(executor_target)
     session_id = _redacted_metadata_label(session_id)
     scope_kind = _redacted_metadata_label(scope_kind) if scope_kind is not None else None
@@ -1933,7 +1939,7 @@ def _resolve_query_intent(query: str, supplied: str | None) -> str:
     if normalized in {"", "auto"}:
         return _recall_query_intent(query)
     if normalized not in {"default", "temporal"}:
-        raise ValueError(f"query_intent must be one of auto, default, temporal; got {supplied!r}")
+        raise ValueError("query_intent must be one of auto, default, temporal")
     return normalized
 
 

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -2785,12 +2785,12 @@ def _lineage_card(record: dict[str, Any], *, depth: int, due_soon_days: int | No
     return {
         "record_id": _redacted_metadata_label(record.get("record_id", "")),
         "depth": depth,
-        "record_type": str(record.get("record_type", "")),
+        "record_type": _redact_admitted_text(str(record.get("record_type", ""))),
         "summary": _redact_admitted_text(str(record.get("summary", "")))[:500],
         "scope": _redacted_scope(record.get("scope", _scope("project", "default"))),
         "tags": _normalize_tags(record.get("tags", [])),
-        "approved_at": str(record.get("approved_at", "")),
-        "staleness": _record_staleness(record, due_soon_days=due_soon_days),
+        "approved_at": _redact_admitted_text(str(record.get("approved_at", ""))),
+        "staleness": _redact_nested_metadata(_record_staleness(record, due_soon_days=due_soon_days)),
         "derived_from": [
             _redacted_metadata_label(ref) for ref in _string_list(record.get("derived_from", []))
         ],
@@ -3702,13 +3702,13 @@ def _recall_item(
     evidence = _replay_evaluation(record, evaluation)
     return {
         "record_id": _redacted_metadata_label(record.get("record_id", "")),
-        "record_type": str(record.get("record_type", "")),
+        "record_type": _redact_admitted_text(str(record.get("record_type", ""))),
         "summary": _redact_admitted_text(str(record.get("summary", "")))[:500],
         "scope": _normalize_scope(record.get("scope", _scope("project", "default"))),
         "tags": _normalize_tags(record.get("tags", [])),
         "source": str(record.get("source", "")),
-        "approved_at": str(record.get("approved_at", "")),
-        "staleness": staleness,
+        "approved_at": _redact_admitted_text(str(record.get("approved_at", ""))),
+        "staleness": _redact_nested_metadata(staleness),
         "score": int(score),
         "attention_tier": attention_tier,
         "derived_from": _string_list(record.get("derived_from", [])),
@@ -3728,7 +3728,7 @@ def _recall_exclusion(
     return {
         "record_id": _redacted_metadata_label(record.get("record_id", "")),
         "reason": reason or str(evidence["reason_code"]),
-        "staleness": staleness,
+        "staleness": _redact_nested_metadata(staleness),
         **_recall_evidence_fields(evidence),
     }
 
@@ -4981,7 +4981,7 @@ def _redacted_metadata_label(value: Any) -> str:
 
 def _redact_nested_metadata(value: Any) -> Any:
     if isinstance(value, str):
-        return _redact(value)
+        return _redact_admitted_text(value)
     if isinstance(value, dict):
         sanitized: dict[str, Any] = {}
         for index, (key, nested) in enumerate(value.items()):

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -4983,7 +4983,7 @@ def _safe_to_expose_value(key: str, value: Any, item: dict[str, Any]) -> bool:
 
 def _redacted_metadata_label(value: Any) -> str:
     text = str(value or "")
-    return "redacted" if _looks_sensitive(text) else text
+    return "redacted" if contains_credential_like_material(text) else text
 
 
 def _redact_nested_metadata(value: Any) -> Any:

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -4415,8 +4415,8 @@ def _scope_for_project_memory(kind: str, ref: str) -> dict[str, str]:
     scope = _scope(str(kind or "project"), str(ref or "default"))
     if scope["kind"] not in ALLOWED_SCOPE_KINDS:
         raise ValueError(f"unsupported memory scope kind: {scope['kind']}")
-    if not _SAFE_REF.match(scope["ref"]):
-        raise ValueError(f"unsafe memory scope ref: {scope['ref']!r}")
+    if not _SAFE_REF.match(scope["ref"]) or contains_credential_like_material(scope["ref"]):
+        raise ValueError("unsafe memory scope ref")
     return scope
 
 

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -33,7 +33,9 @@ from ..plugin_bundle.omh.memory_governance import (
     build_retention,
     canonical_payload_digest,
     classify_memory_admission,
+    contains_credential_like_material,
     evaluate_memory_replay,
+    evaluate_renderable_strings,
     stable_artifact_identity,
 )
 from ..paths import OmhPaths, project_identity
@@ -786,6 +788,42 @@ def capture_project_memory_candidate(
             "reason": "project_memory_disabled",
             "claim_boundary": "Memory capture is disabled by OMH project policy; Hermes global or internal memory is not mutated.",
         }
+    # Structural metadata cannot be safely replaced with a redaction marker:
+    # scope and lineage values participate in lookup semantics, while actor
+    # labels participate in perspective filtering. Reject protected shapes
+    # before normalizers can lowercase them or include them in an exception.
+    structural_values = [
+        str(record_type or ""),
+        str(scope_kind or ""),
+        str(scope_ref or ""),
+        str(retention_class or ""),
+        str(stale_after or ""),
+        str(expires_at or ""),
+        str(observer or ""),
+        str(observed or ""),
+    ]
+    if isinstance(derived_from, (list, tuple)):
+        structural_values.extend(str(ref) for ref in derived_from)
+    elif derived_from is not None:
+        structural_values.append(str(derived_from))
+    structural_safety = _project_memory_safety(
+        "",
+        "",
+        tags=[],
+        source="",
+        source_ref="\n".join(structural_values),
+    )
+    if structural_safety["status"] != "safe":
+        return {
+            "schema_version": PROJECT_MEMORY_CAPTURE_SCHEMA_VERSION,
+            "captured": False,
+            "auto_approved": False,
+            "policy": policy,
+            "reason": "unsafe_project_memory_metadata",
+            "safety": structural_safety,
+            "redaction_policy": "metadata_only",
+            "claim_boundary": "Credential-like structural metadata is rejected before project-memory persistence.",
+        }
     # Absolute deadlines: "the contract ends on the 18th" is a date, not a
     # day count, and forcing the captor to do the subtraction moved the
     # anchor to whenever they happened to run the command. Each absolute
@@ -966,6 +1004,7 @@ def _project_memory_review_card_projection(candidate: dict[str, Any]) -> dict[st
     differ between two cards for the same candidate, so binding them would
     add noise to the fingerprint without adding any guarantee.
     """
+    candidate = _sanitize_project_memory_candidate(candidate)
     safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
     return {
         "candidate_id": str(candidate.get("candidate_id", "")),
@@ -1058,6 +1097,11 @@ def approve_project_memory_candidate(
     retention_class: str | None = None,
     expected_revision: str = "",
 ) -> dict[str, object]:
+    reviewer_safety = classify_memory_admission(
+        "\n".join((str(approved_by or ""), str(retention_class or "")))
+    )
+    if reviewer_safety["status"] != "safe":
+        raise ValueError("credential-like project-memory approval metadata is not allowed")
     # Read, validate, and write under ONE hold of the store lock. Reading the
     # candidate outside the lock made the guard advisory: a recapture landing
     # between the revision check and the record write would be approved on the
@@ -1083,6 +1127,10 @@ def approve_project_memory_candidate(
                 f"candidate {candidate_id} is a lifecycle ({candidate.get('lifecycle', 'v2')}) candidate; "
                 "it must be reapproved through the lifecycle path, not plain approval"
             )
+        current_safety = evaluate_renderable_strings(candidate)
+        if current_safety.get("status") != "safe":
+            raise ValueError("project memory candidate no longer passes the current safety policy")
+        candidate = _sanitize_project_memory_candidate(candidate)
         safety = candidate.get("safety", {}) if isinstance(candidate.get("safety"), dict) else {}
         if safety.get("status") == "blocked":
             raise ValueError("blocked memory candidates must be rejected or recaptured without protected raw content")
@@ -1138,7 +1186,16 @@ def reject_project_memory_candidate(
         if expected_revision:
             _require_review_revision(candidate, expected_revision)
         now = utc_now()
-        candidate = {**candidate, "status": "rejected", "reviewed_at": now, "reviewed_by": rejected_by, "rejection_reason": _redact(str(reason or ""))[:300]}
+        safe_rejected_by = _redacted_metadata_label(rejected_by)
+        candidate = _sanitize_project_memory_candidate(
+            {
+                **candidate,
+                "status": "rejected",
+                "reviewed_at": now,
+                "reviewed_by": safe_rejected_by,
+                "rejection_reason": _redact(str(reason or ""))[:300],
+            }
+        )
         _write_project_memory_candidate_unlocked(paths, candidate)
         review = _write_project_memory_review_decision(
             paths,
@@ -1147,7 +1204,7 @@ def reject_project_memory_candidate(
                 "review_id": f"review_{candidate_id}",
                 "candidate_id": candidate_id,
                 "decision": "rejected",
-                "reviewer_claim": rejected_by,
+                "reviewer_claim": safe_rejected_by,
                 "reason": _redact(str(reason or ""))[:300],
                 "reviewed_at": now,
                 "claim_boundary": "Project memory review decisions are prepared governance only, never executor-use evidence.",
@@ -1757,7 +1814,7 @@ def build_memory_rollup(
             {
                 "record_id": str(record.get("record_id", "")),
                 "record_type": str(record.get("record_type", "")),
-                "summary": _redact(str(record.get("summary", "")))[:240],
+                "summary": _redact_admitted_text(str(record.get("summary", "")))[:240],
                 "approved_at": str(record.get("approved_at", "")),
             }
             for record in members
@@ -1765,7 +1822,7 @@ def build_memory_rollup(
         "member_count": len(members),
         "considered_count": considered,
         "truncated_members": truncated_members,
-        "proposed_summary": _redact(proposed_summary)[:240],
+        "proposed_summary": _redact_admitted_text(proposed_summary)[:240],
         "next_action": _rollup_next_action(reason_code),
         "redaction_policy": "metadata_only",
         "claim_boundary": (
@@ -1818,7 +1875,7 @@ def _rollup_next_action(reason_code: str) -> str:
 
 
 def _find_pending_candidate_by_summary(paths: OmhPaths, summary: str) -> str:
-    key = _normalized_summary_key(_redact(summary.strip())[:500])
+    key = _normalized_summary_key(_redact_admitted_text(summary.strip())[:500])
     if not key:
         return ""
     for candidate in _read_project_memory_candidates(paths):
@@ -2562,7 +2619,10 @@ def build_memory_perspectives(paths: OmhPaths) -> dict[str, object]:
     for record in _read_project_memory_records(paths):
         perspective = record.get("perspective")
         if isinstance(perspective, dict) and str(perspective.get("observed", "")):
-            key = (str(perspective.get("observer", "")), str(perspective.get("observed", "")))
+            key = (
+                _redacted_metadata_label(perspective.get("observer", "")),
+                _redacted_metadata_label(perspective.get("observed", "")),
+            )
             pairs[key] = pairs.get(key, 0) + 1
         else:
             unscoped += 1
@@ -2633,7 +2693,7 @@ def build_memory_lineage(paths: OmhPaths, record_id: str, *, depth: int = 3) -> 
     }
     base = {
         "schema_version": MEMORY_LINEAGE_SCHEMA_VERSION,
-        "record_id": str(record_id),
+        "record_id": _redacted_metadata_label(record_id),
         "depth": depth,
         "redaction_policy": "metadata_only",
         "claim_boundary": (
@@ -2672,7 +2732,12 @@ def build_memory_lineage(paths: OmhPaths, record_id: str, *, depth: int = 3) -> 
                 if ref not in records:
                     if (ref, node_id) not in seen_unresolved:
                         seen_unresolved.add((ref, node_id))
-                        unresolved.append({"record_id": ref, "referenced_by": node_id})
+                        unresolved.append(
+                            {
+                                "record_id": _redacted_metadata_label(ref),
+                                "referenced_by": _redacted_metadata_label(node_id),
+                            }
+                        )
                     continue
                 visited.add(ref)
                 ancestors.append(_lineage_card(records[ref], depth=hop, due_soon_days=window))
@@ -2718,15 +2783,17 @@ def build_memory_lineage(paths: OmhPaths, record_id: str, *, depth: int = 3) -> 
 
 def _lineage_card(record: dict[str, Any], *, depth: int, due_soon_days: int | None = None) -> dict[str, object]:
     return {
-        "record_id": str(record.get("record_id", "")),
+        "record_id": _redacted_metadata_label(record.get("record_id", "")),
         "depth": depth,
         "record_type": str(record.get("record_type", "")),
-        "summary": _redact(str(record.get("summary", "")))[:500],
-        "scope": _normalize_scope(record.get("scope", _scope("project", "default"))),
+        "summary": _redact_admitted_text(str(record.get("summary", "")))[:500],
+        "scope": _redacted_scope(record.get("scope", _scope("project", "default"))),
         "tags": _normalize_tags(record.get("tags", [])),
         "approved_at": str(record.get("approved_at", "")),
         "staleness": _record_staleness(record, due_soon_days=due_soon_days),
-        "derived_from": _string_list(record.get("derived_from", [])),
+        "derived_from": [
+            _redacted_metadata_label(ref) for ref in _string_list(record.get("derived_from", []))
+        ],
     }
 
 
@@ -3311,7 +3378,7 @@ def _build_project_memory_candidate(
 ) -> dict[str, object]:
     normalized_type = _normalize_record_type(record_type)
     scope = _scope_for_project_memory(scope_kind, scope_ref)
-    raw_tags = _normalize_tags(tags, redact_sensitive=False)
+    raw_tags = [unicodedata.normalize("NFC", str(value)).strip() for value in tags]
     normalized_tags = _normalize_tags(raw_tags)
     content_text = str(content or "")
     safety = _project_memory_safety(
@@ -3361,7 +3428,7 @@ def _build_project_memory_candidate(
         "candidate_id": candidate_id,
         "status": status,
         "record_type": normalized_type,
-        "summary": _redact(summary.strip())[:500],
+        "summary": _redact_admitted_text(summary.strip())[:500],
         "scope": scope,
         "tags": normalized_tags,
         "source": _redact(str(source or "cli")),
@@ -3477,7 +3544,7 @@ def _record_from_candidate(
         "candidate_id": str(candidate.get("candidate_id", "")),
         "revision": 1,
         "record_type": record_type,
-        "summary": _redact(str(candidate.get("summary", "")))[:500],
+        "summary": _redact_admitted_text(str(candidate.get("summary", "")))[:500],
         "scope": scope,
         "tags": _normalize_tags(candidate.get("tags", [])),
         "source": _redact(str(candidate.get("source", "cli"))),
@@ -3634,9 +3701,9 @@ def _recall_item(
 ) -> dict[str, object]:
     evidence = _replay_evaluation(record, evaluation)
     return {
-        "record_id": str(record.get("record_id", "")),
+        "record_id": _redacted_metadata_label(record.get("record_id", "")),
         "record_type": str(record.get("record_type", "")),
-        "summary": _redact(str(record.get("summary", "")))[:500],
+        "summary": _redact_admitted_text(str(record.get("summary", "")))[:500],
         "scope": _normalize_scope(record.get("scope", _scope("project", "default"))),
         "tags": _normalize_tags(record.get("tags", [])),
         "source": str(record.get("source", "")),
@@ -3659,7 +3726,7 @@ def _recall_exclusion(
 ) -> dict[str, object]:
     evidence = _replay_evaluation(record, evaluation)
     return {
-        "record_id": str(record.get("record_id", "")),
+        "record_id": _redacted_metadata_label(record.get("record_id", "")),
         "reason": reason or str(evidence["reason_code"]),
         "staleness": staleness,
         **_recall_evidence_fields(evidence),
@@ -3747,6 +3814,8 @@ def freshness_reason_detail(reason_code: str) -> str:
 
 def _recall_evidence_fields(value: Any) -> dict[str, object]:
     evidence = value if isinstance(value, dict) else {}
+    safe_evidence = _redact_nested_metadata(evidence)
+    evidence = safe_evidence if isinstance(safe_evidence, dict) else {}
     return {
         "revision": int(evidence.get("revision", 0) or 0),
         "admission_mode": str(evidence.get("admission_mode") or ""),
@@ -4343,11 +4412,17 @@ def _normalize_tags(values: Any, *, redact_sensitive: bool = True) -> list[str]:
     tags: list[str] = []
     seen: set[str] = set()
     for value in values:
-        tag = unicodedata.normalize("NFC", str(value)).strip().lower()
-        if not tag or not _SAFE_TAG.match(tag):
+        raw_tag = unicodedata.normalize("NFC", str(value)).strip()
+        if not raw_tag:
             continue
-        if redact_sensitive and _looks_sensitive(tag):
+        if raw_tag == "[redacted]":
+            tag = raw_tag
+        elif redact_sensitive and _looks_sensitive(raw_tag):
             tag = "[redacted]"
+        else:
+            tag = raw_tag.lower()
+            if not _SAFE_TAG.match(tag):
+                continue
         if tag not in seen:
             tags.append(tag)
             seen.add(tag)
@@ -4880,7 +4955,7 @@ def _sanitize_item(item: dict[str, Any], *, default_scope: dict[str, str]) -> di
 def _safe_summary(item: dict[str, Any]) -> str:
     summary = str(item.get("summary", ""))
     if summary:
-        return _redact(summary)
+        return _redact_admitted_text(summary)
     key = str(item.get("key", item.get("item_id", "item")))
     value = str(item.get("value", ""))
     if key in _PROMPTISH_KEYS or item.get("sensitive"):
@@ -4899,17 +4974,75 @@ def _safe_to_expose_value(key: str, value: Any, item: dict[str, Any]) -> bool:
     return len(text) <= 240
 
 
+def _redacted_metadata_label(value: Any) -> str:
+    text = str(value or "")
+    return "redacted" if _looks_sensitive(text) else text
+
+
+def _redact_nested_metadata(value: Any) -> Any:
+    if isinstance(value, str):
+        return _redact(value)
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for index, (key, nested) in enumerate(value.items()):
+            safe_key = _redact_admitted_text(str(key))
+            if safe_key in sanitized:
+                safe_key = f"redacted_{index}"
+            sanitized[safe_key] = _redact_nested_metadata(nested)
+        return sanitized
+    if isinstance(value, (list, tuple)):
+        return [_redact_nested_metadata(nested) for nested in value]
+    return value
+
+
+def _redacted_scope(value: Any) -> dict[str, str]:
+    scope = _normalize_scope(value)
+    return {
+        "kind": _redacted_metadata_label(scope.get("kind", "project")) or "project",
+        "ref": _redacted_metadata_label(scope.get("ref", "default")) or "default",
+    }
+
+
+def _sanitize_project_memory_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    nested = _redact_nested_metadata(candidate)
+    sanitized = nested if isinstance(nested, dict) else {}
+    sanitized["summary"] = _redact_admitted_text(str(candidate.get("summary", "")))[:500]
+    sanitized["tags"] = _normalize_tags(candidate.get("tags", []))
+    sanitized["source"] = _redact(str(candidate.get("source", "")))
+    sanitized["source_ref"] = _redact(str(candidate.get("source_ref", "")))[:160]
+    sanitized["scope"] = _redacted_scope(candidate.get("scope", _scope("project", "default")))
+    if "derived_from" in candidate:
+        sanitized["derived_from"] = [
+            _redacted_metadata_label(ref) for ref in _string_list(candidate.get("derived_from", []))
+        ]
+    if isinstance(candidate.get("perspective"), dict):
+        sanitized["perspective"] = {
+            str(key): _redacted_metadata_label(value)
+            for key, value in candidate["perspective"].items()
+        }
+    if isinstance(candidate.get("source_evidence"), dict):
+        sanitized["source_evidence"] = _redact_nested_metadata(candidate["source_evidence"])
+    return sanitized
+
+
 def _redact(value: str) -> str:
     if _looks_sensitive(value):
         return "[redacted]"
     return value[:240]
 
 
+def _redact_admitted_text(value: str) -> str:
+    if contains_credential_like_material(value):
+        return "[redacted]"
+    return value[:500]
+
+
 def _looks_sensitive(value: str) -> bool:
     lowered = value.lower()
-    if any(marker in lowered for marker in ("secret", "token", "password", "private-key", "api_key", "apikey")):
-        return True
-    return classify_memory_admission(value).get("status") == "blocked"
+    return any(
+        marker in lowered
+        for marker in ("secret", "token", "password", "private-key", "api_key", "apikey")
+    ) or contains_credential_like_material(value)
 
 
 def _validate_allowed_keys(value: dict[str, Any], allowed: set[str], errors: list[str], label: str) -> None:
@@ -5040,7 +5173,7 @@ def _contains_sensitive_text(value: Any) -> bool:
     if isinstance(value, list):
         return any(_contains_sensitive_text(item) for item in value)
     if isinstance(value, str):
-        return _looks_sensitive(value)
+        return contains_credential_like_material(value)
     return False
 
 

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -2876,7 +2876,12 @@ def _reconcile_retirement_archive(paths: OmhPaths) -> list[dict[str, object]]:
         stem = path.name[: -len(".json")]
         record_id, _, compact = stem.rpartition(".")
         retired_at = _iso_from_compact(compact) if record_id else None
-        if not record_id or retired_at is None or not _SAFE_REF.match(record_id):
+        if (
+            not record_id
+            or retired_at is None
+            or not _SAFE_REF.match(record_id)
+            or contains_credential_like_material(record_id)
+        ):
             continue
         repaired: list[str] = []
         if (record_id, retired_at) not in pairs:
@@ -2996,12 +3001,13 @@ def build_memory_retirement(
     skipped: list[dict[str, object]] = []
     candidates = sorted(records_dir.glob("*.json")) if records_dir.exists() else []
     for path in candidates:
+        safe_path_name = _redacted_metadata_label(path.name)
         if path.is_symlink() or not path.is_file():
-            skipped.append({"path_name": path.name, "reason": "symlink_or_not_file"})
+            skipped.append({"path_name": safe_path_name, "reason": "symlink_or_not_file"})
             continue
         data, _error = read_json_object_result(path)
         if data is None:
-            skipped.append({"path_name": path.name, "reason": "corrupt_json"})
+            skipped.append({"path_name": safe_path_name, "reason": "corrupt_json"})
             continue
         is_v2_approved = (
             data.get("schema_version") == PROJECT_MEMORY_RECORD_SCHEMA_VERSION
@@ -3014,18 +3020,18 @@ def build_memory_retirement(
             and data.get("review_status") == "approved"
         )
         if not (is_v2_approved or is_v1_approved):
-            skipped.append({"path_name": path.name, "reason": "not_canonical"})
+            skipped.append({"path_name": safe_path_name, "reason": "not_canonical"})
             continue
         record_id = str(data.get("record_id", ""))
-        if not _SAFE_REF.match(record_id) or record_id != path.stem:
-            skipped.append({"path_name": path.name, "reason": "unsafe_record_id"})
+        if not _SAFE_REF.match(record_id) or record_id != path.stem or contains_credential_like_material(record_id):
+            skipped.append({"path_name": safe_path_name, "reason": "unsafe_record_id"})
             continue
         state = _classify_record_expiry(data, now=now, window_days=window_days)
         ttl = data.get("ttl", {}) if isinstance(data.get("ttl"), dict) else {}
         row = {
             "record_id": record_id,
             "expires_at": str(ttl.get("expires_at", "") or ""),
-            "path_name": path.name,
+            "path_name": safe_path_name,
             # Delivery-usage annotation only: a never-delivered record is a
             # cheaper retire call than one executors keep receiving. A pin
             # likewise annotates, never blocks: expiry still wins.
@@ -3037,7 +3043,7 @@ def build_memory_retirement(
         elif state == "expiring":
             expiring_soon.append(row)
         elif state == "malformed":
-            skipped.append({"path_name": path.name, "reason": "malformed_expires_at"})
+            skipped.append({"path_name": safe_path_name, "reason": "malformed_expires_at"})
     return {
         "schema_version": RETIREMENT_REPORT_SCHEMA_VERSION,
         "applied": False,

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -1287,7 +1287,7 @@ def build_project_memory_recall_pack(
             # what the archive is holding back.
             excluded.append(
                 {
-                    "record_id": str(record.get("record_id", "")),
+                    "record_id": _redacted_metadata_label(record.get("record_id", "")),
                     "reason": "archived_tier",
                     "staleness": {"state": "not_checked"},
                 }
@@ -3421,7 +3421,7 @@ def _build_project_memory_candidate(
     # Digest the ref exactly as it will be stored, not as it was passed:
     # redaction and truncation can change the string, and the freshness check
     # later reads the stored one.
-    stored_source_ref = _redact(str(source_ref or ""))[:160]
+    stored_source_ref = _redact_admitted_text(str(source_ref or ""))[:160]
     source_evidence = _source_evidence(stored_source_ref, captured_at=now)
     return {
         "schema_version": PROJECT_MEMORY_CANDIDATE_SCHEMA_VERSION,
@@ -3431,7 +3431,7 @@ def _build_project_memory_candidate(
         "summary": _redact_admitted_text(summary.strip())[:500],
         "scope": scope,
         "tags": normalized_tags,
-        "source": _redact(str(source or "cli")),
+        "source": _redact_admitted_text(str(source or "cli")),
         "source_ref": stored_source_ref,
         **({"source_evidence": source_evidence} if source_evidence else {}),
         "created_at": now,
@@ -3547,9 +3547,9 @@ def _record_from_candidate(
         "summary": _redact_admitted_text(str(candidate.get("summary", "")))[:500],
         "scope": scope,
         "tags": _normalize_tags(candidate.get("tags", [])),
-        "source": _redact(str(candidate.get("source", "cli"))),
+        "source": _redact_admitted_text(str(candidate.get("source", "cli"))),
         "source_class": "omh_local",
-        "source_ref": _redact(str(candidate.get("source_ref", "")))[:160],
+        "source_ref": _redact_admitted_text(str(candidate.get("source_ref", "")))[:160],
         # The digest is carried over as observed at capture, never recomputed
         # here: approval must not silently re-bless a source that changed
         # while the candidate sat in the review queue.
@@ -3915,7 +3915,7 @@ def _replay_evaluation(artifact: dict[str, Any], result: dict[str, object]) -> d
         "artifact_identity": identity,
         "revision": int(artifact.get("revision", 0) or 0),
         "admission_mode": str(result.get("admission_mode") or ""),
-        "source_class": str(artifact.get("source_class", "")),
+        "source_class": str(result.get("source_class") or ""),
         "retention_class": str(result.get("retention_class") or _retention_class(artifact)),
         "evaluated_at": str(result.get("evaluated_at", "")),
         "eligible": bool(result.get("eligible", False)),
@@ -4473,10 +4473,12 @@ def scan_project_memory_records(paths: OmhPaths) -> tuple[list[dict[str, Any]], 
     unreadable: list[dict[str, str]] = []
     directory = _memory_records_dir(paths)
     for record, path_name in _read_memory_record_files(paths, directory):
+        safe_path_name = _redact_admitted_text(path_name)
         if record is None:
-            unreadable.append({"path_name": path_name, "reason": "unreadable_file", "schema_version": ""})
+            unreadable.append({"path_name": safe_path_name, "reason": "unreadable_file", "schema_version": ""})
             continue
         schema_version = str(record.get("schema_version", "") or "")
+        safe_schema_version = _redact_admitted_text(schema_version)
         if schema_version == PROJECT_MEMORY_RECORD_SCHEMA_VERSION:
             records.append(record)
         elif schema_version == LEGACY_PROJECT_MEMORY_RECORD_SCHEMA_VERSION:
@@ -4485,9 +4487,9 @@ def scan_project_memory_records(paths: OmhPaths) -> tuple[list[dict[str, Any]], 
                 # will fail them closed as review_required_legacy before replay.
                 records.append(record)
             else:
-                unreadable.append({"path_name": path_name, "reason": "legacy_review_status_missing", "schema_version": schema_version})
+                unreadable.append({"path_name": safe_path_name, "reason": "legacy_review_status_missing", "schema_version": safe_schema_version})
         else:
-            unreadable.append({"path_name": path_name, "reason": "unsupported_record_schema", "schema_version": schema_version})
+            unreadable.append({"path_name": safe_path_name, "reason": "unsupported_record_schema", "schema_version": safe_schema_version})
     return records, unreadable
 
 
@@ -4925,7 +4927,7 @@ def _normalize_wrapper_snapshot(snapshot: dict[str, Any]) -> dict[str, object]:
 
 
 def _snapshot(source: str, scope: Any, items: list[dict[str, object]], *, claim_boundary: str = "") -> dict[str, object]:
-    normalized_scope = _normalize_scope(scope)
+    normalized_scope = _redacted_scope(scope)
     return {
         "schema_version": MEMORY_SNAPSHOT_SCHEMA_VERSION,
         "source": source,
@@ -4976,7 +4978,7 @@ def _safe_to_expose_value(key: str, value: Any, item: dict[str, Any]) -> bool:
     text = str(value)
     if key in _PROMPTISH_KEYS:
         return False
-    if _looks_sensitive(text):
+    if contains_credential_like_material(text):
         return False
     return len(text) <= 240
 
@@ -5015,18 +5017,15 @@ def _sanitize_project_memory_candidate(candidate: dict[str, Any]) -> dict[str, A
     sanitized = nested if isinstance(nested, dict) else {}
     sanitized["summary"] = _redact_admitted_text(str(candidate.get("summary", "")))[:500]
     sanitized["tags"] = _normalize_tags(candidate.get("tags", []))
-    sanitized["source"] = _redact(str(candidate.get("source", "")))
-    sanitized["source_ref"] = _redact(str(candidate.get("source_ref", "")))[:160]
+    sanitized["source"] = _redact_admitted_text(str(candidate.get("source", "")))
+    sanitized["source_ref"] = _redact_admitted_text(str(candidate.get("source_ref", "")))[:160]
     sanitized["scope"] = _redacted_scope(candidate.get("scope", _scope("project", "default")))
     if "derived_from" in candidate:
         sanitized["derived_from"] = [
             _redacted_metadata_label(ref) for ref in _string_list(candidate.get("derived_from", []))
         ]
     if isinstance(candidate.get("perspective"), dict):
-        sanitized["perspective"] = {
-            str(key): _redacted_metadata_label(value)
-            for key, value in candidate["perspective"].items()
-        }
+        sanitized["perspective"] = _redact_nested_metadata(candidate["perspective"])
     if isinstance(candidate.get("source_evidence"), dict):
         sanitized["source_evidence"] = _redact_nested_metadata(candidate["source_evidence"])
     return sanitized

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -17,6 +17,18 @@ from .memory_store import run_memory_operation
 BATCH_CANDIDATE_SCHEMA_VERSION, BATCH_REVIEW_SCHEMA_VERSION, BATCH_RECEIPT_SCHEMA_VERSION = "memory_update_batch_candidate/v1", "memory_update_batch_review/v1", "memory_update_batch_receipt/v1"
 _LEGACY_BATCH_SCHEMA_VERSION, _OPS, _DECISIONS = "memory_update_batch/v1", frozenset({"keep", "forget", "update", "change_scope", "dismiss_conflict"}), frozenset({"remember", "refuse", "defer"})
 _RECEIPT_KEYS = frozenset({"schema_version", "operation_id", "operation_type", "state", "created_at", "completed_at", "step_count", "recovery_count", "outcome"})
+_REVIEW_BOUND_ITEM_KEYS = (
+    "review_id",
+    "candidate_revision",
+    "item_id",
+    "op",
+    "target_ref",
+    "scope",
+    "from_scope",
+    "retention",
+    "artifact_identity",
+    "payload_digest",
+)
 
 
 def stage_memory_update_batch(paths: OmhPaths, batch: Mapping[str, object], *, now: datetime | None = None) -> dict[str, object]:
@@ -229,15 +241,33 @@ def _revalidate(candidate: Mapping[str, object], reviews: Mapping[str, Mapping[s
 
 
 def _review_record(candidate: Mapping[str, object], item: Mapping[str, object], decision: str, label: str, reviewed_at: str) -> dict[str, object]:
-    return {"schema_version": PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION, "review_id": item["review_id"], "batch_id": candidate["batch_id"], "candidate_revision": item["candidate_revision"], "item_id": item["item_id"], "artifact_identity": item["artifact_identity"], "payload_digest": item["payload_digest"], "decision": decision, "reviewer_label": label, "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION, "reviewed_at": reviewed_at}
+    return {
+        "schema_version": PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION,
+        "batch_id": candidate["batch_id"],
+        "candidate_digest": canonical_payload_digest(dict(candidate)),
+        **{key: item.get(key) for key in _REVIEW_BOUND_ITEM_KEYS},
+        "decision": decision,
+        "reviewer_label": label,
+        "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION,
+        "reviewed_at": reviewed_at,
+    }
 
 
 def _review_matches(review: Mapping[str, object], candidate: Mapping[str, object], item: Mapping[str, object]) -> bool:
-    return review.get("schema_version") == PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION and all(review.get(key) == item.get(key) for key in ("review_id", "candidate_revision", "item_id", "artifact_identity", "payload_digest")) and review.get("batch_id") == candidate.get("batch_id") and review.get("decision") in _DECISIONS and isinstance(review.get("reviewer_label"), str) and bool(review["reviewer_label"])
+    return (
+        review.get("schema_version") == PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION
+        and all(review.get(key) == item.get(key) for key in _REVIEW_BOUND_ITEM_KEYS)
+        and review.get("batch_id") == candidate.get("batch_id")
+        and review.get("candidate_digest") == canonical_payload_digest(dict(candidate))
+        and review.get("decision") in _DECISIONS
+        and isinstance(review.get("reviewer_label"), str)
+        and bool(review["reviewer_label"])
+    )
 
 
 def _same_review(left: Mapping[str, object], right: Mapping[str, object]) -> bool:
-    return all(left.get(key) == right.get(key) for key in ("review_id", "batch_id", "candidate_revision", "item_id", "artifact_identity", "payload_digest", "decision", "reviewer_label"))
+    keys = (*_REVIEW_BOUND_ITEM_KEYS, "batch_id", "candidate_digest", "decision", "reviewer_label")
+    return all(left.get(key) == right.get(key) for key in keys)
 
 
 def _decisions(candidate: Mapping[str, object], raw: Mapping[str, object] | list[Mapping[str, object]]) -> dict[str, str]:

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -378,6 +378,17 @@ def _scope_matches_candidate_apply(
     ]
     if not matching:
         return False
+    expected_scope = next(
+        scope
+        for item in matching
+        for scope in _item_scopes(item)
+        if _relative_scope(scope) == target
+    )
+    if (
+        value.get("schema_version") != MEMORY_SCOPE_SCHEMA_VERSION
+        or value.get("scope") != dict(expected_scope)
+    ):
+        return False
     for item in matching:
         op = item.get("op")
         target_ref = str(item.get("target_ref", ""))

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -46,7 +46,7 @@ _REVIEW_KEYS = frozenset(
 )
 _REVIEW_REQUEST_SCHEMA_VERSION = "memory_update_batch_review_request/v1"
 _REVIEW_REQUEST_KEYS = frozenset(
-    {"schema_version", "decisions", "reviewer_label", "policy_version", "reviewed_at"}
+    {"schema_version", "candidate_digest", "decisions", "reviewer_label", "policy_version", "reviewed_at"}
 )
 
 
@@ -67,6 +67,7 @@ def stage_memory_update_batch(paths: OmhPaths, batch: Mapping[str, object], *, n
     for item in items:
         for scope in _item_scopes(item):
             _scope_snapshot(paths, scope, scope_cache)
+    _reject_live_logical_target_collisions(items, scope_cache)
     scope_preconditions = {
         target: _scope_precondition_digest(value, items, target)
         for target, value in sorted(scope_cache.items())
@@ -96,6 +97,7 @@ def review_memory_update_batch(paths: OmhPaths, batch_id: str, decisions: Mappin
     reviewed_at = _stamp(_utc(now))
     with file_lock(paths.memory_index_path, private=True):
         candidate = _candidate(paths, batch_id)
+        _validate_review_membership(candidate)
         decision_map = _decisions(candidate, decisions)
         request = candidate.get("review_request")
         if request is None:
@@ -103,7 +105,7 @@ def review_memory_update_batch(paths: OmhPaths, batch_id: str, decisions: Mappin
                 (_reviews_dir(paths) / f"{item['review_id']}.json").exists() for item in candidate["items"]
             ):
                 raise ValueError("batch review is immutable")
-            request = _review_request(decision_map, label, reviewed_at)
+            request = _review_request(candidate, decision_map, label, reviewed_at)
             candidate = {**candidate, "review_request": request}
             atomic_write_json(paths.memory_dir / _candidate_relative(batch_id), candidate, private=True)
         elif not _review_request_matches(request, candidate, decision_map, label):
@@ -313,7 +315,7 @@ def _apply_scope(
     if not matching:
         return
     scope = next(scope for item in matching for scope in _item_scopes(item) if _relative_scope(scope) == target)
-    path = paths.memory_dir / target
+    path = _checked_scope_path(paths, target)
     current, error = read_json_object_result(path)
     if error:
         raise ValueError("scope file is corrupt")
@@ -345,6 +347,7 @@ def _apply_scope(
             data["items"].pop(item["target_ref"], None)
             data["items"][item["item_id"]] = _approved_item(candidate, item, reviews[item["item_id"]])
     data["updated_at"] = updated_at
+    _checked_scope_path(paths, target)
     atomic_write_json(path, data, private=True)
 
 
@@ -498,9 +501,15 @@ def _review_record(candidate: Mapping[str, object], item: Mapping[str, object], 
     }
 
 
-def _review_request(decisions: Mapping[str, str], label: str, reviewed_at: str) -> dict[str, object]:
+def _review_request(
+    candidate: Mapping[str, object],
+    decisions: Mapping[str, str],
+    label: str,
+    reviewed_at: str,
+) -> dict[str, object]:
     return {
         "schema_version": _REVIEW_REQUEST_SCHEMA_VERSION,
+        "candidate_digest": _candidate_subject_digest(candidate),
         "decisions": {key: decisions[key] for key in sorted(decisions)},
         "reviewer_label": label,
         "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION,
@@ -522,6 +531,7 @@ def _review_request_matches(
     expected_ids = {str(item.get("item_id", "")) for item in items if isinstance(item, Mapping)}
     return (
         request.get("schema_version") == _REVIEW_REQUEST_SCHEMA_VERSION
+        and request.get("candidate_digest") == _candidate_subject_digest(candidate)
         and request.get("decisions") == {key: decisions[key] for key in sorted(decisions)}
         and set(decisions) == expected_ids
         and request.get("reviewer_label") == label
@@ -555,6 +565,16 @@ def _review_base_matches(review: Mapping[str, object], candidate: Mapping[str, o
     )
 
 
+def _candidate_subject_digest(candidate: Mapping[str, object]) -> str:
+    payload = {
+        str(key): value
+        for key, value in candidate.items()
+        if key not in {"review_request", "review_seals"}
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 def _candidate_digest(candidate: Mapping[str, object]) -> str:
     payload = {str(key): value for key, value in candidate.items() if key != "review_seals"}
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
@@ -573,6 +593,42 @@ def _canonical_review_time(value: object) -> bool:
         return _stamp(_parse_time(value)) == value
     except (TypeError, ValueError):
         return False
+
+
+def _validate_review_membership(candidate: Mapping[str, object]) -> None:
+    items = candidate.get("items")
+    if not isinstance(items, list) or not all(isinstance(item, dict) for item in items):
+        raise ValueError("batch review membership is malformed")
+    for item in items:
+        identifiers = (
+            item.get("item_id", ""),
+            item.get("review_id", ""),
+            item.get("target_ref", ""),
+        )
+        artifact = item.get("artifact")
+        if (
+            any(not safe_token(str(value)) for value in identifiers)
+            or any(classify_memory_admission(str(value))["status"] != "safe" for value in identifiers)
+            or item.get("op") not in _OPS
+            or item.get("batch_id") != candidate.get("batch_id")
+            or not isinstance(artifact, dict)
+            or evaluate_renderable_strings(artifact).get("status") != "safe"
+            or stable_artifact_identity(artifact) != item.get("artifact_identity")
+            or canonical_payload_digest(artifact) != item.get("payload_digest")
+        ):
+            raise ValueError("batch review membership is malformed")
+        scope = _scope(item.get("scope"))
+        if artifact.get("scope") != scope or artifact.get("retention") != item.get("retention"):
+            raise ValueError("batch review membership is malformed")
+        if item.get("op") == "change_scope":
+            _scope(item.get("from_scope"))
+    try:
+        _distinct_targets(items)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("batch review membership is ambiguous") from exc
+    review_ids = [str(item.get("review_id", "")) for item in items]
+    if not all(review_ids) or len(review_ids) != len(set(review_ids)):
+        raise ValueError("batch review membership is ambiguous")
 
 
 def _decisions(candidate: Mapping[str, object], raw: Mapping[str, object] | list[Mapping[str, object]]) -> dict[str, str]:
@@ -637,13 +693,29 @@ def _scope_snapshot(
 
 
 def _scope_snapshot_by_target(paths: OmhPaths, target: str) -> dict[str, Any] | None:
-    path = paths.memory_dir / target
-    if path.is_symlink():
-        raise ValueError("scope file is unsafe")
+    path = _checked_scope_path(paths, target)
     value, error = read_json_object_result(path)
     if error or (value is not None and not isinstance(value, dict)):
         raise ValueError("scope file is corrupt")
     return value
+
+
+def _checked_scope_path(paths: OmhPaths, target: str) -> Path:
+    root = paths.memory_dir
+    relative = Path(target)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError("scope path is unsafe")
+    path = root / relative
+    cursor = root
+    for part in relative.parts:
+        cursor /= part
+        if cursor.is_symlink():
+            raise ValueError("scope path is unsafe")
+    resolved_root = root.resolve(strict=False)
+    resolved_path = path.resolve(strict=False)
+    if resolved_root != resolved_path and resolved_root not in resolved_path.parents:
+        raise ValueError("scope path is unsafe")
+    return path
 
 
 def _scope_precondition_digest(
@@ -790,6 +862,32 @@ def _distinct_targets(items: list[dict[str, object]]) -> None:
         if logical_targets & item_logical_targets:
             raise ValueError("batch has ambiguous logical targets")
         logical_targets.update(item_logical_targets)
+
+
+def _reject_live_logical_target_collisions(
+    items: list[dict[str, object]],
+    scope_cache: Mapping[str, dict[str, Any] | None],
+) -> None:
+    for item in items:
+        if item.get("op") == "forget":
+            continue
+        scope = item.get("scope")
+        artifact = item.get("artifact")
+        if not isinstance(scope, Mapping) or not isinstance(artifact, Mapping):
+            raise ValueError("batch has malformed logical target")
+        current = scope_cache.get(_relative_scope(scope))
+        current_items = current.get("items", {}) if isinstance(current, Mapping) else {}
+        if not isinstance(current_items, Mapping):
+            continue
+        logical_key = str(artifact.get("key", ""))
+        allowed_refs = {str(item.get("target_ref", "")), str(item.get("item_id", ""))}
+        if any(
+            str(ref) not in allowed_refs
+            and isinstance(value, Mapping)
+            and str(value.get("key", "")) == logical_key
+            for ref, value in current_items.items()
+        ):
+            raise ValueError("batch has ambiguous live logical target")
 
 
 def _batch_view(candidate: Mapping[str, object], *, status: str) -> dict[str, object]:

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -50,7 +50,7 @@ _REVIEW_REQUEST_KEYS = frozenset(
 )
 
 
-class _ScopePreconditionChanged(ValueError):
+class _ScopePreconditionChanged(RuntimeError):
     pass
 
 
@@ -179,7 +179,15 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
     ]
 
     def assert_precondition(check_paths: OmhPaths, step: dict[str, str]) -> None:
-        snapshot = _scope_snapshot_by_target(check_paths, step["target"])
+        try:
+            snapshot = _scope_snapshot_by_target(check_paths, step["target"])
+        except ValueError as exc:
+            raise _ScopePreconditionChanged("reviewed scope is unreadable before apply") from exc
+        if snapshot is not None and (
+            not isinstance(snapshot.get("items"), Mapping)
+            or not isinstance(snapshot.get("tombstones", {}), Mapping)
+        ):
+            raise _ScopePreconditionChanged("reviewed scope is malformed before apply")
         if (
             _scope_precondition_digest(snapshot, candidate["items"], step["target"])
             != step["revision"]
@@ -749,10 +757,14 @@ def _existing_batch_review_ids(paths: OmhPaths, batch_id: str) -> set[str]:
 def _distinct_targets(items: list[dict[str, object]]) -> None:
     scope_item_targets: set[tuple[str, str]] = set()
     logical_targets: set[tuple[str, str]] = set()
+    candidate_item_ids: set[str] = set()
     for item in items:
         op = str(item["op"])
         target_ref = str(item["target_ref"])
         item_id = str(item["item_id"])
+        if item_id in candidate_item_ids:
+            raise ValueError("batch has ambiguous candidate item ids")
+        candidate_item_ids.add(item_id)
         destination_scope = item.get("scope")
         if not isinstance(destination_scope, Mapping):
             raise ValueError("batch has malformed logical target")

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from ..plugin_bundle.omh.memory_governance import MEMORY_GOVERNANCE_POLICY_VERSION, MEMORY_SCOPE_SCHEMA_VERSION, PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION, SOURCE_CLASSES, build_retention, canonical_memory_scope, canonical_payload_digest, classify_memory_admission, evaluate_renderable_strings, stable_artifact_identity
-from ..system.local_store import atomic_write_json, ensure_dir, file_lock, read_json_object_result, utc_now
+from ..system.local_store import atomic_write_json, ensure_dir, file_lock, read_json_object_result
 from ..system.paths import OmhPaths
 from ._memory_store_validation import safe_token
 from .memory_store import run_memory_operation
@@ -173,8 +173,8 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
     if any(review["decision"] != "remember" for review in reviews.values()):
         return {"schema_version": BATCH_RECEIPT_SCHEMA_VERSION, "status": "review_required", "reason_code": "review_required", "applied": False, "batch_id": batch_id}
     scopes = sorted({_relative_scope(scope) for item in candidate["items"] for scope in _item_scopes(item)})
-    steps = [
-        {"name": f"write_scope_{index}", "action": "write_batch_scope", "source": _candidate_relative(batch_id), "target": target, "revision": preconditions[target]}
+    scope_steps = [
+        {"name": f"write_scope_{index}", "action": "write_batch_scope", "target": target, "revision": preconditions[target]}
         for index, target in enumerate(scopes, start=1)
     ]
 
@@ -190,16 +190,37 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
             raise _ScopePreconditionChanged("reviewed scope changed before apply")
 
     def preflight(check_paths: OmhPaths) -> None:
-        for step in steps:
-            assert_precondition(check_paths, step)
+        for scope_step in scope_steps:
+            assert_precondition(check_paths, scope_step)
 
-    def write_scope(check_paths: OmhPaths, step: dict[str, str]) -> None:
-        if step["action"] != "write_batch_scope":
+    def write_scopes(check_paths: OmhPaths, step: dict[str, str]) -> str:
+        if step["action"] != "write_batch_scopes":
             raise ValueError("unexpected batch apply operation")
+        # Run every interruption/drift hook before rechecking any target so a
+        # later target cannot fail after an earlier scope has been mutated.
         if write_hook:
-            write_hook(step["name"])
-        assert_precondition(check_paths, step)
-        _apply_scope(check_paths, candidate, reviews, step["target"])
+            for scope_step in scope_steps:
+                write_hook(scope_step["name"])
+        for scope_step in scope_steps:
+            assert_precondition(check_paths, scope_step)
+        for scope_step in scope_steps:
+            _apply_scope(
+                check_paths,
+                candidate,
+                reviews,
+                scope_step["target"],
+                updated_at=step["revision"],
+            )
+        return "written"
+
+    steps = [
+        {
+            "name": "write_reviewed_scopes",
+            "action": "write_batch_scopes",
+            "target": _candidate_relative(batch_id),
+            "revision": _stamp(_utc(now)),
+        }
+    ]
 
     try:
         operation = run_memory_operation(
@@ -207,7 +228,7 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
             operation_id=str(candidate["apply_operation_id"]),
             operation_type="apply_memory_batch",
             steps=steps,
-            step_writer=write_scope,
+            step_writer=write_scopes,
             preflight=preflight,
             now=now,
         )
@@ -269,7 +290,14 @@ def _proposal(
     return {"item_id": item_id, "candidate_revision": 1, "review_id": _opaque("review"), "op": op, "target_ref": target_ref, "scope": scope, "from_scope": from_scope, "retention": retention, "artifact": artifact, "artifact_identity": stable_artifact_identity(artifact), "payload_digest": canonical_payload_digest(artifact), "batch_id": batch_id}
 
 
-def _apply_scope(paths: OmhPaths, candidate: dict[str, Any], reviews: dict[str, dict[str, Any]], target: str) -> None:
+def _apply_scope(
+    paths: OmhPaths,
+    candidate: dict[str, Any],
+    reviews: dict[str, dict[str, Any]],
+    target: str,
+    *,
+    updated_at: str,
+) -> None:
     matching = [item for item in candidate["items"] if target in {_relative_scope(scope) for scope in _item_scopes(item)}]
     if not matching:
         return
@@ -291,13 +319,13 @@ def _apply_scope(paths: OmhPaths, candidate: dict[str, Any], reviews: dict[str, 
             data["items"].pop(item["target_ref"], None)
         elif op == "forget":
             data["items"].pop(item["target_ref"], None)
-            data["tombstones"][item["target_ref"]] = {"item_id": item["target_ref"], "operation_id": candidate["apply_operation_id"], "candidate_item_id": item["item_id"], "review_id": item["review_id"], "tombstoned_at": utc_now()}
+            data["tombstones"][item["target_ref"]] = {"item_id": item["target_ref"], "operation_id": candidate["apply_operation_id"], "candidate_item_id": item["item_id"], "review_id": item["review_id"], "tombstoned_at": updated_at}
         else:
             if data["items"].get(item["item_id"], {}).get("candidate_item_id") == item["item_id"]:
                 continue
             data["items"].pop(item["target_ref"], None)
             data["items"][item["item_id"]] = _approved_item(candidate, item, reviews[item["item_id"]])
-    data["updated_at"] = utc_now()
+    data["updated_at"] = updated_at
     atomic_write_json(path, data, private=True)
 
 
@@ -543,10 +571,14 @@ def _scope_precondition_digest(
         if isinstance(item, Mapping) and target in {_relative_scope(scope) for scope in _item_scopes(item)}
     ]
     item_keys: set[str] = set()
+    logical_keys: set[str] = set()
     tombstone_keys: set[str] = set()
     for item in matching:
         target_ref = str(item.get("target_ref", ""))
         item_id = str(item.get("item_id", ""))
+        artifact = item.get("artifact")
+        if isinstance(artifact, Mapping):
+            logical_keys.add(str(artifact.get("key", "")))
         item_keys.add(target_ref)
         if not (
             item.get("op") == "forget"
@@ -568,6 +600,15 @@ def _scope_precondition_digest(
             {key: current_tombstones.get(key) for key in sorted(tombstone_keys)}
             if isinstance(current_tombstones, Mapping)
             else current_tombstones
+        ),
+        "logical_items": (
+            {
+                str(item_id): item
+                for item_id, item in sorted(current_items.items(), key=lambda pair: str(pair[0]))
+                if isinstance(item, Mapping) and str(item.get("key", "")) in logical_keys
+            }
+            if isinstance(current_items, Mapping)
+            else current_items
         ),
     }
     canonical = json.dumps(projection, sort_keys=True, separators=(",", ":"), ensure_ascii=False)

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -747,9 +747,34 @@ def _existing_batch_review_ids(paths: OmhPaths, batch_id: str) -> set[str]:
 
 
 def _distinct_targets(items: list[dict[str, object]]) -> None:
-    targets = [(item["op"], item["target_ref"], _relative_scope(item["scope"])) for item in items]
-    if len(targets) != len(set(targets)):
-        raise ValueError("batch has ambiguous scope-item targets")
+    scope_item_targets: set[tuple[str, str]] = set()
+    logical_targets: set[tuple[str, str]] = set()
+    for item in items:
+        op = str(item["op"])
+        target_ref = str(item["target_ref"])
+        item_id = str(item["item_id"])
+        destination_scope = item.get("scope")
+        if not isinstance(destination_scope, Mapping):
+            raise ValueError("batch has malformed logical target")
+        destination_target = _relative_scope(destination_scope)
+        item_targets: set[tuple[str, str]] = set()
+        for scope in _item_scopes(item):
+            scope_target = _relative_scope(scope)
+            item_targets.add((scope_target, target_ref))
+            if op != "forget" and scope_target == destination_target:
+                item_targets.add((scope_target, item_id))
+        if scope_item_targets & item_targets:
+            raise ValueError("batch has ambiguous scope-item targets")
+        scope_item_targets.update(item_targets)
+
+        if op != "forget":
+            artifact = item.get("artifact")
+            if not isinstance(artifact, Mapping):
+                raise ValueError("batch has malformed logical target")
+            logical_target = (destination_target, str(artifact.get("key", "")))
+            if logical_target in logical_targets:
+                raise ValueError("batch has ambiguous logical targets")
+            logical_targets.add(logical_target)
 
 
 def _batch_view(candidate: Mapping[str, object], *, status: str) -> dict[str, object]:

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -12,10 +12,16 @@ from pathlib import Path
 from typing import Any
 
 from ..plugin_bundle.omh.memory_governance import MEMORY_GOVERNANCE_POLICY_VERSION, MEMORY_SCOPE_SCHEMA_VERSION, PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION, SOURCE_CLASSES, build_retention, canonical_memory_scope, canonical_payload_digest, classify_memory_admission, evaluate_renderable_strings, stable_artifact_identity
-from ..system.local_store import atomic_write_json, ensure_dir, file_lock, read_json_object_result
+from ..system.local_store import atomic_write_json, file_lock, read_json_object_result
 from ..system.paths import OmhPaths
 from ._memory_store_validation import safe_token
-from .memory_store import MemoryOperationIdentityError, run_memory_operation
+from .memory_store import (
+    MemoryOperationIdentityError,
+    checked_memory_directory,
+    checked_memory_json_path,
+    ensure_memory_directory,
+    run_memory_operation,
+)
 
 BATCH_CANDIDATE_SCHEMA_VERSION, BATCH_REVIEW_SCHEMA_VERSION, BATCH_RECEIPT_SCHEMA_VERSION = "memory_update_batch_candidate/v1", "memory_update_batch_review/v1", "memory_update_batch_receipt/v1"
 _LEGACY_BATCH_SCHEMA_VERSION, _OPS, _DECISIONS = "memory_update_batch/v1", frozenset({"keep", "forget", "update", "change_scope", "dismiss_conflict"}), frozenset({"remember", "refuse", "defer"})
@@ -74,15 +80,18 @@ def stage_memory_update_batch(paths: OmhPaths, batch: Mapping[str, object], *, n
     }
     candidate = {"schema_version": BATCH_CANDIDATE_SCHEMA_VERSION, "batch_id": batch_id, "candidate_revision": 1, "stage_operation_id": _opaque("op_stage"), "apply_operation_id": _opaque("op_apply"), "status": "pending_review", "source_class": source_class, "source_surface": _label(batch.get("source_surface", "api")), "created_at": _stamp(current), "admission": {"state": "pending_review", "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION}, "scope_preconditions": scope_preconditions, "items": items}
     target = _candidate_relative(batch_id)
+    ensure_memory_directory(paths, "candidates")
+    checked_memory_json_path(paths, target)
 
-    def write_candidate(_: OmhPaths, step: dict[str, str]) -> None:
+    def write_candidate(check_paths: OmhPaths, step: dict[str, str]) -> None:
         if step["action"] != "write_batch_candidate" or step["target"] != target:
             raise ValueError("unexpected batch staging operation")
-        present, error = read_json_object_result(paths.memory_dir / target)
+        path = checked_memory_json_path(check_paths, target)
+        present, error = read_json_object_result(path)
         if error:
             raise ValueError("batch candidate is corrupt")
         if present is None:
-            atomic_write_json(paths.memory_dir / target, candidate, private=True)
+            atomic_write_json(path, candidate, private=True)
         elif present != candidate:
             raise ValueError("batch candidate identity collision")
 
@@ -99,20 +108,20 @@ def review_memory_update_batch(paths: OmhPaths, batch_id: str, decisions: Mappin
         candidate = _candidate(paths, batch_id)
         _validate_review_membership(candidate)
         decision_map = _decisions(candidate, decisions)
+        ensure_memory_directory(paths, "reviews")
         request = candidate.get("review_request")
         if request is None:
             if candidate.get("review_seals") or any(
-                (_reviews_dir(paths) / f"{item['review_id']}.json").exists() for item in candidate["items"]
+                _review_path(paths, str(item["review_id"])).exists() for item in candidate["items"]
             ):
                 raise ValueError("batch review is immutable")
             request = _review_request(candidate, decision_map, label, reviewed_at)
             candidate = {**candidate, "review_request": request}
-            atomic_write_json(paths.memory_dir / _candidate_relative(batch_id), candidate, private=True)
+            atomic_write_json(_candidate_path(paths, batch_id), candidate, private=True)
         elif not _review_request_matches(request, candidate, decision_map, label):
             raise ValueError("batch review is immutable")
         reviewed_at = str(request["reviewed_at"])
         reviews = [_review_record(candidate, item, decision_map[item["item_id"]], label, reviewed_at) for item in candidate["items"]]
-        ensure_dir(_reviews_dir(paths), private=True)
         existing_seals = candidate.get("review_seals", {})
         if not isinstance(existing_seals, dict):
             raise ValueError("batch review linkage is corrupt")
@@ -125,7 +134,7 @@ def review_memory_update_batch(paths: OmhPaths, batch_id: str, decisions: Mappin
         if existing_seals and set(existing_seals) != expected_item_ids:
             raise ValueError("batch review is immutable")
         for review in reviews:
-            path = _reviews_dir(paths) / f"{review['review_id']}.json"
+            path = _review_path(paths, str(review["review_id"]))
             item = items_by_review[str(review["review_id"])]
             if existing_seals:
                 present, error = read_json_object_result(path)
@@ -160,7 +169,7 @@ def review_memory_update_batch(paths: OmhPaths, batch_id: str, decisions: Mappin
             raise ValueError("batch review is immutable")
         sealed_candidate = {**candidate, "review_seals": seals}
         if sealed_candidate != candidate:
-            atomic_write_json(paths.memory_dir / _candidate_relative(batch_id), sealed_candidate, private=True)
+            atomic_write_json(_candidate_path(paths, batch_id), sealed_candidate, private=True)
     return {"schema_version": BATCH_REVIEW_SCHEMA_VERSION, "status": "reviewed", "batch_id": candidate["batch_id"], "reviewer_label": label, "items": [{"item_id": item["item_id"], "review_id": item["review_id"], "decision": decision_map[item["item_id"]]} for item in candidate["items"]]}
 
 
@@ -439,7 +448,9 @@ def _approved_item(candidate: Mapping[str, object], item: Mapping[str, object], 
     retention = build_retention(str(item["retention"]["class"]), record_type="fact", admitted_at=admitted, ttl_days=item["retention"].get("ttl_days"))
     days = item["artifact"].get("revalidation_days")
     revalidation = {"deadline": _stamp(admitted + timedelta(days=days))} if isinstance(days, int) and days > 0 else {}
-    artifact.update({"admission": {"state": "approved_manual", "review_id": review["review_id"], "reviewer_label": review["reviewer_label"], "admitted_at": review["reviewed_at"], "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION}, "retention": retention, "revalidation": revalidation, "batch_id": candidate["batch_id"], "candidate_item_id": item["item_id"], "operation_id": candidate["apply_operation_id"]})
+    artifact.update({"admission": {"state": "approved_manual", "review_id": review["review_id"], "reviewer_label": review["reviewer_label"], "admitted_at": review["reviewed_at"], "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION}, "retention": retention, "revalidation": revalidation, "batch_id": candidate["batch_id"], "candidate_item_id": item["item_id"], "operation_id": candidate["apply_operation_id"], "operation": item["op"]})
+    if item["op"] == "dismiss_conflict":
+        artifact["dismissed_at"] = review["reviewed_at"]
     artifact["admission"]["payload_digest"] = canonical_payload_digest(artifact)
     return artifact
 
@@ -454,7 +465,7 @@ def _approved_reviews(paths: OmhPaths, candidate: Mapping[str, object]) -> dict[
         raise ValueError("exact immutable batch review seals are required")
     reviews: dict[str, dict[str, Any]] = {}
     for item in items:
-        value, error = read_json_object_result(_reviews_dir(paths) / f"{item['review_id']}.json")
+        value, error = read_json_object_result(_review_path(paths, str(item["review_id"])))
         if error or not isinstance(value, dict) or not _review_matches(value, candidate, item):
             raise ValueError("exact immutable batch review is required")
         reviews[item["item_id"]] = value
@@ -660,7 +671,7 @@ def _decisions(candidate: Mapping[str, object], raw: Mapping[str, object] | list
 def _candidate(paths: OmhPaths, batch_id: str) -> dict[str, Any]:
     if not safe_token(batch_id) or classify_memory_admission(batch_id)["status"] != "safe":
         raise ValueError("unsafe batch id")
-    value, error = read_json_object_result(paths.memory_dir / _candidate_relative(batch_id))
+    value, error = read_json_object_result(_candidate_path(paths, batch_id))
     if error or not isinstance(value, dict) or value.get("schema_version") != BATCH_CANDIDATE_SCHEMA_VERSION or value.get("batch_id") != batch_id or not isinstance(value.get("items"), list) or not value["items"]:
         raise ValueError("unknown or malformed batch candidate")
     return value
@@ -833,8 +844,16 @@ def _candidate_relative(batch_id: str) -> str:
     return f"candidates/{batch_id}.json"
 
 
+def _candidate_path(paths: OmhPaths, batch_id: str) -> Path:
+    return checked_memory_json_path(paths, _candidate_relative(batch_id))
+
+
+def _review_path(paths: OmhPaths, review_id: str) -> Path:
+    return checked_memory_json_path(paths, f"reviews/{review_id}.json")
+
+
 def _reviews_dir(paths: OmhPaths) -> Path:
-    return paths.memory_dir / "reviews"
+    return checked_memory_directory(paths, "reviews")
 
 
 def _existing_batch_review_ids(paths: OmhPaths, batch_id: str) -> set[str]:

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -15,7 +15,7 @@ from ..plugin_bundle.omh.memory_governance import MEMORY_GOVERNANCE_POLICY_VERSI
 from ..system.local_store import atomic_write_json, ensure_dir, file_lock, read_json_object_result
 from ..system.paths import OmhPaths
 from ._memory_store_validation import safe_token
-from .memory_store import run_memory_operation
+from .memory_store import MemoryOperationIdentityError, run_memory_operation
 
 BATCH_CANDIDATE_SCHEMA_VERSION, BATCH_REVIEW_SCHEMA_VERSION, BATCH_RECEIPT_SCHEMA_VERSION = "memory_update_batch_candidate/v1", "memory_update_batch_review/v1", "memory_update_batch_receipt/v1"
 _LEGACY_BATCH_SCHEMA_VERSION, _OPS, _DECISIONS = "memory_update_batch/v1", frozenset({"keep", "forget", "update", "change_scope", "dismiss_conflict"}), frozenset({"remember", "refuse", "defer"})
@@ -226,12 +226,13 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
             )
         return "written"
 
+    apply_revision = min(str(review["reviewed_at"]) for review in reviews.values())
     steps = [
         {
             "name": "write_reviewed_scopes",
             "action": "write_batch_scopes",
             "target": _candidate_relative(batch_id),
-            "revision": _stamp(_utc(now)),
+            "revision": apply_revision,
         }
     ]
 
@@ -247,6 +248,8 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
         )
     except _ScopePreconditionChanged:
         return {"schema_version": BATCH_RECEIPT_SCHEMA_VERSION, "status": "review_required", "reason_code": "scope_precondition_changed", "applied": False, "batch_id": batch_id}
+    except MemoryOperationIdentityError:
+        return {"schema_version": BATCH_RECEIPT_SCHEMA_VERSION, "status": "review_required", "reason_code": "operation_identity_conflict", "applied": False, "batch_id": batch_id}
     receipt = {key: operation["receipt"][key] for key in _RECEIPT_KEYS if key in operation.get("receipt", {})}
     return {"schema_version": BATCH_RECEIPT_SCHEMA_VERSION, "status": "applied" if operation.get("state") == "completed" else str(operation.get("state")), "applied": operation.get("state") == "completed", "batch_id": batch_id, "receipt": receipt}
 
@@ -342,10 +345,11 @@ def _apply_scope(
             data["items"].pop(item["target_ref"], None)
             data["tombstones"][item["target_ref"]] = {"item_id": item["target_ref"], "operation_id": candidate["apply_operation_id"], "candidate_item_id": item["item_id"], "review_id": item["review_id"], "tombstoned_at": updated_at}
         else:
-            if data["items"].get(item["item_id"], {}).get("candidate_item_id") == item["item_id"]:
+            approved = _approved_item(candidate, item, reviews[item["item_id"]])
+            if data["items"].get(item["item_id"]) == approved:
                 continue
             data["items"].pop(item["target_ref"], None)
-            data["items"][item["item_id"]] = _approved_item(candidate, item, reviews[item["item_id"]])
+            data["items"][item["item_id"]] = approved
     data["updated_at"] = updated_at
     _checked_scope_path(paths, target)
     atomic_write_json(path, data, private=True)
@@ -749,9 +753,19 @@ def _scope_precondition_digest(
         ):
             tombstone_keys.add(target_ref)
     data = dict(value) if isinstance(value, Mapping) else None
-    current_items = data.get("items", {}) if data else {}
-    current_tombstones = data.get("tombstones", {}) if data else {}
+    current_items = data.get("items", {}) if data is not None else {}
+    current_tombstones = data.get("tombstones", {}) if data is not None else {}
+    expected_scope = next(
+        scope
+        for item in matching
+        for scope in _item_scopes(item)
+        if _relative_scope(scope) == target
+    )
     projection = {
+        "schema_version": (
+            data.get("schema_version") if data is not None else MEMORY_SCOPE_SCHEMA_VERSION
+        ),
+        "scope": data.get("scope") if data is not None else dict(expected_scope),
         "items": (
             {key: current_items.get(key) for key in sorted(item_keys)}
             if isinstance(current_items, Mapping)

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -178,24 +178,39 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
         for index, target in enumerate(scopes, start=1)
     ]
 
-    def write_scope(_: OmhPaths, step: dict[str, str]) -> None:
-        if step["action"] != "write_batch_scope":
-            raise ValueError("unexpected batch apply operation")
-        if write_hook:
-            write_hook(step["name"])
+    def assert_precondition(check_paths: OmhPaths, step: dict[str, str]) -> None:
         if (
             _scope_precondition_digest(
-                _scope_snapshot_by_target(paths, step["target"]),
+                _scope_snapshot_by_target(check_paths, step["target"]),
                 candidate["items"],
                 step["target"],
             )
             != step["revision"]
         ):
             raise _ScopePreconditionChanged("reviewed scope changed before apply")
-        _apply_scope(paths, candidate, reviews, step["target"])
+
+    def preflight(check_paths: OmhPaths) -> None:
+        for step in steps:
+            assert_precondition(check_paths, step)
+
+    def write_scope(check_paths: OmhPaths, step: dict[str, str]) -> None:
+        if step["action"] != "write_batch_scope":
+            raise ValueError("unexpected batch apply operation")
+        if write_hook:
+            write_hook(step["name"])
+        assert_precondition(check_paths, step)
+        _apply_scope(check_paths, candidate, reviews, step["target"])
 
     try:
-        operation = run_memory_operation(paths, operation_id=str(candidate["apply_operation_id"]), operation_type="apply_memory_batch", steps=steps, step_writer=write_scope, now=now)
+        operation = run_memory_operation(
+            paths,
+            operation_id=str(candidate["apply_operation_id"]),
+            operation_type="apply_memory_batch",
+            steps=steps,
+            step_writer=write_scope,
+            preflight=preflight,
+            now=now,
+        )
     except _ScopePreconditionChanged:
         return {"schema_version": BATCH_RECEIPT_SCHEMA_VERSION, "status": "review_required", "reason_code": "scope_precondition_changed", "applied": False, "batch_id": batch_id}
     receipt = {key: operation["receipt"][key] for key in _RECEIPT_KEYS if key in operation.get("receipt", {})}

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import secrets
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
@@ -43,6 +44,14 @@ _REVIEW_KEYS = frozenset(
         "reviewed_at",
     }
 )
+_REVIEW_REQUEST_SCHEMA_VERSION = "memory_update_batch_review_request/v1"
+_REVIEW_REQUEST_KEYS = frozenset(
+    {"schema_version", "decisions", "reviewer_label", "policy_version", "reviewed_at"}
+)
+
+
+class _ScopePreconditionChanged(ValueError):
+    pass
 
 
 def stage_memory_update_batch(paths: OmhPaths, batch: Mapping[str, object], *, now: datetime | None = None) -> dict[str, object]:
@@ -52,9 +61,17 @@ def stage_memory_update_batch(paths: OmhPaths, batch: Mapping[str, object], *, n
     source_class = str(batch.get("source_class", "omh_local"))
     if source_class not in SOURCE_CLASSES:
         raise ValueError("unsupported batch source_class")
-    items = [_proposal(paths, raw, batch, batch_id, current, source_class) for raw in batch["updates"]]
+    scope_cache: dict[str, dict[str, Any] | None] = {}
+    items = [_proposal(paths, raw, batch, batch_id, current, source_class, scope_cache) for raw in batch["updates"]]
     _distinct_targets(items)
-    candidate = {"schema_version": BATCH_CANDIDATE_SCHEMA_VERSION, "batch_id": batch_id, "candidate_revision": 1, "stage_operation_id": _opaque("op_stage"), "apply_operation_id": _opaque("op_apply"), "status": "pending_review", "source_class": source_class, "source_surface": _label(batch.get("source_surface", "api")), "created_at": _stamp(current), "admission": {"state": "pending_review", "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION}, "items": items}
+    for item in items:
+        for scope in _item_scopes(item):
+            _scope_snapshot(paths, scope, scope_cache)
+    scope_preconditions = {
+        target: _scope_precondition_digest(value, items, target)
+        for target, value in sorted(scope_cache.items())
+    }
+    candidate = {"schema_version": BATCH_CANDIDATE_SCHEMA_VERSION, "batch_id": batch_id, "candidate_revision": 1, "stage_operation_id": _opaque("op_stage"), "apply_operation_id": _opaque("op_apply"), "status": "pending_review", "source_class": source_class, "source_surface": _label(batch.get("source_surface", "api")), "created_at": _stamp(current), "admission": {"state": "pending_review", "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION}, "scope_preconditions": scope_preconditions, "items": items}
     target = _candidate_relative(batch_id)
 
     def write_candidate(_: OmhPaths, step: dict[str, str]) -> None:
@@ -80,6 +97,18 @@ def review_memory_update_batch(paths: OmhPaths, batch_id: str, decisions: Mappin
     with file_lock(paths.memory_index_path, private=True):
         candidate = _candidate(paths, batch_id)
         decision_map = _decisions(candidate, decisions)
+        request = candidate.get("review_request")
+        if request is None:
+            if candidate.get("review_seals") or any(
+                (_reviews_dir(paths) / f"{item['review_id']}.json").exists() for item in candidate["items"]
+            ):
+                raise ValueError("batch review is immutable")
+            request = _review_request(decision_map, label, reviewed_at)
+            candidate = {**candidate, "review_request": request}
+            atomic_write_json(paths.memory_dir / _candidate_relative(batch_id), candidate, private=True)
+        elif not _review_request_matches(request, candidate, decision_map, label):
+            raise ValueError("batch review is immutable")
+        reviewed_at = str(request["reviewed_at"])
         reviews = [_review_record(candidate, item, decision_map[item["item_id"]], label, reviewed_at) for item in candidate["items"]]
         ensure_dir(_reviews_dir(paths), private=True)
         existing_seals = candidate.get("review_seals", {})
@@ -87,7 +116,10 @@ def review_memory_update_batch(paths: OmhPaths, batch_id: str, decisions: Mappin
             raise ValueError("batch review linkage is corrupt")
         seals: dict[str, str] = {}
         items_by_review = {str(item["review_id"]): item for item in candidate["items"]}
+        expected_review_ids = set(items_by_review)
         expected_item_ids = {str(item["item_id"]) for item in candidate["items"]}
+        if _existing_batch_review_ids(paths, batch_id) - expected_review_ids:
+            raise ValueError("batch review is immutable")
         if existing_seals and set(existing_seals) != expected_item_ids:
             raise ValueError("batch review is immutable")
         for review in reviews:
@@ -108,7 +140,16 @@ def review_memory_update_batch(paths: OmhPaths, batch_id: str, decisions: Mappin
             else:
                 # Unsealed reviews are interrupted-write debris, not
                 # executable authorization. Replace them before committing
-                # the complete seal set on the candidate.
+                # the complete seal set on the candidate. A digest mismatch,
+                # however, proves the candidate itself moved since the review
+                # file was written and must fail closed.
+                present, error = read_json_object_result(path)
+                if (
+                    not error
+                    and isinstance(present, Mapping)
+                    and present.get("candidate_digest") != _candidate_digest(candidate)
+                ):
+                    raise ValueError("batch review is immutable")
                 atomic_write_json(path, review, private=True)
                 sealed = review
             seals[str(item["item_id"])] = _review_digest(sealed)
@@ -125,14 +166,15 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
     candidate = _candidate(paths, batch_id)
     try:
         reviews = _approved_reviews(paths, candidate)
+        _revalidate(candidate, reviews)
+        preconditions = _scope_preconditions(candidate)
     except ValueError:
         return {"schema_version": BATCH_RECEIPT_SCHEMA_VERSION, "status": "review_required", "reason_code": "review_linkage_invalid", "applied": False, "batch_id": batch_id}
     if any(review["decision"] != "remember" for review in reviews.values()):
         return {"schema_version": BATCH_RECEIPT_SCHEMA_VERSION, "status": "review_required", "reason_code": "review_required", "applied": False, "batch_id": batch_id}
-    _revalidate(candidate, reviews)
     scopes = sorted({_relative_scope(scope) for item in candidate["items"] for scope in _item_scopes(item)})
     steps = [
-        {"name": f"write_scope_{index}", "action": "write_batch_scope", "source": _candidate_relative(batch_id), "target": target}
+        {"name": f"write_scope_{index}", "action": "write_batch_scope", "source": _candidate_relative(batch_id), "target": target, "revision": preconditions[target]}
         for index, target in enumerate(scopes, start=1)
     ]
 
@@ -141,9 +183,21 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
             raise ValueError("unexpected batch apply operation")
         if write_hook:
             write_hook(step["name"])
+        if (
+            _scope_precondition_digest(
+                _scope_snapshot_by_target(paths, step["target"]),
+                candidate["items"],
+                step["target"],
+            )
+            != step["revision"]
+        ):
+            raise _ScopePreconditionChanged("reviewed scope changed before apply")
         _apply_scope(paths, candidate, reviews, step["target"])
 
-    operation = run_memory_operation(paths, operation_id=str(candidate["apply_operation_id"]), operation_type="apply_memory_batch", steps=steps, step_writer=write_scope, now=now)
+    try:
+        operation = run_memory_operation(paths, operation_id=str(candidate["apply_operation_id"]), operation_type="apply_memory_batch", steps=steps, step_writer=write_scope, now=now)
+    except _ScopePreconditionChanged:
+        return {"schema_version": BATCH_RECEIPT_SCHEMA_VERSION, "status": "review_required", "reason_code": "scope_precondition_changed", "applied": False, "batch_id": batch_id}
     receipt = {key: operation["receipt"][key] for key in _RECEIPT_KEYS if key in operation.get("receipt", {})}
     return {"schema_version": BATCH_RECEIPT_SCHEMA_VERSION, "status": "applied" if operation.get("state") == "completed" else str(operation.get("state")), "applied": operation.get("state") == "completed", "batch_id": batch_id, "receipt": receipt}
 
@@ -153,7 +207,15 @@ def legacy_batch_review_required(paths: OmhPaths, batch: Mapping[str, object], *
     return {"schema_version": _LEGACY_BATCH_SCHEMA_VERSION, "status": "review_required", "applied": False, "dry_run": bool(dry_run), "update_count": len(batch["updates"]), "claim_boundary": "Direct memory batches are review-required and do not write OMH memory."}
 
 
-def _proposal(paths: OmhPaths, raw: object, batch: Mapping[str, object], batch_id: str, now: datetime, source_class: str) -> dict[str, object]:
+def _proposal(
+    paths: OmhPaths,
+    raw: object,
+    batch: Mapping[str, object],
+    batch_id: str,
+    now: datetime,
+    source_class: str,
+    scope_cache: dict[str, dict[str, Any] | None],
+) -> dict[str, object]:
     if not isinstance(raw, Mapping):
         raise ValueError("memory batch update must be an object")
     op, target_ref = str(raw.get("op", "")), str(raw.get("item_id", ""))
@@ -167,8 +229,14 @@ def _proposal(paths: OmhPaths, raw: object, batch: Mapping[str, object], batch_i
     from_scope = _scope(raw.get("from_scope")) if op == "change_scope" else None
     if op == "change_scope" and from_scope == scope:
         raise ValueError("change_scope requires distinct scopes")
-    existing = _existing(paths, from_scope or scope, target_ref)
-    item_id = str(existing.get("item_id")) if existing and safe_token(existing.get("item_id")) else _opaque("item")
+    existing = _existing(paths, from_scope or scope, target_ref, scope_cache)
+    existing_id = str(existing.get("item_id", "")) if existing else ""
+    if existing and (
+        not safe_token(existing_id)
+        or classify_memory_admission(existing_id)["status"] != "safe"
+    ):
+        raise ValueError("unsafe legacy memory batch item")
+    item_id = existing_id if existing else _opaque("item")
     revision = int(existing.get("revision", 0)) + 1 if existing and isinstance(existing.get("revision"), int) else 1
     key = _label(raw.get("key", existing.get("key", target_ref) if existing else target_ref))
     value = str(raw.get("value", existing.get("value", "") if existing else ""))[:500]
@@ -301,6 +369,38 @@ def _review_record(candidate: Mapping[str, object], item: Mapping[str, object], 
     }
 
 
+def _review_request(decisions: Mapping[str, str], label: str, reviewed_at: str) -> dict[str, object]:
+    return {
+        "schema_version": _REVIEW_REQUEST_SCHEMA_VERSION,
+        "decisions": {key: decisions[key] for key in sorted(decisions)},
+        "reviewer_label": label,
+        "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION,
+        "reviewed_at": reviewed_at,
+    }
+
+
+def _review_request_matches(
+    request: object,
+    candidate: Mapping[str, object],
+    decisions: Mapping[str, str],
+    label: str,
+) -> bool:
+    if not isinstance(request, Mapping) or set(request) != _REVIEW_REQUEST_KEYS:
+        return False
+    items = candidate.get("items")
+    if not isinstance(items, list):
+        return False
+    expected_ids = {str(item.get("item_id", "")) for item in items if isinstance(item, Mapping)}
+    return (
+        request.get("schema_version") == _REVIEW_REQUEST_SCHEMA_VERSION
+        and request.get("decisions") == {key: decisions[key] for key in sorted(decisions)}
+        and set(decisions) == expected_ids
+        and request.get("reviewer_label") == label
+        and request.get("policy_version") == MEMORY_GOVERNANCE_POLICY_VERSION
+        and _canonical_review_time(request.get("reviewed_at"))
+    )
+
+
 def _review_matches(review: Mapping[str, object], candidate: Mapping[str, object], item: Mapping[str, object]) -> bool:
     seals = candidate.get("review_seals")
     return (
@@ -383,12 +483,100 @@ def _scope(value: object) -> dict[str, object]:
     return {"kind": kind, "ref": ref}
 
 
-def _existing(paths: OmhPaths, scope: Mapping[str, object], target_ref: str) -> dict[str, Any] | None:
-    value, error = read_json_object_result(paths.memory_dir / _relative_scope(scope))
-    if error or not isinstance(value, dict):
+def _existing(
+    paths: OmhPaths,
+    scope: Mapping[str, object],
+    target_ref: str,
+    scope_cache: dict[str, dict[str, Any] | None],
+) -> dict[str, Any] | None:
+    value = _scope_snapshot(paths, scope, scope_cache)
+    if not isinstance(value, dict):
         return None
     item = value.get("items", {}).get(target_ref) if isinstance(value.get("items"), dict) else None
     return item if isinstance(item, dict) else None
+
+
+def _scope_snapshot(
+    paths: OmhPaths,
+    scope: Mapping[str, object],
+    cache: dict[str, dict[str, Any] | None],
+) -> dict[str, Any] | None:
+    target = _relative_scope(scope)
+    if target not in cache:
+        cache[target] = _scope_snapshot_by_target(paths, target)
+    return cache[target]
+
+
+def _scope_snapshot_by_target(paths: OmhPaths, target: str) -> dict[str, Any] | None:
+    path = paths.memory_dir / target
+    if path.is_symlink():
+        raise ValueError("scope file is unsafe")
+    value, error = read_json_object_result(path)
+    if error or (value is not None and not isinstance(value, dict)):
+        raise ValueError("scope file is corrupt")
+    return value
+
+
+def _scope_precondition_digest(
+    value: Mapping[str, object] | None,
+    items: list[dict[str, object]] | list[object],
+    target: str,
+) -> str:
+    matching = [
+        item
+        for item in items
+        if isinstance(item, Mapping) and target in {_relative_scope(scope) for scope in _item_scopes(item)}
+    ]
+    item_keys: set[str] = set()
+    tombstone_keys: set[str] = set()
+    for item in matching:
+        target_ref = str(item.get("target_ref", ""))
+        item_id = str(item.get("item_id", ""))
+        item_keys.add(target_ref)
+        if not (
+            item.get("op") == "forget"
+            or (item.get("op") == "change_scope" and target == _relative_scope(item["from_scope"]))
+        ):
+            item_keys.add(item_id)
+        if item.get("op") == "forget":
+            tombstone_keys.add(target_ref)
+    data = dict(value) if isinstance(value, Mapping) else None
+    current_items = data.get("items", {}) if data else {}
+    current_tombstones = data.get("tombstones", {}) if data else {}
+    projection = {
+        "items": (
+            {key: current_items.get(key) for key in sorted(item_keys)}
+            if isinstance(current_items, Mapping)
+            else current_items
+        ),
+        "tombstones": (
+            {key: current_tombstones.get(key) for key in sorted(tombstone_keys)}
+            if isinstance(current_tombstones, Mapping)
+            else current_tombstones
+        ),
+    }
+    canonical = json.dumps(projection, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _scope_preconditions(candidate: Mapping[str, object]) -> dict[str, str]:
+    raw = candidate.get("scope_preconditions")
+    items = candidate.get("items")
+    if not isinstance(items, list):
+        raise ValueError("batch scope preconditions are invalid")
+    expected = {
+        _relative_scope(scope)
+        for item in items
+        if isinstance(item, Mapping)
+        for scope in _item_scopes(item)
+    }
+    if (
+        not isinstance(raw, Mapping)
+        or set(raw) != expected
+        or any(not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value) for value in raw.values())
+    ):
+        raise ValueError("batch scope preconditions are invalid")
+    return {str(key): str(value) for key, value in raw.items()}
 
 
 def _item_scopes(item: Mapping[str, object]) -> tuple[Mapping[str, object], ...]:
@@ -405,6 +593,20 @@ def _candidate_relative(batch_id: str) -> str:
 
 def _reviews_dir(paths: OmhPaths) -> Path:
     return paths.memory_dir / "reviews"
+
+
+def _existing_batch_review_ids(paths: OmhPaths, batch_id: str) -> set[str]:
+    review_ids: set[str] = set()
+    directory = _reviews_dir(paths)
+    if not directory.exists():
+        return review_ids
+    for path in directory.glob("*.json"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        value, error = read_json_object_result(path)
+        if not error and isinstance(value, Mapping) and value.get("batch_id") == batch_id:
+            review_ids.add(str(value.get("review_id", "")))
+    return review_ids
 
 
 def _distinct_targets(items: list[dict[str, object]]) -> None:

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from ..plugin_bundle.omh.memory_governance import MEMORY_GOVERNANCE_POLICY_VERSION, MEMORY_SCOPE_SCHEMA_VERSION, PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION, SOURCE_CLASSES, build_retention, canonical_memory_scope, canonical_payload_digest, classify_memory_admission, stable_artifact_identity
+from ..plugin_bundle.omh.memory_governance import MEMORY_GOVERNANCE_POLICY_VERSION, MEMORY_SCOPE_SCHEMA_VERSION, PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION, SOURCE_CLASSES, build_retention, canonical_memory_scope, canonical_payload_digest, classify_memory_admission, evaluate_renderable_strings, stable_artifact_identity
 from ..system.local_store import atomic_write_json, ensure_dir, file_lock, read_json_object_result, utc_now
 from ..system.paths import OmhPaths
 from ._memory_store_validation import safe_token
@@ -104,7 +104,11 @@ def _proposal(paths: OmhPaths, raw: object, batch: Mapping[str, object], batch_i
     if not isinstance(raw, Mapping):
         raise ValueError("memory batch update must be an object")
     op, target_ref = str(raw.get("op", "")), str(raw.get("item_id", ""))
-    if op not in _OPS or not safe_token(target_ref):
+    if (
+        op not in _OPS
+        or not safe_token(target_ref)
+        or classify_memory_admission(target_ref)["status"] != "safe"
+    ):
         raise ValueError("invalid memory batch update")
     scope = _scope(raw.get("to_scope") if op == "change_scope" else raw.get("scope"))
     from_scope = _scope(raw.get("from_scope")) if op == "change_scope" else None
@@ -119,6 +123,8 @@ def _proposal(paths: OmhPaths, raw: object, batch: Mapping[str, object], batch_i
     if classify_memory_admission("\n".join((key, value, summary))).get("status") != "safe":
         raise ValueError("unsafe memory batch candidate")
     retention_class = str(raw.get("retention_class", batch.get("retention_class", "standard")))
+    if classify_memory_admission(retention_class)["status"] != "safe":
+        raise ValueError("unsafe memory batch retention class")
     ttl_days = raw.get("ttl_days", batch.get("ttl_days"))
     if ttl_days is not None and (isinstance(ttl_days, bool) or not isinstance(ttl_days, int)):
         raise ValueError("ttl_days must be an integer")
@@ -181,14 +187,45 @@ def _approved_reviews(paths: OmhPaths, candidate: Mapping[str, object]) -> dict[
 
 
 def _revalidate(candidate: Mapping[str, object], reviews: Mapping[str, Mapping[str, object]]) -> None:
+    control_values = (
+        candidate.get("batch_id", ""),
+        candidate.get("stage_operation_id", ""),
+        candidate.get("apply_operation_id", ""),
+        candidate.get("source_surface", ""),
+    )
+    if (
+        any(not safe_token(str(value)) for value in control_values[:3])
+        or any(classify_memory_admission(str(value))["status"] != "safe" for value in control_values)
+        or candidate.get("source_class") not in SOURCE_CLASSES
+    ):
+        raise ValueError("batch candidate control metadata is invalid")
     for item in candidate["items"]:
-        artifact = item["artifact"]
-        if stable_artifact_identity(artifact) != item["artifact_identity"] or canonical_payload_digest(artifact) != item["payload_digest"] or classify_memory_admission("\n".join(str(artifact.get(key, "")) for key in ("key", "value", "summary"))).get("status") != "safe":
+        artifact = item.get("artifact")
+        if not isinstance(artifact, dict):
             raise ValueError("batch candidate linkage or safety is invalid")
-        _scope(artifact["scope"])
+        identifiers = (item.get("item_id", ""), item.get("review_id", ""), item.get("target_ref", ""))
+        if (
+            any(not safe_token(str(value)) for value in identifiers)
+            or any(classify_memory_admission(str(value))["status"] != "safe" for value in identifiers)
+            or item.get("op") not in _OPS
+            or item.get("batch_id") != candidate.get("batch_id")
+            or evaluate_renderable_strings(artifact).get("status") != "safe"
+            or stable_artifact_identity(artifact) != item["artifact_identity"]
+            or canonical_payload_digest(artifact) != item["payload_digest"]
+        ):
+            raise ValueError("batch candidate linkage or safety is invalid")
+        scope = _scope(item["scope"])
+        if scope != artifact.get("scope"):
+            raise ValueError("batch candidate scope linkage is invalid")
+        if item.get("op") == "change_scope":
+            _scope(item["from_scope"])
         build_retention(str(item["retention"]["class"]), record_type="fact", admitted_at=_utc(None), ttl_days=item["retention"].get("ttl_days"))
-        if reviews[item["item_id"]]["decision"] != "remember":
-            raise ValueError("unapproved batch item")
+        review = reviews[item["item_id"]]
+        if (
+            review["decision"] != "remember"
+            or classify_memory_admission(str(review.get("reviewer_label", "")))["status"] != "safe"
+        ):
+            raise ValueError("unapproved or unsafe batch review")
 
 
 def _review_record(candidate: Mapping[str, object], item: Mapping[str, object], decision: str, label: str, reviewed_at: str) -> dict[str, object]:
@@ -215,7 +252,7 @@ def _decisions(candidate: Mapping[str, object], raw: Mapping[str, object] | list
 
 
 def _candidate(paths: OmhPaths, batch_id: str) -> dict[str, Any]:
-    if not safe_token(batch_id):
+    if not safe_token(batch_id) or classify_memory_admission(batch_id)["status"] != "safe":
         raise ValueError("unsafe batch id")
     value, error = read_json_object_result(paths.memory_dir / _candidate_relative(batch_id))
     if error or not isinstance(value, dict) or value.get("schema_version") != BATCH_CANDIDATE_SCHEMA_VERSION or value.get("batch_id") != batch_id or not isinstance(value.get("items"), list) or not value["items"]:
@@ -230,9 +267,14 @@ def _validate_batch(batch: Mapping[str, object]) -> None:
 
 def _scope(value: object) -> dict[str, object]:
     scope = canonical_memory_scope(dict(value) if isinstance(value, Mapping) else {})
-    if not safe_token(scope["kind"]) or not safe_token(scope["ref"]):
+    kind, ref = str(scope["kind"]), str(scope["ref"])
+    if (
+        not safe_token(kind)
+        or not safe_token(ref)
+        or classify_memory_admission("\n".join((kind, ref)))["status"] != "safe"
+    ):
         raise ValueError("unsafe memory scope")
-    return scope
+    return {"kind": kind, "ref": ref}
 
 
 def _existing(paths: OmhPaths, scope: Mapping[str, object], target_ref: str) -> dict[str, Any] | None:
@@ -274,10 +316,12 @@ def _opaque(prefix: str) -> str:
 
 
 def _label(value: object) -> str:
-    text = str(value or "operator").strip()[:120]
+    text = str(value or "operator").strip()
     if not text:
         raise ValueError("reviewer label is required")
-    return text
+    if classify_memory_admission(text)["status"] != "safe":
+        raise ValueError("credential-like batch label is not allowed")
+    return text[:120]
 
 
 def _utc(value: datetime | None) -> datetime:

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -179,13 +179,16 @@ def apply_approved_memory_update_batch(paths: OmhPaths, batch_id: str, *, now: d
     ]
 
     def assert_precondition(check_paths: OmhPaths, step: dict[str, str]) -> None:
+        snapshot = _scope_snapshot_by_target(check_paths, step["target"])
         if (
-            _scope_precondition_digest(
-                _scope_snapshot_by_target(check_paths, step["target"]),
-                candidate["items"],
+            _scope_precondition_digest(snapshot, candidate["items"], step["target"])
+            != step["revision"]
+            and not _scope_matches_candidate_apply(
+                snapshot,
+                candidate,
+                reviews,
                 step["target"],
             )
-            != step["revision"]
         ):
             raise _ScopePreconditionChanged("reviewed scope changed before apply")
 
@@ -317,6 +320,14 @@ def _apply_scope(
         op = item["op"]
         if op == "change_scope" and target == _relative_scope(item["from_scope"]):
             data["items"].pop(item["target_ref"], None)
+            data["tombstones"][item["target_ref"]] = {
+                "item_id": item["target_ref"],
+                "operation_id": candidate["apply_operation_id"],
+                "candidate_item_id": item["item_id"],
+                "review_id": item["review_id"],
+                "reason_code": "scope_changed",
+                "tombstoned_at": updated_at,
+            }
         elif op == "forget":
             data["items"].pop(item["target_ref"], None)
             data["tombstones"][item["target_ref"]] = {"item_id": item["target_ref"], "operation_id": candidate["apply_operation_id"], "candidate_item_id": item["item_id"], "review_id": item["review_id"], "tombstoned_at": updated_at}
@@ -327,6 +338,73 @@ def _apply_scope(
             data["items"][item["item_id"]] = _approved_item(candidate, item, reviews[item["item_id"]])
     data["updated_at"] = updated_at
     atomic_write_json(path, data, private=True)
+
+
+def _scope_matches_candidate_apply(
+    value: Mapping[str, object] | None,
+    candidate: Mapping[str, object],
+    reviews: Mapping[str, Mapping[str, object]],
+    target: str,
+) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    items = value.get("items")
+    tombstones = value.get("tombstones", {})
+    if not isinstance(items, Mapping) or not isinstance(tombstones, Mapping):
+        return False
+    candidate_items = candidate.get("items")
+    if not isinstance(candidate_items, list):
+        return False
+    matching = [
+        item
+        for item in candidate_items
+        if isinstance(item, Mapping)
+        and target in {_relative_scope(scope) for scope in _item_scopes(item)}
+    ]
+    if not matching:
+        return False
+    for item in matching:
+        op = item.get("op")
+        target_ref = str(item.get("target_ref", ""))
+        item_id = str(item.get("item_id", ""))
+        review_id = str(item.get("review_id", ""))
+        if op == "change_scope" and target == _relative_scope(item["from_scope"]):
+            marker = tombstones.get(target_ref)
+            if target_ref in items or not isinstance(marker, Mapping):
+                return False
+            if any(
+                marker.get(key) != expected
+                for key, expected in {
+                    "operation_id": candidate.get("apply_operation_id"),
+                    "candidate_item_id": item_id,
+                    "review_id": review_id,
+                    "reason_code": "scope_changed",
+                }.items()
+            ):
+                return False
+        elif op == "forget":
+            marker = tombstones.get(target_ref)
+            if target_ref in items or not isinstance(marker, Mapping):
+                return False
+            if any(
+                marker.get(key) != expected
+                for key, expected in {
+                    "operation_id": candidate.get("apply_operation_id"),
+                    "candidate_item_id": item_id,
+                    "review_id": review_id,
+                }.items()
+            ):
+                return False
+        else:
+            review = reviews.get(item_id)
+            if not isinstance(review, Mapping):
+                return False
+            expected_item = _approved_item(candidate, item, review)
+            if items.get(item_id) != expected_item:
+                return False
+            if target_ref != item_id and target_ref in items:
+                return False
+    return True
 
 
 def _approved_item(candidate: Mapping[str, object], item: Mapping[str, object], review: Mapping[str, object]) -> dict[str, object]:
@@ -585,7 +663,10 @@ def _scope_precondition_digest(
             or (item.get("op") == "change_scope" and target == _relative_scope(item["from_scope"]))
         ):
             item_keys.add(item_id)
-        if item.get("op") == "forget":
+        if item.get("op") == "forget" or (
+            item.get("op") == "change_scope"
+            and target == _relative_scope(_item_scopes(item)[0])
+        ):
             tombstone_keys.add(target_ref)
     data = dict(value) if isinstance(value, Mapping) else None
     current_items = data.get("items", {}) if data else {}

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -767,14 +767,17 @@ def _distinct_targets(items: list[dict[str, object]]) -> None:
             raise ValueError("batch has ambiguous scope-item targets")
         scope_item_targets.update(item_targets)
 
-        if op != "forget":
-            artifact = item.get("artifact")
-            if not isinstance(artifact, Mapping):
-                raise ValueError("batch has malformed logical target")
-            logical_target = (destination_target, str(artifact.get("key", "")))
-            if logical_target in logical_targets:
-                raise ValueError("batch has ambiguous logical targets")
-            logical_targets.add(logical_target)
+        artifact = item.get("artifact")
+        if not isinstance(artifact, Mapping):
+            raise ValueError("batch has malformed logical target")
+        logical_key = str(artifact.get("key", ""))
+        item_logical_targets = {
+            (_relative_scope(scope), logical_key)
+            for scope in _item_scopes(item)
+        }
+        if logical_targets & item_logical_targets:
+            raise ValueError("batch has ambiguous logical targets")
+        logical_targets.update(item_logical_targets)
 
 
 def _batch_view(candidate: Mapping[str, object], *, status: str) -> dict[str, object]:

--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import secrets
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta, timezone
@@ -28,6 +30,18 @@ _REVIEW_BOUND_ITEM_KEYS = (
     "retention",
     "artifact_identity",
     "payload_digest",
+)
+_REVIEW_KEYS = frozenset(
+    {
+        "schema_version",
+        "batch_id",
+        "candidate_digest",
+        *_REVIEW_BOUND_ITEM_KEYS,
+        "decision",
+        "reviewer_label",
+        "policy_version",
+        "reviewed_at",
+    }
 )
 
 
@@ -61,22 +75,49 @@ def stage_memory_update_batch(paths: OmhPaths, batch: Mapping[str, object], *, n
 
 
 def review_memory_update_batch(paths: OmhPaths, batch_id: str, decisions: Mapping[str, object] | list[Mapping[str, object]], *, reviewer_label: str = "operator", now: datetime | None = None) -> dict[str, object]:
-    candidate = _candidate(paths, batch_id)
-    decision_map = _decisions(candidate, decisions)
     label = _label(reviewer_label)
     reviewed_at = _stamp(_utc(now))
-    reviews = [_review_record(candidate, item, decision_map[item["item_id"]], label, reviewed_at) for item in candidate["items"]]
     with file_lock(paths.memory_index_path, private=True):
+        candidate = _candidate(paths, batch_id)
+        decision_map = _decisions(candidate, decisions)
+        reviews = [_review_record(candidate, item, decision_map[item["item_id"]], label, reviewed_at) for item in candidate["items"]]
         ensure_dir(_reviews_dir(paths), private=True)
+        existing_seals = candidate.get("review_seals", {})
+        if not isinstance(existing_seals, dict):
+            raise ValueError("batch review linkage is corrupt")
+        seals: dict[str, str] = {}
+        items_by_review = {str(item["review_id"]): item for item in candidate["items"]}
+        expected_item_ids = {str(item["item_id"]) for item in candidate["items"]}
+        if existing_seals and set(existing_seals) != expected_item_ids:
+            raise ValueError("batch review is immutable")
         for review in reviews:
             path = _reviews_dir(paths) / f"{review['review_id']}.json"
-            present, error = read_json_object_result(path)
-            if error:
-                raise ValueError("batch review is corrupt")
-            if present is not None and not _same_review(present, review):
-                raise ValueError("batch review is immutable")
-            if present is None:
+            item = items_by_review[str(review["review_id"])]
+            if existing_seals:
+                present, error = read_json_object_result(path)
+                if (
+                    error
+                    or present is None
+                    or not _review_base_matches(present, candidate, item)
+                    or present.get("decision") != review.get("decision")
+                    or present.get("reviewer_label") != review.get("reviewer_label")
+                    or existing_seals.get(str(item["item_id"])) != _review_digest(present)
+                ):
+                    raise ValueError("batch review is immutable")
+                sealed = dict(present)
+            else:
+                # Unsealed reviews are interrupted-write debris, not
+                # executable authorization. Replace them before committing
+                # the complete seal set on the candidate.
                 atomic_write_json(path, review, private=True)
+                sealed = review
+            seals[str(item["item_id"])] = _review_digest(sealed)
+
+        if existing_seals and existing_seals != seals:
+            raise ValueError("batch review is immutable")
+        sealed_candidate = {**candidate, "review_seals": seals}
+        if sealed_candidate != candidate:
+            atomic_write_json(paths.memory_dir / _candidate_relative(batch_id), sealed_candidate, private=True)
     return {"schema_version": BATCH_REVIEW_SCHEMA_VERSION, "status": "reviewed", "batch_id": candidate["batch_id"], "reviewer_label": label, "items": [{"item_id": item["item_id"], "review_id": item["review_id"], "decision": decision_map[item["item_id"]]} for item in candidate["items"]]}
 
 
@@ -189,8 +230,15 @@ def _approved_item(candidate: Mapping[str, object], item: Mapping[str, object], 
 
 
 def _approved_reviews(paths: OmhPaths, candidate: Mapping[str, object]) -> dict[str, dict[str, Any]]:
+    seals = candidate.get("review_seals")
+    items = candidate.get("items")
+    if not isinstance(items, list) or not all(isinstance(item, Mapping) for item in items):
+        raise ValueError("batch candidate items are malformed")
+    expected_item_ids = {str(item.get("item_id", "")) for item in items}
+    if not isinstance(seals, Mapping) or set(seals) != expected_item_ids:
+        raise ValueError("exact immutable batch review seals are required")
     reviews: dict[str, dict[str, Any]] = {}
-    for item in candidate["items"]:
+    for item in items:
         value, error = read_json_object_result(_reviews_dir(paths) / f"{item['review_id']}.json")
         if error or not isinstance(value, dict) or not _review_matches(value, candidate, item):
             raise ValueError("exact immutable batch review is required")
@@ -244,7 +292,7 @@ def _review_record(candidate: Mapping[str, object], item: Mapping[str, object], 
     return {
         "schema_version": PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION,
         "batch_id": candidate["batch_id"],
-        "candidate_digest": canonical_payload_digest(dict(candidate)),
+        "candidate_digest": _candidate_digest(candidate),
         **{key: item.get(key) for key in _REVIEW_BOUND_ITEM_KEYS},
         "decision": decision,
         "reviewer_label": label,
@@ -254,20 +302,48 @@ def _review_record(candidate: Mapping[str, object], item: Mapping[str, object], 
 
 
 def _review_matches(review: Mapping[str, object], candidate: Mapping[str, object], item: Mapping[str, object]) -> bool:
+    seals = candidate.get("review_seals")
     return (
-        review.get("schema_version") == PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION
-        and all(review.get(key) == item.get(key) for key in _REVIEW_BOUND_ITEM_KEYS)
-        and review.get("batch_id") == candidate.get("batch_id")
-        and review.get("candidate_digest") == canonical_payload_digest(dict(candidate))
-        and review.get("decision") in _DECISIONS
-        and isinstance(review.get("reviewer_label"), str)
-        and bool(review["reviewer_label"])
+        _review_base_matches(review, candidate, item)
+        and isinstance(seals, Mapping)
+        and seals.get(str(item.get("item_id", ""))) == _review_digest(review)
     )
 
 
-def _same_review(left: Mapping[str, object], right: Mapping[str, object]) -> bool:
-    keys = (*_REVIEW_BOUND_ITEM_KEYS, "batch_id", "candidate_digest", "decision", "reviewer_label")
-    return all(left.get(key) == right.get(key) for key in keys)
+def _review_base_matches(review: Mapping[str, object], candidate: Mapping[str, object], item: Mapping[str, object]) -> bool:
+    return (
+        set(review) == _REVIEW_KEYS
+        and review.get("schema_version") == PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION
+        and all(review.get(key) == item.get(key) for key in _REVIEW_BOUND_ITEM_KEYS)
+        and review.get("batch_id") == candidate.get("batch_id")
+        and review.get("candidate_digest") == _candidate_digest(candidate)
+        and review.get("decision") in _DECISIONS
+        and isinstance(review.get("reviewer_label"), str)
+        and bool(review["reviewer_label"])
+        and classify_memory_admission(str(review["reviewer_label"]))["status"] == "safe"
+        and review.get("policy_version") == MEMORY_GOVERNANCE_POLICY_VERSION
+        and _canonical_review_time(review.get("reviewed_at"))
+    )
+
+
+def _candidate_digest(candidate: Mapping[str, object]) -> str:
+    payload = {str(key): value for key, value in candidate.items() if key != "review_seals"}
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _review_digest(review: Mapping[str, object]) -> str:
+    canonical = json.dumps(dict(review), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _canonical_review_time(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        return _stamp(_parse_time(value)) == value
+    except (TypeError, ValueError):
+        return False
 
 
 def _decisions(candidate: Mapping[str, object], raw: Mapping[str, object] | list[Mapping[str, object]]) -> dict[str, str]:

--- a/src/workflows/memory_lifecycle.py
+++ b/src/workflows/memory_lifecycle.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from ..plugin_bundle.omh.memory_governance import (
     PROJECT_MEMORY_RECORD_SCHEMA_VERSION,
     canonical_memory_scope,
+    contains_credential_like_material,
     evaluate_renderable_strings,
 )
 from ..system.paths import OmhPaths
@@ -43,7 +44,27 @@ _ALLOWED_OUTCOMES = frozenset({"written", "moved", "rewritten", "removed", "alre
 def lifecycle_replay_status(record: Mapping[str, object], *, now: datetime) -> dict[str, object]:
     reason = _expiry_reason(record, now)
     state = _admission_state(record)
-    return {"record_id": str(record.get("record_id", "")), "revision": record.get("revision"), "scope": _scope(record), "admission_state": state, "retention_class": _retention_class(record), "replay_eligible": reason == "eligible" and state in {"approved_manual", "approved_auto_safe"}, "reason_code": reason if reason != "eligible" else ("eligible" if state in {"approved_manual", "approved_auto_safe"} else "review_required")}
+    scope_value = record.get("scope")
+    try:
+        scope = canonical_memory_scope(dict(scope_value) if isinstance(scope_value, Mapping) else {})
+    except (TypeError, ValueError):
+        scope = {"kind": "redacted", "ref": "redacted"}
+    public_scope = {key: _public_label(scope.get(key, "")) for key in ("kind", "ref")}
+    revision = record.get("revision")
+    return {
+        "record_id": _public_label(record.get("record_id", "")),
+        "revision": revision if isinstance(revision, int) and not isinstance(revision, bool) else None,
+        "scope": public_scope,
+        "admission_state": _public_label(state),
+        "retention_class": _public_label(_retention_class(record)),
+        "replay_eligible": reason == "eligible" and state in {"approved_manual", "approved_auto_safe"},
+        "reason_code": reason if reason != "eligible" else ("eligible" if state in {"approved_manual", "approved_auto_safe"} else "review_required"),
+    }
+
+
+def _public_label(value: object) -> str:
+    text = str(value or "")
+    return "redacted" if contains_credential_like_material(text) else text
 
 
 def build_memory_retirement(paths: OmhPaths, record_id: str, revision: int, *, now: datetime) -> LifecyclePlan:
@@ -101,6 +122,8 @@ def apply_memory_restore(paths: OmhPaths, plan: LifecyclePlan, *, transaction_ex
 
 
 def build_memory_reapproval(paths: OmhPaths, candidate_id: str, *, reviewer_claim: str, now: datetime) -> LifecyclePlan:
+    if not safe_token(candidate_id):
+        raise ValueError("unsafe_candidate_id")
     candidate, error = read_json(paths.memory_dir, f"candidates/{candidate_id}.json")
     if error or candidate is None or candidate.get("schema_version") != "project_memory_candidate/v2" or _admission_state(candidate) != "pending_review":
         return _rejected("reapprove", candidate_id, 0, now, "restore_candidate_not_pending")

--- a/src/workflows/memory_lifecycle.py
+++ b/src/workflows/memory_lifecycle.py
@@ -6,7 +6,11 @@ import hashlib
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 
-from ..plugin_bundle.omh.memory_governance import PROJECT_MEMORY_RECORD_SCHEMA_VERSION, canonical_memory_scope
+from ..plugin_bundle.omh.memory_governance import (
+    PROJECT_MEMORY_RECORD_SCHEMA_VERSION,
+    canonical_memory_scope,
+    evaluate_renderable_strings,
+)
 from ..system.paths import OmhPaths
 from ._memory_lifecycle_model import LifecycleMutation, LifecyclePlan, LifecycleTransactionExecutor, MAX_MANIFEST_TARGETS
 from ._memory_lifecycle_plans import (
@@ -77,6 +81,9 @@ def build_memory_restore(paths: OmhPaths, record_id: str, revision: int, *, now:
     candidate_id = candidate_id or _lifecycle_candidate_id("restore", record_id, revision)
     if not safe_token(candidate_id):
         raise ValueError("unsafe_candidate_id")
+    safety = evaluate_renderable_strings(dict(archived))
+    if safety["status"] != "safe":
+        return _rejected("restore", record_id, revision, now, str(safety["reason_code"]))
     candidate = _pending_candidate(archived, candidate_id, revision + 1, "restore")
     manifest = _manifest(((f"archive:{record_id}:r{revision}", "archive", relative), (f"candidate:{candidate_id}", "candidate", f"candidates/{candidate_id}.json")))
     mutation = LifecycleMutation("write_restore_candidate", "write", f"candidates/{candidate_id}.json", f"candidate:{candidate_id}", "candidate", payload=candidate)
@@ -100,11 +107,17 @@ def build_memory_reapproval(paths: OmhPaths, candidate_id: str, *, reviewer_clai
     record_id, revision = str(candidate.get("record_id", "")), candidate.get("candidate_revision")
     if not safe_token(record_id) or not isinstance(revision, int) or revision < 2:
         return _rejected("reapprove", candidate_id, 0, now, "restore_candidate_invalid")
+    reviewer_safety = evaluate_renderable_strings({"label": str(reviewer_claim or "")})
+    if reviewer_safety["status"] != "safe":
+        return _rejected("reapprove", record_id, revision, now, "unsafe_reviewer_claim")
     if (paths.memory_dir / f"records/{record_id}.json").exists():
         return _rejected("reapprove", record_id, revision, now, "newer_live_revision_conflict")
     replacement = candidate.get("replacement")
     if not isinstance(replacement, Mapping):
         return _rejected("reapprove", record_id, revision, now, "restore_candidate_invalid")
+    safety = evaluate_renderable_strings(dict(replacement))
+    if safety["status"] != "safe":
+        return _rejected("reapprove", record_id, revision, now, str(safety["reason_code"]))
     record = _approved_record(replacement, record_id, revision, reviewer_claim, now)
     review_id = str(record["admission"]["review_id"])
     review = _review(record, review_id, reviewer_claim)
@@ -128,9 +141,13 @@ def build_memory_correction(paths: OmhPaths, record_id: str, revision: int, summ
     candidate_id = candidate_id or _lifecycle_candidate_id("correct", record_id, revision)
     if not safe_token(candidate_id):
         raise ValueError("unsafe_candidate_id")
+    replacement = {**record, "summary": str(summary)[:500]}
+    safety = evaluate_renderable_strings(replacement)
+    if safety["status"] != "safe":
+        return _rejected("correct", record_id, revision, now, str(safety["reason_code"]))
     successor = {"schema_version": PROJECT_MEMORY_RECORD_SCHEMA_VERSION, "id": record_id, "id_key": "record_id", "revision": revision + 1, "scope": _scope(record)}
     history = {**record, "superseded_by": successor}
-    candidate = _pending_candidate({**record, "summary": str(summary)[:500]}, candidate_id, revision + 1, "correction")
+    candidate = _pending_candidate(replacement, candidate_id, revision + 1, "correction")
     manifest = _manifest(((f"record:{record_id}:r{revision}", "record", f"records/{record_id}.json"), (f"history:{record_id}:r{revision}", "history", f"history/{record_id}.r{revision}.json"), (f"candidate:{candidate_id}", "candidate", f"candidates/{candidate_id}.json")))
     mutations = (LifecycleMutation("write_superseded_history", "write", f"history/{record_id}.r{revision}.json", f"history:{record_id}:r{revision}", "history", payload=history), LifecycleMutation("remove_current_revision", "delete", f"records/{record_id}.json", f"record:{record_id}:r{revision}", "record"), LifecycleMutation("write_correction_candidate", "write", f"candidates/{candidate_id}.json", f"candidate:{candidate_id}", "candidate", payload=candidate))
     return _plan("correct", record_id, revision, _scope(record), now, manifest, mutations)

--- a/src/workflows/memory_store.py
+++ b/src/workflows/memory_store.py
@@ -28,11 +28,18 @@ _INDEX_DIRS = (("scope_files", "scopes"), ("candidate_files", "candidates"), ("r
 StepWriter = Callable[[OmhPaths, dict[str, Any]], str | None]
 IndexRebuilder = Callable[[OmhPaths], None]
 OperationPreflight = Callable[[OmhPaths], None]
+
+
+class MemoryOperationIdentityError(ValueError):
+    pass
+
+
 __all__ = [
     "MEMORY_OPERATION_SCHEMA_VERSION",
     "MEMORY_OPERATION_STATES",
     "MEMORY_RECEIPT_FIELDS",
     "MEMORY_TOMBSTONE_SCHEMA_VERSION",
+    "MemoryOperationIdentityError",
     "apply_memory_operation_step",
     "prune_expired_memory_evidence",
     "recover_memory_operations",
@@ -73,6 +80,10 @@ def run_memory_operation(
             record = normalized
             atomic_write_json(path, record, private=True)
         else:
+            if not _operation_request_matches(existing, normalized):
+                raise MemoryOperationIdentityError(
+                    "memory operation id is already bound to a different request"
+                )
             record = existing
         return _resume_unlocked(paths, record, rebuild_index, step_writer, now)
 
@@ -87,6 +98,23 @@ def recover_memory_operations(
     with file_lock(paths.memory_index_path, private=True):
         ensure_dir(paths.memory_operations_dir, private=True)
         return _recover_unlocked(paths, rebuild_index, step_writer, now)
+
+
+def _operation_request_matches(existing: Mapping[str, object], requested: Mapping[str, object]) -> bool:
+    def request_steps(value: Mapping[str, object]) -> list[dict[str, object]] | None:
+        steps = value.get("steps")
+        if not isinstance(steps, list) or not all(isinstance(step, Mapping) for step in steps):
+            return None
+        return [
+            {str(key): item for key, item in step.items() if key not in {"state", "outcome"}}
+            for step in steps
+        ]
+
+    return (
+        existing.get("operation_id") == requested.get("operation_id")
+        and existing.get("operation_type") == requested.get("operation_type")
+        and request_steps(existing) == request_steps(requested)
+    )
 
 
 def apply_memory_operation_step(paths: OmhPaths, step: dict[str, Any]) -> str:

--- a/src/workflows/memory_store.py
+++ b/src/workflows/memory_store.py
@@ -18,6 +18,7 @@ from ._memory_store_validation import (
     parse_time,
     relative_memory_json_path,
     relative_memory_jsonl_path,
+    safe_json_value,
     safe_token,
     valid_memory_operation,
     validate_memory_receipt,
@@ -41,6 +42,9 @@ __all__ = [
     "MEMORY_TOMBSTONE_SCHEMA_VERSION",
     "MemoryOperationIdentityError",
     "apply_memory_operation_step",
+    "checked_memory_directory",
+    "checked_memory_json_path",
+    "ensure_memory_directory",
     "prune_expired_memory_evidence",
     "recover_memory_operations",
     "run_memory_operation",
@@ -62,8 +66,8 @@ def run_memory_operation(
     now: datetime | str | None = None,
 ) -> dict[str, Any]:
     normalized = build_memory_operation(operation_id, operation_type, steps, _stamp(now))
+    ensure_memory_directory(paths, "operations")
     with file_lock(paths.memory_index_path, private=True):
-        ensure_dir(paths.memory_operations_dir, private=True)
         # A candidate-bound writer can only interpret its own operation. Passing
         # it to unrelated interrupted records can poison their recovery state.
         if step_writer is None:
@@ -95,8 +99,8 @@ def recover_memory_operations(
     step_writer: StepWriter | None = None,
     now: datetime | str | None = None,
 ) -> list[dict[str, Any]]:
+    ensure_memory_directory(paths, "operations")
     with file_lock(paths.memory_index_path, private=True):
-        ensure_dir(paths.memory_operations_dir, private=True)
         return _recover_unlocked(paths, rebuild_index, step_writer, now)
 
 
@@ -144,6 +148,9 @@ def apply_memory_operation_step(paths: OmhPaths, step: dict[str, Any]) -> str:
     source_value = step.get("source", "")
     if not isinstance(source_value, str) or not source_value:
         raise ValueError("operation step has no source")
+    raw_source = paths.memory_dir / source_value
+    if raw_source.is_symlink():
+        raise ValueError("operation source is a symlink")
     source = _memory_path(paths, source_value)
     if source.is_symlink():
         raise ValueError("operation source is a symlink")
@@ -151,11 +158,18 @@ def apply_memory_operation_step(paths: OmhPaths, step: dict[str, Any]) -> str:
         payload, error = read_json_object_result(source)
         if error or payload is None:
             raise ValueError("operation source is not a JSON object")
+        if not safe_json_value(payload):
+            raise ValueError("operation source contains unsafe content")
         atomic_write_json(target, payload, private=True)
         return "copied"
     if action == "move":
         if not source.exists():
             raise FileNotFoundError("operation source is missing")
+        payload, error = read_json_object_result(source)
+        if error or payload is None:
+            raise ValueError("operation source is not a JSON object")
+        if not safe_json_value(payload):
+            raise ValueError("operation source contains unsafe content")
         ensure_dir(target.parent, private=True)
         os.replace(source, target)
         target.chmod(0o600)
@@ -169,9 +183,10 @@ def write_memory_tombstone(paths: OmhPaths, tombstone: Mapping[str, object]) -> 
     errors = validate_memory_tombstone(value)
     if errors:
         raise ValueError("; ".join(errors))
+    ensure_memory_directory(paths, "tombstones")
     with file_lock(paths.memory_index_path, private=True):
-        ensure_dir(paths.memory_tombstones_dir, private=True)
-        atomic_write_json(paths.memory_tombstones_dir / f"{value['tombstone_id']}.json", value, private=True)
+        target = checked_memory_json_path(paths, f"tombstones/{value['tombstone_id']}.json")
+        atomic_write_json(target, value, private=True)
     return value
 
 
@@ -180,12 +195,12 @@ def prune_expired_memory_evidence(
 ) -> dict[str, Any]:
     if isinstance(retention_days, bool) or not isinstance(retention_days, int) or retention_days < 1:
         raise ValueError("retention_days must be positive")
+    operations_dir = ensure_memory_directory(paths, "operations")
+    tombstones_dir = ensure_memory_directory(paths, "tombstones")
     with file_lock(paths.memory_index_path, private=True):
-        ensure_dir(paths.memory_operations_dir, private=True)
-        ensure_dir(paths.memory_tombstones_dir, private=True)
         current = _as_utc(now)
-        operations = _prune_dir(paths.memory_operations_dir, MEMORY_OPERATION_SCHEMA_VERSION, "operation_id", "created_at", current, retention_days)
-        tombstones = _prune_dir(paths.memory_tombstones_dir, MEMORY_TOMBSTONE_SCHEMA_VERSION, "tombstone_id", "tombstoned_at", current, retention_days)
+        operations = _prune_dir(operations_dir, MEMORY_OPERATION_SCHEMA_VERSION, "operation_id", "created_at", current, retention_days)
+        tombstones = _prune_dir(tombstones_dir, MEMORY_TOMBSTONE_SCHEMA_VERSION, "tombstone_id", "tombstoned_at", current, retention_days)
     return {"schema_version": "memory_evidence_prune/v1", "removed_operations": operations, "removed_tombstones": tombstones, "retention_days": retention_days}
 
 
@@ -268,12 +283,29 @@ def _write_operation(paths: OmhPaths, record: dict[str, Any]) -> None:
 
 
 def _operation_path(paths: OmhPaths, operation_id: str) -> Path:
-    return paths.memory_operations_dir / f"{operation_id}.json"
+    return checked_memory_json_path(paths, f"operations/{operation_id}.json")
 
 
 def _rebuild_index(paths: OmhPaths) -> None:
-    files = {key: [path.relative_to(paths.memory_dir).as_posix() for path in sorted((paths.memory_dir / directory).rglob("*.json")) if path.is_file() and not path.is_symlink()] for key, directory in _INDEX_DIRS}
+    files = {
+        key: [
+            path.relative_to(paths.memory_dir).as_posix()
+            for path in sorted((paths.memory_dir / directory).rglob("*.json"))
+            if _indexable_memory_file(paths, path)
+        ]
+        for key, directory in _INDEX_DIRS
+    }
     atomic_write_json(paths.memory_index_path, {"schema_version": "omh_memory_index/v1", "updated_at": utc_now(), **files, "claim_boundary": "OMH local memory only; this index is not Hermes internal memory."}, private=True)
+
+
+def _indexable_memory_file(paths: OmhPaths, path: Path) -> bool:
+    if not path.is_file() or path.is_symlink():
+        return False
+    try:
+        relative = path.relative_to(paths.memory_dir).as_posix()
+    except ValueError:
+        return False
+    return relative_memory_json_path(relative)
 
 
 def _receipt(record: dict[str, Any]) -> dict[str, Any]:
@@ -297,9 +329,46 @@ def _prune_dir(directory: Path, schema: str, id_key: str, timestamp_key: str, no
 def _memory_path(paths: OmhPaths, relative: str) -> Path:
     if not (relative_memory_json_path(relative) or relative_memory_jsonl_path(relative)):
         raise ValueError("memory path must be relative and contained")
-    root, path = paths.memory_dir.resolve(strict=False), paths.memory_dir / relative
-    resolved = path.resolve(strict=False)
-    if root != resolved and root not in resolved.parents:
+    return _checked_memory_relative_path(paths, relative)
+
+
+def checked_memory_json_path(paths: OmhPaths, relative: str) -> Path:
+    if not relative_memory_json_path(relative):
+        raise ValueError("memory path must be relative and contained")
+    return _checked_memory_relative_path(paths, relative)
+
+
+def ensure_memory_directory(paths: OmhPaths, relative: str) -> Path:
+    directory = checked_memory_directory(paths, relative)
+    ensure_dir(directory, private=True)
+    return directory
+
+
+def checked_memory_directory(paths: OmhPaths, relative: str) -> Path:
+    path = Path(relative)
+    if (
+        not relative
+        or path.is_absolute()
+        or ".." in path.parts
+        or not all(safe_token(part) for part in path.parts)
+    ):
+        raise ValueError("memory directory must be relative and contained")
+    return _checked_memory_relative_path(paths, relative)
+
+
+def _checked_memory_relative_path(paths: OmhPaths, relative: str) -> Path:
+    root = paths.memory_dir
+    if root.is_symlink():
+        raise ValueError("memory path escapes store")
+    path = root / relative
+    cursor = root
+    for part in Path(relative).parts:
+        cursor /= part
+        if cursor.is_symlink():
+            raise ValueError("memory path escapes store")
+    resolved_root = root.resolve(strict=False)
+    resolved_path = path.resolve(strict=False)
+    if resolved_root != resolved_path and resolved_root not in resolved_path.parents:
         raise ValueError("memory path escapes store")
     return path
 

--- a/src/workflows/memory_store.py
+++ b/src/workflows/memory_store.py
@@ -57,7 +57,10 @@ def run_memory_operation(
     normalized = build_memory_operation(operation_id, operation_type, steps, _stamp(now))
     with file_lock(paths.memory_index_path, private=True):
         ensure_dir(paths.memory_operations_dir, private=True)
-        _recover_unlocked(paths, rebuild_index, step_writer, now, skip=operation_id)
+        # A candidate-bound writer can only interpret its own operation. Passing
+        # it to unrelated interrupted records can poison their recovery state.
+        if step_writer is None:
+            _recover_unlocked(paths, rebuild_index, None, now, skip=operation_id)
         path = _operation_path(paths, operation_id)
         if path.is_symlink():
             return {"operation_id": operation_id, "state": "corrupt"}
@@ -209,6 +212,12 @@ def _recover_unlocked(paths: OmhPaths, rebuild: IndexRebuilder | None, writer: S
             else:
                 results.append({"operation_id": "", "state": "corrupt"})
         else:
+            if writer is None and record.get("state") not in {"completed", "failed", "corrupt"} and any(
+                step.get("action") not in {"copy", "delete", "move", "rewrite_jsonl", "write_json"}
+                for step in record.get("steps", [])
+                if isinstance(step, Mapping)
+            ):
+                continue
             results.append(_resume_unlocked(paths, record, rebuild, writer, now))
     return results
 

--- a/src/workflows/memory_store.py
+++ b/src/workflows/memory_store.py
@@ -27,6 +27,7 @@ from ._memory_store_validation import (
 _INDEX_DIRS = (("scope_files", "scopes"), ("candidate_files", "candidates"), ("record_files", "records"), ("review_files", "reviews"))
 StepWriter = Callable[[OmhPaths, dict[str, Any]], str | None]
 IndexRebuilder = Callable[[OmhPaths], None]
+OperationPreflight = Callable[[OmhPaths], None]
 __all__ = [
     "MEMORY_OPERATION_SCHEMA_VERSION",
     "MEMORY_OPERATION_STATES",
@@ -50,6 +51,7 @@ def run_memory_operation(
     steps: Sequence[Mapping[str, object]],
     rebuild_index: IndexRebuilder | None = None,
     step_writer: StepWriter | None = None,
+    preflight: OperationPreflight | None = None,
     now: datetime | str | None = None,
 ) -> dict[str, Any]:
     normalized = build_memory_operation(operation_id, operation_type, steps, _stamp(now))
@@ -63,6 +65,8 @@ def run_memory_operation(
         if error or existing is None or not valid_memory_operation(existing):
             if path.exists():
                 return _mark_corrupt_operation(paths, operation_id, now)
+            if preflight is not None:
+                preflight(paths)
             record = normalized
             atomic_write_json(path, record, private=True)
         else:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 from _local_package import load_local_package
 from _platform_support import requires_posix, requires_posix_permissions
+from _credential_fixtures import AWS_ACCESS_KEY_ID
 
 load_local_package()
 from omh.coding_delegation import build_coding_delegation_payload
@@ -131,6 +132,39 @@ class MemoryContractTests(unittest.TestCase):
             needs_review = capture_project_memory_candidate(paths, "PR #123 fixed this temporarily", record_type="lesson")
             self.assertEqual(needs_review["candidate"]["safety"]["status"], "safe")
             self.assertEqual(needs_review["candidate"]["safety"]["review_reasons"], [])
+
+    def test_project_memory_bare_credentials_are_blocked_and_redacted_before_review(self) -> None:
+        credentials = (
+            AWS_ACCESS_KEY_ID,
+            "gh" + "p_" + "a" * 36,
+            "sk" + "-" + "a" * 48,
+            "https://user:pass@example.com",
+            "-----BEGIN PRIVATE KEY-----",
+        )
+        for credential in credentials:
+            with self.subTest(credential_kind=credential[:4]), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                write_setup_profile(paths, memory_mode="auto-safe")
+
+                captured = capture_project_memory_candidate(
+                    paths,
+                    f"Observed {credential}",
+                    tags=[credential],
+                    source=credential,
+                    source_ref=credential,
+                )
+                candidate = captured["candidate"]
+                serialized = json.dumps(captured, sort_keys=True)
+                self.assertEqual(candidate["status"], "blocked_review_required")
+                self.assertFalse(captured["auto_approved"])
+                self.assertNotIn(credential, serialized)
+                self.assertNotIn(credential, json.dumps(build_project_memory_review(paths), sort_keys=True))
+
+                with self.assertRaises(ValueError):
+                    approve_project_memory_candidate(paths, candidate["candidate_id"])
+                rejected = reject_project_memory_candidate(paths, candidate["candidate_id"], reason=f"blocked {credential}")
+                self.assertNotIn(credential, json.dumps(rejected, sort_keys=True))
+                self.assertFalse((paths.memory_dir / "records").exists())
 
     def test_project_memory_auto_safe_policy_auto_approves_safe_candidates(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -280,6 +280,29 @@ class MemoryContractTests(unittest.TestCase):
             self.assertNotIn(credential, json.dumps(recall, sort_keys=True))
             self.assertEqual(record_path.read_bytes(), legacy_bytes)
 
+    def test_recall_redacts_credential_shaped_request_metadata(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            recall = build_project_memory_recall_pack(
+                paths,
+                "safe query",
+                executor_target=credential,
+                session_id=credential,
+                scope_kind="run",
+                scope_ref=credential,
+                observer=credential,
+                observed=credential,
+            )
+            serialized = json.dumps(recall, sort_keys=True)
+
+            self.assertNotIn(credential, serialized)
+            self.assertEqual(recall["executor_target"], "redacted")
+            self.assertEqual(recall["session_id"], "redacted")
+            self.assertEqual(recall["scope"], {"kind": "run", "ref": "redacted"})
+            self.assertEqual(recall["perspective"], {"observer": "redacted", "observed": "redacted"})
+
     def test_replay_projection_uses_sanitized_source_class_from_evaluation(self) -> None:
         credential = "gh" + "u_" + "a" * 36
         projection = memory_workflow._replay_evaluation(

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -354,6 +354,29 @@ class MemoryContractTests(unittest.TestCase):
             wrapper_inspection = build_memory_inspection(paths, wrapper_snapshot=wrapper)
             self.assertNotIn(credential, json.dumps(wrapper_inspection, sort_keys=True))
 
+    def test_wrapper_scope_preserves_ordinary_credential_vocabulary(self) -> None:
+        for scope_ref in ("token-based", "secret-management"):
+            with self.subTest(scope_ref=scope_ref), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                wrapper = {
+                    "schema_version": "memory_snapshot/v1",
+                    "scope": {"kind": "project", "ref": scope_ref},
+                    "items": [
+                        {
+                            "item_id": "safe-wrapper-item",
+                            "key": "safe_wrapper_item",
+                            "summary": "Safe wrapper item",
+                            "scope": {"kind": "project", "ref": scope_ref},
+                        }
+                    ],
+                }
+
+                inspection = build_memory_inspection(paths, wrapper_snapshot=wrapper)
+                snapshot = next(item for item in inspection["snapshots"] if item["source"] == "wrapper_snapshot")
+
+                self.assertEqual(snapshot["scope"]["ref"], scope_ref)
+                self.assertEqual(snapshot["items"][0]["scope"]["ref"], scope_ref)
+
     def test_project_memory_auto_safe_policy_auto_approves_safe_candidates(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -206,6 +206,27 @@ class MemoryContractTests(unittest.TestCase):
             self.assertNotIn(opaque_summary, json.dumps(approved, sort_keys=True))
             self.assertNotIn(opaque_tag.lower(), json.dumps(approved, sort_keys=True).lower())
 
+    def test_letters_only_encoded_values_are_review_gated_before_any_raw_persistence(self) -> None:
+        encoded_values = (
+            "mQvHzLrNaPeTgWuYbJxDcFkSiOoUaZcV",
+            "JBSWYDPFJBSWYDPFJBSWYDPFJBSWYDPF",
+        )
+        for encoded in encoded_values:
+            with self.subTest(encoded=encoded[:8]), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                write_setup_profile(paths, memory_mode="auto-safe")
+
+                captured = capture_project_memory_candidate(paths, encoded, source="cli")
+                candidate = captured["candidate"]
+                candidate_path = paths.memory_dir / "candidates" / f"{candidate['candidate_id']}.json"
+
+                self.assertEqual(candidate["safety"]["status"], "needs_review")
+                self.assertFalse(captured["auto_approved"])
+                self.assertEqual(candidate["summary"], "[redacted]")
+                self.assertNotIn(encoded, json.dumps(captured, sort_keys=True))
+                self.assertNotIn(encoded, candidate_path.read_text(encoding="utf-8"))
+                self.assertFalse((paths.memory_dir / "records").exists())
+
     def test_unknown_credential_label_is_redacted_before_candidate_and_review_persistence(self) -> None:
         credential = "credential:" + "a" * 40
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -287,6 +287,8 @@ class MemoryContractTests(unittest.TestCase):
             record_path = paths.memory_dir / "records" / f"{record_id}.json"
             record = json.loads(record_path.read_text(encoding="utf-8"))
             record["scope"]["ref"] = credential
+            record["approved_at"] = credential
+            record["ttl"]["expires_at"] = credential
             record_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
             legacy_bytes = record_path.read_bytes()
 
@@ -305,6 +307,9 @@ class MemoryContractTests(unittest.TestCase):
             record_id = captured["record"]["record_id"]
             record_path = paths.memory_dir / "records" / f"{record_id}.json"
             record = json.loads(record_path.read_text(encoding="utf-8"))
+            record["record_type"] = credential
+            record["approved_at"] = credential
+            record["ttl"]["expires_at"] = credential
             record["scope"]["ref"] = credential
             record["derived_from"] = [credential]
             record["perspective"] = {"observer": "hermes", "observed": credential}

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -230,6 +230,21 @@ class MemoryContractTests(unittest.TestCase):
             self.assertNotIn(credential, json.dumps(recall, sort_keys=True))
             self.assertEqual(record_path.read_bytes(), legacy_bytes)
 
+    def test_replay_projection_uses_sanitized_source_class_from_evaluation(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        projection = memory_workflow._replay_evaluation(
+            {
+                "schema_version": "project_memory_record/v3",
+                "record_id": "safe-record",
+                "revision": 1,
+                "source_class": credential,
+            },
+            {"source_class": "redacted", "eligible": False, "reason_code": "unsupported_schema"},
+        )
+
+        self.assertEqual(projection["source_class"], "redacted")
+        self.assertNotIn(credential, json.dumps(projection, sort_keys=True))
+
     def test_legacy_candidate_review_and_rejection_mask_protected_fields(self) -> None:
         credential = "gh" + "u_" + "a" * 36
         with TemporaryDirectory() as tmp:
@@ -248,7 +263,11 @@ class MemoryContractTests(unittest.TestCase):
             candidate["source_ref"] = credential
             candidate["source_evidence"] = {credential: {"nested": credential}}
             candidate["scope"]["ref"] = credential
-            candidate["perspective"] = {"observer": "hermes", "observed": credential}
+            candidate["perspective"] = {
+                "observer": "hermes",
+                "observed": credential,
+                credential: "safe nested perspective value",
+            }
             candidate["safety"]["detail"] = credential
             candidate[credential] = credential
             candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -314,6 +333,25 @@ class MemoryContractTests(unittest.TestCase):
             self.assertNotIn(credential, json.dumps(recall, sort_keys=True))
             self.assertEqual(record_path.read_bytes(), legacy_bytes)
 
+    def test_archived_recall_exclusion_masks_a_legacy_credential_record_id(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            captured = capture_project_memory_candidate(paths, "Archived identity fixture")
+            record_id = captured["record"]["record_id"]
+            record_path = paths.memory_dir / "records" / f"{record_id}.json"
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+            record["record_id"] = credential
+            record["attention"] = {"tier": "archive"}
+            record_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            recall = build_project_memory_recall_pack(paths, "archived identity fixture")
+
+            self.assertEqual(recall["record_count"], 0)
+            self.assertEqual(recall["excluded_records"][0]["reason"], "archived_tier")
+            self.assertNotIn(credential, json.dumps(recall, sort_keys=True))
+
     def test_legacy_record_inspection_views_mask_structural_credentials(self) -> None:
         credential = "gh" + "u_" + "a" * 36
         with TemporaryDirectory() as tmp:
@@ -330,12 +368,39 @@ class MemoryContractTests(unittest.TestCase):
             record["derived_from"] = [credential]
             record["perspective"] = {"observer": "hermes", "observed": credential}
             record_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            scope_path = paths.memory_dir / "scopes" / "project.json"
+            scope_path.parent.mkdir(parents=True, exist_ok=True)
+            scope_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": memory_governance.MEMORY_SCOPE_SCHEMA_VERSION,
+                        "scope": {"kind": "project", "ref": credential},
+                        "items": {
+                            "safe-item": {
+                                "item_id": "safe-item",
+                                "revision": 1,
+                                "key": "safe_item",
+                                "summary": "Safe legacy scope item",
+                                "value": "safe value",
+                            }
+                        },
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
 
             lineage = memory_workflow.build_memory_lineage(paths, record_id)
             perspectives = memory_workflow.build_memory_perspectives(paths)
+            inspection = build_memory_inspection(paths)
+            summary_inspection = build_memory_inspection(paths, summary=True)
 
             self.assertNotIn(credential, json.dumps(lineage, sort_keys=True))
             self.assertNotIn(credential, json.dumps(perspectives, sort_keys=True))
+            self.assertNotIn(credential, json.dumps(inspection, sort_keys=True))
+            self.assertNotIn(credential, json.dumps(summary_inspection, sort_keys=True))
 
             wrapper = {
                 "schema_version": "memory_snapshot/v1",
@@ -366,6 +431,7 @@ class MemoryContractTests(unittest.TestCase):
                             "item_id": "safe-wrapper-item",
                             "key": "safe_wrapper_item",
                             "summary": "Safe wrapper item",
+                            "value": "token-based metadata",
                             "scope": {"kind": "project", "ref": scope_ref},
                         }
                     ],
@@ -376,6 +442,7 @@ class MemoryContractTests(unittest.TestCase):
 
                 self.assertEqual(snapshot["scope"]["ref"], scope_ref)
                 self.assertEqual(snapshot["items"][0]["scope"]["ref"], scope_ref)
+                self.assertEqual(snapshot["items"][0]["value"], "token-based metadata")
 
     def test_project_memory_auto_safe_policy_auto_approves_safe_candidates(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -398,10 +465,14 @@ class MemoryContractTests(unittest.TestCase):
                 paths,
                 summary,
                 tags=["token-based", "secret-management"],
+                source="token-service",
+                source_ref="https://example.com/secret-management",
             )
 
             self.assertTrue(captured["auto_approved"])
             self.assertEqual(captured["candidate"]["summary"], summary)
+            self.assertEqual(captured["candidate"]["source"], "token-service")
+            self.assertEqual(captured["candidate"]["source_ref"], "https://example.com/secret-management")
             self.assertEqual(captured["record"]["summary"], summary)
             self.assertEqual(captured["record"]["tags"], ["token-based", "secret-management"])
             recall = build_project_memory_recall_pack(paths, "parsing policy")
@@ -1879,6 +1950,37 @@ class UnreadableRecordVisibilityTests(unittest.TestCase):
             # approved v1 record still counts and still fails closed on replay.
             self.assertEqual(status["counts"]["approved_records"], 1)
             self.assertEqual(status["counts"]["review_required_legacy"], 1)
+
+    def test_unreadable_record_filename_is_redacted_when_it_has_a_credential_shape(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            records_dir = paths.memory_dir / "records"
+            records_dir.mkdir(parents=True, exist_ok=True)
+            (records_dir / f"{credential}.json").write_text("{", encoding="utf-8")
+
+            status = build_project_memory_status(paths)
+
+            self.assertEqual(status["counts"]["unreadable_records"], 1)
+            self.assertNotIn(credential, json.dumps(status, sort_keys=True))
+            self.assertEqual(status["unreadable_records"][0]["path_name"], "[redacted]")
+
+    def test_unreadable_record_schema_is_redacted_when_it_has_a_credential_shape(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            records_dir = paths.memory_dir / "records"
+            records_dir.mkdir(parents=True, exist_ok=True)
+            (records_dir / "future.json").write_text(
+                json.dumps({"schema_version": credential}),
+                encoding="utf-8",
+            )
+
+            status = build_project_memory_status(paths)
+
+            self.assertEqual(status["counts"]["unreadable_records"], 1)
+            self.assertNotIn(credential, json.dumps(status, sort_keys=True))
+            self.assertEqual(status["unreadable_records"][0]["schema_version"], "[redacted]")
 
     def test_a_healthy_store_reports_nothing_unreadable(self) -> None:
         # Overroute guard: the count must stay zero for an ordinary store, or

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -206,6 +206,56 @@ class MemoryContractTests(unittest.TestCase):
             self.assertNotIn(opaque_summary, json.dumps(approved, sort_keys=True))
             self.assertNotIn(opaque_tag.lower(), json.dumps(approved, sort_keys=True).lower())
 
+    def test_unknown_credential_label_is_redacted_before_candidate_and_review_persistence(self) -> None:
+        credential = "credential:" + "a" * 40
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+
+            captured = capture_project_memory_candidate(paths, credential)
+            candidate = captured["candidate"]
+            candidate_path = paths.memory_dir / "candidates" / f"{candidate['candidate_id']}.json"
+
+            self.assertEqual(candidate["safety"]["status"], "needs_review")
+            self.assertFalse(captured["auto_approved"])
+            self.assertNotIn(credential, json.dumps(captured, sort_keys=True))
+            self.assertNotIn(credential, candidate_path.read_text(encoding="utf-8"))
+            self.assertNotIn(credential, json.dumps(build_project_memory_review(paths), sort_keys=True))
+
+    def test_retirement_masks_credential_shaped_legacy_filenames_and_ids(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            captured = capture_project_memory_candidate(paths, "Expired retirement security fixture", ttl_days=1)
+            record = dict(captured["record"])
+            expires_at = datetime.fromisoformat(str(record["ttl"]["expires_at"]).replace("Z", "+00:00"))
+            record["record_id"] = credential
+            records_dir = paths.memory_dir / "records"
+            credential_path = records_dir / f"{credential}.json"
+            credential_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            corrupt_path = records_dir / f"{credential}-corrupt.json"
+            corrupt_path.write_text("{", encoding="utf-8")
+
+            report = build_memory_retirement(paths, now=expires_at + timedelta(days=1))
+
+            self.assertNotIn(credential, json.dumps(report, sort_keys=True))
+
+            retired_at = (expires_at + timedelta(days=1)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+            compact = retired_at.replace("-", "").replace(":", "")
+            archive_dir = paths.memory_dir / "archive"
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            (archive_dir / f"{credential}.{compact}.json").write_text(
+                json.dumps(record, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
+            applied = apply_memory_retirement(paths, now=expires_at + timedelta(days=1))
+            journal = archive_dir / "retirements.jsonl"
+
+            self.assertNotIn(credential, json.dumps(applied, sort_keys=True))
+            self.assertNotIn(credential, journal.read_text(encoding="utf-8") if journal.exists() else "")
+
     def test_recall_rescans_legacy_source_without_rewriting_the_record(self) -> None:
         credential = "gh" + "u_" + "a" * 36
         with TemporaryDirectory() as tmp:
@@ -479,6 +529,28 @@ class MemoryContractTests(unittest.TestCase):
             self.assertEqual(recall["included_records"][0]["summary"], summary)
             self.assertEqual(recall["included_records"][0]["tags"], ["token-based", "secret-management"])
             self.assertEqual(validate_project_memory_recall_pack(recall), [])
+
+    def test_safe_identifier_and_path_shapes_remain_visible_in_auto_safe_memory(self) -> None:
+        sha224 = "0123456789AbCdEf0123456789aBcDeF0123456789AbCdEf01234567"
+        sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        values = (
+            sha224,
+            "HTTPServerConfigurationV2ProjectManager",
+            "@scope/HermesAgentRuntimeV2PackageManager",
+            "packages/HermesAgentRuntimeV2PackageManager/src",
+            "https://example.com/releases/HermesAgentRuntimeV2PackageManager",
+            f"https://example.com/artifact?id={sha256}",
+        )
+        for value in values:
+            with self.subTest(value=value), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                write_setup_profile(paths, memory_mode="auto-safe")
+
+                captured = capture_project_memory_candidate(paths, value)
+
+                self.assertTrue(captured["auto_approved"])
+                self.assertEqual(captured["candidate"]["summary"], value)
+                self.assertEqual(captured["record"]["summary"], value)
 
     def test_recall_pack_validator_rejects_credential_shaped_mapping_keys(self) -> None:
         credential = "gh" + "u_" + "a" * 36

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -276,8 +276,8 @@ class MemoryContractTests(unittest.TestCase):
                     action(paths, selector)
                 self.assertNotIn(selector, str(candidate_error.exception))
 
-    def test_unknown_credential_label_is_redacted_before_candidate_and_review_persistence(self) -> None:
-        credential = "credential:" + "a" * 40
+    def test_qualified_credential_label_is_redacted_before_candidate_and_review_persistence(self) -> None:
+        credential = "access_key:" + "a" * 40
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
             write_setup_profile(paths, memory_mode="auto-safe")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -217,6 +217,7 @@ class MemoryContractTests(unittest.TestCase):
             "abcdefghijklmnopqrstuvwxyzaaaaaaaa",
             "ABCDE.FGHIJ.KLMNO.PQRSTUVWXYZaBcdef",
             "abcdefgh.ijklmnop.qrstuvwx.yzabcdef",
+            "QwertyuiopaAsdfghjklmObservation",
         )
         for encoded in encoded_values:
             with self.subTest(encoded=encoded[:8]), TemporaryDirectory() as tmp:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -291,17 +291,73 @@ class MemoryContractTests(unittest.TestCase):
                 executor_target=credential,
                 session_id=credential,
                 scope_kind="run",
-                scope_ref=credential,
-                observer=credential,
-                observed=credential,
+                scope_ref="safe-run",
+                observer="hermes",
+                observed="codex",
             )
             serialized = json.dumps(recall, sort_keys=True)
 
             self.assertNotIn(credential, serialized)
             self.assertEqual(recall["executor_target"], "redacted")
             self.assertEqual(recall["session_id"], "redacted")
-            self.assertEqual(recall["scope"], {"kind": "run", "ref": "redacted"})
-            self.assertEqual(recall["perspective"], {"observer": "redacted", "observed": "redacted"})
+            self.assertEqual(recall["scope"], {"kind": "run", "ref": "safe-run"})
+            self.assertEqual(recall["perspective"], {"observer": "hermes", "observed": "codex"})
+
+    def test_unsafe_recall_scope_selector_cannot_alias_redacted_scope(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            captured = capture_project_memory_candidate(
+                paths,
+                "Redacted scope alias fixture",
+                scope_kind="run",
+                scope_ref="redacted",
+            )
+            self.assertTrue(captured["auto_approved"])
+
+            with self.assertRaisesRegex(ValueError, "selector") as caught:
+                build_project_memory_recall_pack(
+                    paths,
+                    "scope alias fixture",
+                    scope_kind="run",
+                    scope_ref=credential,
+                )
+
+            self.assertNotIn(credential, str(caught.exception))
+
+    def test_unsafe_recall_perspective_selector_cannot_alias_redacted_actor(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            captured = capture_project_memory_candidate(
+                paths,
+                "Redacted perspective alias fixture",
+                observer="redacted",
+                observed="redacted",
+            )
+            self.assertTrue(captured["auto_approved"])
+
+            with self.assertRaisesRegex(ValueError, "selector") as caught:
+                build_project_memory_recall_pack(
+                    paths,
+                    "perspective alias fixture",
+                    observer=credential,
+                    observed=credential,
+                )
+
+            self.assertNotIn(credential, str(caught.exception))
+
+    def test_unsafe_recall_query_intent_error_does_not_echo_value(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+            with self.assertRaises(ValueError) as caught:
+                build_project_memory_recall_pack(paths, "safe query", query_intent=credential)
+
+            self.assertNotIn(credential, str(caught.exception))
 
     def test_replay_projection_uses_sanitized_source_class_from_evaluation(self) -> None:
         credential = "gh" + "u_" + "a" * 36

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -216,6 +216,7 @@ class MemoryContractTests(unittest.TestCase):
             "abcdefghijklmnopqrstuvwxyzaaaaaa",
             "abcdefghijklmnopqrstuvwxyzaaaaaaaa",
             "ABCDE.FGHIJ.KLMNO.PQRSTUVWXYZaBcdef",
+            "abcdefgh.ijklmnop.qrstuvwx.yzabcdef",
         )
         for encoded in encoded_values:
             with self.subTest(encoded=encoded[:8]), TemporaryDirectory() as tmp:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -277,6 +277,22 @@ class MemoryContractTests(unittest.TestCase):
             self.assertNotIn(credential, str(caught.exception))
             self.assertFalse((paths.memory_dir / "records").exists())
 
+    def test_credential_shaped_candidate_id_never_reaches_review_paths_or_errors(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "Safe candidate id fixture")
+            candidate = dict(captured["candidate"])
+            candidate["candidate_id"] = credential
+            unsafe_path = paths.memory_dir / "candidates" / f"{credential}.json"
+            unsafe_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            with self.assertRaises(ValueError) as caught:
+                reject_project_memory_candidate(paths, credential)
+
+            self.assertNotIn(credential, str(caught.exception))
+            self.assertFalse((paths.memory_dir / "reviews").exists())
+
     def test_excluded_legacy_scope_never_leaks_through_replay_evidence(self) -> None:
         credential = "gh" + "u_" + "a" * 36
         with TemporaryDirectory() as tmp:
@@ -321,6 +337,23 @@ class MemoryContractTests(unittest.TestCase):
             self.assertNotIn(credential, json.dumps(lineage, sort_keys=True))
             self.assertNotIn(credential, json.dumps(perspectives, sort_keys=True))
 
+            wrapper = {
+                "schema_version": "memory_snapshot/v1",
+                "scope": {"kind": "project", "ref": credential},
+                "claim_boundary": credential,
+                "items": [
+                    {
+                        "item_id": credential,
+                        "key": credential,
+                        "summary": "Safe wrapper item",
+                        "scope": {"kind": "project", "ref": credential},
+                        "replay_evaluation": {"artifact_identity": {"scope": {"ref": credential}}},
+                    }
+                ],
+            }
+            wrapper_inspection = build_memory_inspection(paths, wrapper_snapshot=wrapper)
+            self.assertNotIn(credential, json.dumps(wrapper_inspection, sort_keys=True))
+
     def test_project_memory_auto_safe_policy_auto_approves_safe_candidates(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
@@ -352,6 +385,36 @@ class MemoryContractTests(unittest.TestCase):
             self.assertEqual(recall["included_records"][0]["summary"], summary)
             self.assertEqual(recall["included_records"][0]["tags"], ["token-based", "secret-management"])
             self.assertEqual(validate_project_memory_recall_pack(recall), [])
+
+    def test_recall_pack_validator_rejects_credential_shaped_mapping_keys(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            capture_project_memory_candidate(paths, "Safe nested-key handoff fixture")
+            recall = build_project_memory_recall_pack(paths, "Safe nested-key handoff fixture")
+            self.assertTrue(recall["included_records"])
+            evaluation = recall["included_records"][0]["replay_evaluation"]
+            evaluation["artifact_identity"]["nested"] = {credential: "safe-value"}
+
+            errors = validate_project_memory_recall_pack(recall)
+
+            self.assertTrue(errors)
+            self.assertNotIn(credential, json.dumps(errors, sort_keys=True))
+
+    def test_status_masks_legacy_credential_shaped_candidate_status_keys(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            candidate = capture_project_memory_candidate(paths, "Safe status fixture", force_review=True)["candidate"]
+            candidate_path = paths.memory_dir / "candidates" / f"{candidate['candidate_id']}.json"
+            legacy = json.loads(candidate_path.read_text(encoding="utf-8"))
+            legacy["status"] = credential
+            candidate_path.write_text(json.dumps(legacy, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            status = build_project_memory_status(paths)
+
+            self.assertNotIn(credential, json.dumps(status, sort_keys=True))
 
     def test_structural_capture_metadata_rejects_credentials_without_serializing_them(self) -> None:
         credential = "gh" + "u_" + "a" * 36

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -338,13 +338,19 @@ class MemoryContractTests(unittest.TestCase):
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
             write_setup_profile(paths, memory_mode="auto-safe")
 
-            captured = capture_project_memory_candidate(paths, summary)
+            captured = capture_project_memory_candidate(
+                paths,
+                summary,
+                tags=["token-based", "secret-management"],
+            )
 
             self.assertTrue(captured["auto_approved"])
             self.assertEqual(captured["candidate"]["summary"], summary)
             self.assertEqual(captured["record"]["summary"], summary)
+            self.assertEqual(captured["record"]["tags"], ["token-based", "secret-management"])
             recall = build_project_memory_recall_pack(paths, "parsing policy")
             self.assertEqual(recall["included_records"][0]["summary"], summary)
+            self.assertEqual(recall["included_records"][0]["tags"], ["token-based", "secret-management"])
             self.assertEqual(validate_project_memory_recall_pack(recall), [])
 
     def test_structural_capture_metadata_rejects_credentials_without_serializing_them(self) -> None:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -214,6 +214,7 @@ class MemoryContractTests(unittest.TestCase):
             "ABCDEFGHIJKLMNOPQRSTUVWX12345678",
             "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz",
             "abcdefghijklmnopqrstuvwxyzaaaaaa",
+            "abcdefghijklmnopqrstuvwxyzaaaaaaaa",
             "ABCDE.FGHIJ.KLMNO.PQRSTUVWXYZaBcdef",
         )
         for encoded in encoded_values:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -27,6 +27,7 @@ from omh.memory import (
     approve_project_memory_candidate,
     build_handoff_context_pack,
     build_memory_inspection,
+
     apply_memory_retirement,
     build_memory_retirement,
     build_memory_review_card,
@@ -137,7 +138,15 @@ class MemoryContractTests(unittest.TestCase):
         credentials = (
             AWS_ACCESS_KEY_ID,
             "gh" + "p_" + "a" * 36,
+            "gh" + "u_" + "a" * 36,
+            "github_pat_" + "a" * 24,
+            "glpat-" + "a" * 24,
+            "npm_" + "a" * 36,
+            "hf_" + "a" * 24,
             "sk" + "-" + "a" * 48,
+            "sk_" + "live_" + "a" * 32,
+            "ya29." + "a" * 40,
+            "Bearer synthetic-credential-value",
             "https://user:pass@example.com",
             "-----BEGIN PRIVATE KEY-----",
         )
@@ -166,6 +175,147 @@ class MemoryContractTests(unittest.TestCase):
                 self.assertNotIn(credential, json.dumps(rejected, sort_keys=True))
                 self.assertFalse((paths.memory_dir / "records").exists())
 
+    def test_opaque_values_are_classified_before_tag_normalization_and_redacted_from_review(self) -> None:
+        opaque_summary = "Ab3dEf4Ghi5Jk6Lm7No8Pq9Rs0Tu1Vw2Xy3Z"
+        opaque_tag = "AbCdEfGhIjKlMnOpQrSt_-UvWxYzAbCdEf"
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+
+            captured = capture_project_memory_candidate(
+                paths,
+                opaque_summary,
+                tags=[opaque_tag],
+                source="cli",
+            )
+            candidate = captured["candidate"]
+            review = build_project_memory_review(paths, candidate_id=candidate["candidate_id"])
+
+            self.assertEqual(candidate["safety"]["status"], "needs_review")
+            self.assertFalse(captured["auto_approved"])
+            self.assertEqual(candidate["summary"], "[redacted]")
+            self.assertEqual(candidate["tags"], ["[redacted]"])
+            self.assertNotIn(opaque_summary, json.dumps(captured, sort_keys=True))
+            self.assertNotIn(opaque_tag.lower(), json.dumps(captured, sort_keys=True).lower())
+            self.assertNotIn(opaque_summary, json.dumps(review, sort_keys=True))
+            self.assertNotIn(opaque_tag.lower(), json.dumps(review, sort_keys=True).lower())
+
+            approved = approve_project_memory_candidate(paths, candidate["candidate_id"])
+            self.assertEqual(approved["record"]["summary"], "[redacted]")
+            self.assertEqual(approved["record"]["tags"], ["[redacted]"])
+            self.assertNotIn(opaque_summary, json.dumps(approved, sort_keys=True))
+            self.assertNotIn(opaque_tag.lower(), json.dumps(approved, sort_keys=True).lower())
+
+    def test_recall_rescans_legacy_source_without_rewriting_the_record(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            captured = capture_project_memory_candidate(
+                paths,
+                "Legacy source metadata recall fixture",
+                source="cli",
+            )
+            record_id = captured["record"]["record_id"]
+            record_path = paths.memory_dir / "records" / f"{record_id}.json"
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+            record["source"] = credential
+            record_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            legacy_bytes = record_path.read_bytes()
+
+            recall = build_project_memory_recall_pack(paths, "legacy source metadata")
+
+            self.assertEqual(recall["record_count"], 0)
+            self.assertEqual(recall["excluded_records"][0]["reason"], "safety_blocked_in_source")
+            self.assertNotIn(credential, json.dumps(recall, sort_keys=True))
+            self.assertEqual(record_path.read_bytes(), legacy_bytes)
+
+    def test_legacy_candidate_review_and_rejection_mask_protected_fields(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "Safe legacy candidate")
+            candidate_id = captured["candidate"]["candidate_id"]
+            candidate_path = paths.memory_dir / "candidates" / f"{candidate_id}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            candidate["summary"] = credential
+            candidate["record_type"] = credential
+            candidate["created_at"] = credential
+            candidate["duplicate_of"] = credential
+            candidate["time_sensitivity"] = {"next_action": credential}
+            candidate["tags"] = [credential]
+            candidate["source"] = credential
+            candidate["source_ref"] = credential
+            candidate["source_evidence"] = {credential: {"nested": credential}}
+            candidate["scope"]["ref"] = credential
+            candidate["perspective"] = {"observer": "hermes", "observed": credential}
+            candidate["safety"]["detail"] = credential
+            candidate[credential] = credential
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            review = build_project_memory_review(paths, candidate_id=candidate_id)
+            rejected = reject_project_memory_candidate(paths, candidate_id, reason=credential)
+
+            self.assertNotIn(credential, json.dumps(review, sort_keys=True))
+            self.assertNotIn(credential, json.dumps(rejected, sort_keys=True))
+            self.assertNotIn(credential, candidate_path.read_text(encoding="utf-8"))
+
+    def test_legacy_candidate_approval_rescans_all_renderable_fields(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            captured = capture_project_memory_candidate(paths, "Safe legacy approval candidate")
+            candidate_id = captured["candidate"]["candidate_id"]
+            candidate_path = paths.memory_dir / "candidates" / f"{candidate_id}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            candidate["time_sensitivity"] = {"reason": credential}
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            with self.assertRaises(ValueError) as caught:
+                approve_project_memory_candidate(paths, candidate_id)
+
+            self.assertNotIn(credential, str(caught.exception))
+            self.assertFalse((paths.memory_dir / "records").exists())
+
+    def test_excluded_legacy_scope_never_leaks_through_replay_evidence(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            captured = capture_project_memory_candidate(paths, "Safe scope replay fixture")
+            record_id = captured["record"]["record_id"]
+            record_path = paths.memory_dir / "records" / f"{record_id}.json"
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+            record["scope"]["ref"] = credential
+            record_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            legacy_bytes = record_path.read_bytes()
+
+            recall = build_project_memory_recall_pack(paths, "scope replay fixture")
+
+            self.assertEqual(recall["record_count"], 0)
+            self.assertNotIn(credential, json.dumps(recall, sort_keys=True))
+            self.assertEqual(record_path.read_bytes(), legacy_bytes)
+
+    def test_legacy_record_inspection_views_mask_structural_credentials(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+            captured = capture_project_memory_candidate(paths, "Safe inspection fixture")
+            record_id = captured["record"]["record_id"]
+            record_path = paths.memory_dir / "records" / f"{record_id}.json"
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+            record["scope"]["ref"] = credential
+            record["derived_from"] = [credential]
+            record["perspective"] = {"observer": "hermes", "observed": credential}
+            record_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            lineage = memory_workflow.build_memory_lineage(paths, record_id)
+            perspectives = memory_workflow.build_memory_perspectives(paths)
+
+            self.assertNotIn(credential, json.dumps(lineage, sort_keys=True))
+            self.assertNotIn(credential, json.dumps(perspectives, sort_keys=True))
+
     def test_project_memory_auto_safe_policy_auto_approves_safe_candidates(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
@@ -176,6 +326,74 @@ class MemoryContractTests(unittest.TestCase):
             self.assertTrue(captured["auto_approved"])
             self.assertEqual(captured["record"]["schema_version"], "project_memory_record/v2")
             self.assertEqual(build_project_memory_status(paths)["counts"]["approved_records"], 1)
+
+    def test_safe_credential_vocabulary_remains_visible_in_auto_safe_memory(self) -> None:
+        summary = "Use token-based parsing with the secret-management policy"
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+
+            captured = capture_project_memory_candidate(paths, summary)
+
+            self.assertTrue(captured["auto_approved"])
+            self.assertEqual(captured["candidate"]["summary"], summary)
+            self.assertEqual(captured["record"]["summary"], summary)
+            recall = build_project_memory_recall_pack(paths, "parsing policy")
+            self.assertEqual(recall["included_records"][0]["summary"], summary)
+            self.assertEqual(validate_project_memory_recall_pack(recall), [])
+
+    def test_structural_capture_metadata_rejects_credentials_without_serializing_them(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        cases = (
+            {"record_type": credential},
+            {"scope_kind": credential},
+            {"scope_ref": credential},
+            {"retention_class": credential},
+            {"stale_after": credential},
+            {"observed": credential},
+            {"derived_from": [credential]},
+        )
+        for kwargs in cases:
+            with self.subTest(field=next(iter(kwargs))), TemporaryDirectory() as tmp:
+                paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+                write_setup_profile(paths, memory_mode="auto-safe")
+
+                captured = capture_project_memory_candidate(paths, "Safe summary", **kwargs)
+
+                self.assertFalse(captured["captured"])
+                self.assertFalse(captured["auto_approved"])
+                self.assertEqual(captured["reason"], "unsafe_project_memory_metadata")
+                self.assertNotIn(credential, json.dumps(captured, sort_keys=True))
+                self.assertFalse((paths.memory_dir / "candidates").exists())
+                self.assertFalse((paths.memory_dir / "records").exists())
+
+    def test_reviewer_metadata_cannot_serialize_credentials(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            approve_candidate = capture_project_memory_candidate(paths, "Approve fixture")["candidate"]
+
+            with self.assertRaises(ValueError) as approval_error:
+                approve_project_memory_candidate(
+                    paths,
+                    approve_candidate["candidate_id"],
+                    approved_by=credential,
+                )
+
+            self.assertNotIn(credential, str(approval_error.exception))
+            self.assertFalse((paths.memory_dir / "records").exists())
+
+            reject_candidate = capture_project_memory_candidate(paths, "Reject fixture")["candidate"]
+            rejected = reject_project_memory_candidate(
+                paths,
+                reject_candidate["candidate_id"],
+                rejected_by=credential,
+                reason=credential,
+            )
+
+            self.assertNotIn(credential, json.dumps(rejected, sort_keys=True))
+            candidate_path = paths.memory_dir / "candidates" / f"{reject_candidate['candidate_id']}.json"
+            self.assertNotIn(credential, candidate_path.read_text(encoding="utf-8"))
 
     def test_staleness_uses_injected_now_and_utc_naive_rule(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -213,6 +213,8 @@ class MemoryContractTests(unittest.TestCase):
             "ABCDEFGHIJKLMNOPQRSTUVWXYZABabcd",
             "ABCDEFGHIJKLMNOPQRSTUVWX12345678",
             "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz",
+            "abcdefghijklmnopqrstuvwxyzaaaaaa",
+            "ABCDE.FGHIJ.KLMNO.PQRSTUVWXYZaBcdef",
         )
         for encoded in encoded_values:
             with self.subTest(encoded=encoded[:8]), TemporaryDirectory() as tmp:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -210,6 +210,9 @@ class MemoryContractTests(unittest.TestCase):
         encoded_values = (
             "mQvHzLrNaPeTgWuYbJxDcFkSiOoUaZcV",
             "JBSWYDPFJBSWYDPFJBSWYDPFJBSWYDPF",
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZABabcd",
+            "ABCDEFGHIJKLMNOPQRSTUVWX12345678",
+            "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz",
         )
         for encoded in encoded_values:
             with self.subTest(encoded=encoded[:8]), TemporaryDirectory() as tmp:
@@ -226,6 +229,28 @@ class MemoryContractTests(unittest.TestCase):
                 self.assertNotIn(encoded, json.dumps(captured, sort_keys=True))
                 self.assertNotIn(encoded, candidate_path.read_text(encoding="utf-8"))
                 self.assertFalse((paths.memory_dir / "records").exists())
+
+    def test_separator_split_opaque_structural_selectors_fail_closed_without_echo(self) -> None:
+        selector = "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz"
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+
+            captured = capture_project_memory_candidate(paths, "safe summary", scope_ref=selector)
+            self.assertFalse(captured["captured"])
+            self.assertFalse(captured["auto_approved"])
+            self.assertNotIn(selector, json.dumps(captured, sort_keys=True))
+            self.assertFalse((paths.memory_dir / "candidates").exists())
+            self.assertFalse((paths.memory_dir / "records").exists())
+
+            with self.assertRaises(ValueError) as recall_error:
+                build_project_memory_recall_pack(paths, scope_ref=selector)
+            self.assertNotIn(selector, str(recall_error.exception))
+
+            for action in (approve_project_memory_candidate, reject_project_memory_candidate):
+                with self.subTest(action=action.__name__), self.assertRaises(ValueError) as candidate_error:
+                    action(paths, selector)
+                self.assertNotIn(selector, str(candidate_error.exception))
 
     def test_unknown_credential_label_is_redacted_before_candidate_and_review_persistence(self) -> None:
         credential = "credential:" + "a" * 40

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -234,6 +234,25 @@ class MemoryContractTests(unittest.TestCase):
                 self.assertNotIn(encoded, candidate_path.read_text(encoding="utf-8"))
                 self.assertFalse((paths.memory_dir / "records").exists())
 
+    def test_restricted_provider_key_is_blocked_before_any_raw_persistence(self) -> None:
+        credential = "rk_" + "live_" + "a" * 32
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            write_setup_profile(paths, memory_mode="auto-safe")
+
+            captured = capture_project_memory_candidate(paths, credential, source="cli")
+
+            self.assertEqual(captured["candidate"]["safety"]["status"], "blocked")
+            self.assertFalse(captured["auto_approved"])
+            self.assertNotIn(credential, json.dumps(captured, sort_keys=True))
+            persisted = "\n".join(
+                path.read_text(encoding="utf-8")
+                for path in paths.memory_dir.rglob("*")
+                if path.is_file()
+            )
+            self.assertNotIn(credential, persisted)
+            self.assertFalse((paths.memory_dir / "records").exists())
+
     def test_separator_split_opaque_structural_selectors_fail_closed_without_echo(self) -> None:
         selector = "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz"
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -182,10 +182,79 @@ class MemoryBatchTests(TestCase):
             candidate["items"][0]["scope"]["ref"] = credential
             candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-            with self.assertRaises(ValueError) as caught:
-                apply_approved_memory_update_batch(paths, staged["batch_id"])
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
 
-            self.assertNotIn(credential, str(caught.exception))
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "review_linkage_invalid")
+            self.assertNotIn(credential, json.dumps(result, sort_keys=True))
+            self.assertFalse((paths.memory_dir / "scopes").exists())
+
+    def test_apply_binds_the_reviewed_operation_before_any_write(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            staged = self._stage_and_remember(paths, _batch("tampered-op"))
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            candidate["items"][0]["op"] = "forget"
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "review_linkage_invalid")
+            self.assertFalse((paths.memory_dir / "scopes").exists())
+
+    def test_apply_binds_reviewed_target_before_any_write(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            staged = self._stage_and_remember(paths, _batch("tampered-target"))
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            candidate["items"][0]["target_ref"] = "different-safe-target"
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "review_linkage_invalid")
+            self.assertFalse((paths.memory_dir / "scopes").exists())
+
+    def test_apply_binds_reviewed_source_scope_before_any_write(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            batch = _batch("tampered-source-scope")
+            updates = batch["updates"]
+            assert isinstance(updates, list)
+            update = updates[0]
+            assert isinstance(update, dict)
+            update["op"] = "change_scope"
+            update["from_scope"] = {"kind": "project", "ref": "default"}
+            update["to_scope"] = {"kind": "thread", "ref": "thread-1"}
+            staged = self._stage_and_remember(paths, batch)
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            candidate["items"][0]["from_scope"] = {"kind": "project", "ref": "different-project"}
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "review_linkage_invalid")
+            self.assertFalse((paths.memory_dir / "scopes").exists())
+
+    def test_apply_binds_reviewed_retention_before_any_write(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            staged = self._stage_and_remember(paths, _batch("tampered-retention"))
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            candidate["items"][0]["retention"]["class"] = "durable"
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "review_linkage_invalid")
             self.assertFalse((paths.memory_dir / "scopes").exists())
 
     def test_refused_or_deferred_items_never_write(self) -> None:

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -433,6 +433,63 @@ class MemoryBatchTests(TestCase):
             self.assertEqual(result["reason_code"], "scope_precondition_changed")
             self.assertEqual(scope_path.read_bytes(), changed_bytes)
 
+    def test_multiscope_preflight_rejects_all_drift_before_removing_source(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            source_path = paths.memory_dir / "scopes" / "project.json"
+            source_path.parent.mkdir(parents=True)
+            source = {
+                "schema_version": "omh_memory_scope/v2",
+                "scope": {"kind": "project", "ref": "default"},
+                "items": {
+                    "live-target": {
+                        "item_id": "live-item",
+                        "revision": 1,
+                        "key": "live_key",
+                        "summary": "Original reviewed value",
+                        "value": "original",
+                    }
+                },
+                "tombstones": {},
+            }
+            source_path.write_text(json.dumps(source, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            batch = _batch("live-target")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            update = updates[0]
+            update.update(
+                {
+                    "op": "change_scope",
+                    "from_scope": {"kind": "project", "ref": "default"},
+                    "to_scope": {"kind": "run", "ref": "destination"},
+                }
+            )
+            staged = self._stage_and_remember(paths, batch)
+            source_bytes = source_path.read_bytes()
+            destination_path = paths.memory_dir / "scopes" / "runs" / "destination.json"
+            destination_path.parent.mkdir(parents=True)
+            destination_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_memory_scope/v2",
+                        "scope": {"kind": "run", "ref": "destination"},
+                        "items": {"live-item": {"item_id": "live-item", "value": "concurrent"}},
+                        "tombstones": {},
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "scope_precondition_changed")
+            self.assertEqual(source_path.read_bytes(), source_bytes)
+
     def test_stage_rejects_credential_shaped_legacy_item_id_without_echo(self) -> None:
         credential = "gh" + "u_" + "a" * 36
         with TemporaryDirectory() as home:

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import multiprocessing
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
@@ -81,8 +82,16 @@ class MemoryBatchTests(TestCase):
             self.assertTrue(staged["batch_id"].startswith("batch_"))
             self.assertNotIn(item["item_id"], {row["item_id"] for row in build_handoff_context_pack(paths)["included_context"]})
 
-            applied = apply_approved_memory_update_batch(paths, staged["batch_id"])
-            repeated = apply_approved_memory_update_batch(paths, staged["batch_id"])
+            applied = apply_approved_memory_update_batch(
+                paths,
+                staged["batch_id"],
+                now=datetime(2026, 9, 6, 1, 0, tzinfo=timezone.utc),
+            )
+            repeated = apply_approved_memory_update_batch(
+                paths,
+                staged["batch_id"],
+                now=datetime(2026, 9, 6, 2, 0, tzinfo=timezone.utc),
+            )
             handoff = build_handoff_context_pack(paths)
             receipt = applied["receipt"]
 
@@ -94,6 +103,36 @@ class MemoryBatchTests(TestCase):
             self.assertNotIn("summary", json.dumps(receipt))
             self.assertNotIn("hash", json.dumps(receipt))
             self.assertNotIn(str(paths.memory_dir), json.dumps(receipt))
+
+    def test_later_reviewed_update_replaces_an_item_written_by_an_earlier_batch(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            first = self._stage_and_remember(paths, _batch("first-record"))
+            self.assertTrue(apply_approved_memory_update_batch(paths, first["batch_id"])["applied"])
+            item_id = first["items"][0]["item_id"]
+
+            second_batch = _batch(item_id)
+            second_updates = second_batch["updates"]
+            self.assertIsInstance(second_updates, list)
+            assert isinstance(second_updates, list)
+            second_update = second_updates[0]
+            self.assertIsInstance(second_update, dict)
+            assert isinstance(second_update, dict)
+            second_update.update(
+                {
+                    "key": "first_record",
+                    "value": "second synthetic value",
+                    "summary": "Replace the first synthetic value",
+                }
+            )
+            second = self._stage_and_remember(paths, second_batch)
+
+            applied = apply_approved_memory_update_batch(paths, second["batch_id"])
+            scope = json.loads((paths.memory_dir / "scopes" / "project.json").read_text(encoding="utf-8"))
+
+            self.assertTrue(applied["applied"])
+            self.assertEqual(scope["items"][item_id]["value"], "second synthetic value")
+            self.assertEqual(scope["items"][item_id]["batch_id"], second["batch_id"])
 
     def test_stage_rejects_unsafe_content_without_writing_a_candidate(self) -> None:
         with TemporaryDirectory() as home:
@@ -331,6 +370,40 @@ class MemoryBatchTests(TestCase):
             self.assertFalse((paths.memory_dir / "scopes").exists())
             self.assertFalse((paths.memory_dir / "operations" / "op_apply_forged.json").exists())
 
+    def test_apply_rejects_operation_id_owned_by_another_reviewed_batch(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            first = self._stage_and_remember(paths, _batch("first-operation-owner"))
+            second = stage_memory_update_batch(
+                paths,
+                _batch(
+                    "second-operation-owner",
+                    scope={"kind": "thread", "ref": "second-thread"},
+                ),
+            )
+            second_path = paths.memory_dir / "candidates" / f"{second['batch_id']}.json"
+            second_candidate = json.loads(second_path.read_text(encoding="utf-8"))
+            second_candidate["apply_operation_id"] = first["operation_id"]
+            second_path.write_text(
+                json.dumps(second_candidate, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            review_memory_update_batch(
+                paths,
+                second["batch_id"],
+                {second["items"][0]["item_id"]: "remember"},
+                reviewer_label="operator-label",
+            )
+            self.assertTrue(apply_approved_memory_update_batch(paths, first["batch_id"])["applied"])
+
+            result = apply_approved_memory_update_batch(paths, second["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "operation_identity_conflict")
+            self.assertFalse(
+                (paths.memory_dir / "scopes" / "threads" / "second-thread.json").exists()
+            )
+
     def test_review_retry_overwrites_unsealed_orphan_authorization(self) -> None:
         with TemporaryDirectory() as home:
             paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
@@ -437,6 +510,56 @@ class MemoryBatchTests(TestCase):
             self.assertFalse(result["applied"])
             self.assertEqual(result["reason_code"], "scope_precondition_changed")
             self.assertEqual(scope_path.read_bytes(), changed_bytes)
+
+    def test_change_scope_rejects_source_scope_identity_drift_after_review(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            source_path = paths.memory_dir / "scopes" / "project.json"
+            source_path.parent.mkdir(parents=True)
+            source = {
+                "schema_version": "omh_memory_scope/v2",
+                "scope": {"kind": "project", "ref": "default"},
+                "items": {
+                    "move-target": {
+                        "item_id": "move-item",
+                        "revision": 1,
+                        "key": "move_key",
+                        "summary": "Move reviewed value",
+                        "value": "move value",
+                    }
+                },
+                "tombstones": {},
+            }
+            source_path.write_text(json.dumps(source, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            batch = _batch("move-target")
+            updates = batch["updates"]
+            self.assertIsInstance(updates, list)
+            assert isinstance(updates, list)
+            update = updates[0]
+            self.assertIsInstance(update, dict)
+            assert isinstance(update, dict)
+            update.update(
+                {
+                    "op": "change_scope",
+                    "from_scope": {"kind": "project", "ref": "default"},
+                    "to_scope": {"kind": "thread", "ref": "destination"},
+                    "key": "move_key",
+                    "summary": "Move reviewed value",
+                    "value": "move value",
+                }
+            )
+            staged = self._stage_and_remember(paths, batch)
+            drifted = json.loads(source_path.read_text(encoding="utf-8"))
+            drifted["scope"] = {"kind": "thread", "ref": "other-thread"}
+            source_path.write_text(json.dumps(drifted, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            drifted_bytes = source_path.read_bytes()
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "scope_precondition_changed")
+            self.assertEqual(source_path.read_bytes(), drifted_bytes)
+            self.assertFalse((paths.memory_dir / "scopes" / "threads" / "destination.json").exists())
 
     def test_multiscope_preflight_rejects_all_drift_before_removing_source(self) -> None:
         with TemporaryDirectory() as home:

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -5,12 +5,14 @@ import multiprocessing
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
+from unittest.mock import patch
 
 from _local_package import load_local_package
 from _platform_support import requires_fcntl_locks
 
 load_local_package()
 from omh.paths import resolve_paths
+from omh.workflows import memory_batches as memory_batches_workflow
 from omh.workflows.memory import (
     _memory_snapshots,
     apply_approved_memory_update_batch,
@@ -249,6 +251,174 @@ class MemoryBatchTests(TestCase):
             candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
             candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
             candidate["items"][0]["retention"]["class"] = "durable"
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "review_linkage_invalid")
+            self.assertFalse((paths.memory_dir / "scopes").exists())
+
+    def test_apply_rejects_a_stored_review_whose_decision_was_changed(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            staged = stage_memory_update_batch(paths, _batch("tampered-review-decision"))
+            item_id = staged["items"][0]["item_id"]
+            reviewed = review_memory_update_batch(
+                paths,
+                staged["batch_id"],
+                {item_id: "refuse"},
+                reviewer_label="operator-label",
+            )
+            review_path = paths.memory_dir / "reviews" / f"{reviewed['items'][0]['review_id']}.json"
+            review = json.loads(review_path.read_text(encoding="utf-8"))
+            review["decision"] = "remember"
+            review_path.write_text(json.dumps(review, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "review_linkage_invalid")
+            self.assertFalse((paths.memory_dir / "scopes").exists())
+
+    def test_apply_rejects_changed_stored_review_metadata(self) -> None:
+        mutations = {
+            "reviewer_label": "forged-reviewer",
+            "reviewed_at": "2027-01-01T00:00:00Z",
+            "policy_version": "forged-policy",
+            "forged_authorization": "accepted",
+        }
+        for field, value in mutations.items():
+            with self.subTest(field=field), TemporaryDirectory() as home:
+                paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+                staged = stage_memory_update_batch(paths, _batch(f"tampered-review-{field}"))
+                item_id = staged["items"][0]["item_id"]
+                reviewed = review_memory_update_batch(
+                    paths,
+                    staged["batch_id"],
+                    {item_id: "remember"},
+                    reviewer_label="operator-label",
+                )
+                review_path = paths.memory_dir / "reviews" / f"{reviewed['items'][0]['review_id']}.json"
+                review = json.loads(review_path.read_text(encoding="utf-8"))
+                review[field] = value
+                review_path.write_text(json.dumps(review, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+                self.assertFalse(result["applied"])
+                self.assertEqual(result["reason_code"], "review_linkage_invalid")
+                self.assertFalse((paths.memory_dir / "scopes").exists())
+
+    def test_apply_binds_candidate_control_metadata_before_any_write(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            staged = self._stage_and_remember(paths, _batch("tampered-apply-operation"))
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            candidate["apply_operation_id"] = "op_apply_forged"
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "review_linkage_invalid")
+            self.assertFalse((paths.memory_dir / "scopes").exists())
+            self.assertFalse((paths.memory_dir / "operations" / "op_apply_forged.json").exists())
+
+    def test_review_retry_overwrites_unsealed_orphan_authorization(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            staged = stage_memory_update_batch(paths, _batch("interrupted-review"))
+            item_id = staged["items"][0]["item_id"]
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            real_write = memory_batches_workflow.atomic_write_json
+
+            def interrupt_seal(path, payload, **kwargs):
+                if Path(path) == candidate_path and isinstance(payload, dict) and "review_seals" in payload:
+                    raise RuntimeError("injected candidate seal interruption")
+                return real_write(path, payload, **kwargs)
+
+            with patch.object(memory_batches_workflow, "atomic_write_json", side_effect=interrupt_seal):
+                with self.assertRaisesRegex(RuntimeError, "candidate seal interruption"):
+                    review_memory_update_batch(
+                        paths,
+                        staged["batch_id"],
+                        {item_id: "remember"},
+                        reviewer_label="operator-label",
+                    )
+
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            self.assertNotIn("review_seals", candidate)
+            review_path = paths.memory_dir / "reviews" / f"{candidate['items'][0]['review_id']}.json"
+            orphan = json.loads(review_path.read_text(encoding="utf-8"))
+            orphan["reviewed_at"] = "2030-01-01T00:00:00Z"
+            orphan["forged_authorization"] = "accepted"
+            review_path.write_text(json.dumps(orphan, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            review_memory_update_batch(
+                paths,
+                staged["batch_id"],
+                {item_id: "remember"},
+                reviewer_label="operator-label",
+            )
+            stored = json.loads(review_path.read_text(encoding="utf-8"))
+
+            self.assertNotEqual(stored["reviewed_at"], "2030-01-01T00:00:00Z")
+            self.assertNotIn("forged_authorization", stored)
+            self.assertTrue(apply_approved_memory_update_batch(paths, staged["batch_id"])["applied"])
+
+    def test_apply_rejects_missing_wrong_or_extra_review_seals_before_any_write(self) -> None:
+        for mutation in ("missing", "wrong", "extra"):
+            with self.subTest(mutation=mutation), TemporaryDirectory() as home:
+                paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+                staged = self._stage_and_remember(paths, _batch(f"{mutation}-review-seal"))
+                candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+                candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+                item_id = staged["items"][0]["item_id"]
+                seals = candidate["review_seals"]
+                self.assertIsInstance(seals, dict)
+                if mutation == "missing":
+                    seals.pop(item_id)
+                elif mutation == "wrong":
+                    seals[item_id] = "0" * 64
+                else:
+                    seals["phantom-item"] = "0" * 64
+                candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+                self.assertFalse(result["applied"])
+                self.assertEqual(result["reason_code"], "review_linkage_invalid")
+                self.assertFalse((paths.memory_dir / "scopes").exists())
+
+    def test_apply_binds_full_candidate_item_membership_before_any_write(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            batch = _batch("remember-membership")
+            updates = batch["updates"]
+            if not isinstance(updates, list):
+                self.fail("batch fixture updates must be a list")
+            updates.append(
+                {
+                    "op": "update",
+                    "item_id": "defer-membership",
+                    "scope": {"kind": "project", "ref": "default"},
+                    "key": "defer_membership",
+                    "value": "value for deferred membership",
+                    "summary": "Remember deferred membership",
+                }
+            )
+            staged = stage_memory_update_batch(paths, batch)
+            decisions = {
+                staged["items"][0]["item_id"]: "remember",
+                staged["items"][1]["item_id"]: "defer",
+            }
+            review_memory_update_batch(paths, staged["batch_id"], decisions, reviewer_label="operator-label")
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            removed = candidate["items"].pop()
+            candidate["review_seals"].pop(removed["item_id"])
             candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
             result = apply_approved_memory_update_batch(paths, staged["batch_id"])

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -107,7 +107,12 @@ class MemoryBatchTests(TestCase):
             self.assertFalse(paths.memory_dir.exists())
 
     def test_stage_rejects_structural_credentials_without_writing_a_candidate(self) -> None:
-        for value in ("gh" + "u_" + "a" * 36, "Ab3dEf4G" * 5 + "="):
+        for value in (
+            "gh" + "u_" + "a" * 36,
+            "Ab3dEf4G" * 5 + "=",
+            "mQvHzLrNaPeTgWuYbJxDcFkSiOoUaZcV",
+            "JBSWYDPFJBSWYDPFJBSWYDPFJBSWYDPF",
+        ):
             with self.subTest(value_kind=value[:4]), TemporaryDirectory() as home:
                 paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
                 unsafe = _batch("structural-credential")
@@ -556,6 +561,81 @@ class MemoryBatchTests(TestCase):
             self.assertEqual(result["reason_code"], "scope_precondition_changed")
             self.assertEqual(source_path.read_bytes(), source_bytes)
 
+            destination_path.unlink()
+            recovered = apply_approved_memory_update_batch(paths, staged["batch_id"])
+            self.assertTrue(recovered["applied"])
+
+    def test_multiscope_malformed_destination_is_rejected_before_source_mutation(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            source_path = paths.memory_dir / "scopes" / "project.json"
+            destination_path = paths.memory_dir / "scopes" / "runs" / "destination.json"
+            source_path.parent.mkdir(parents=True)
+            destination_path.parent.mkdir(parents=True)
+            source_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_memory_scope/v2",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "items": {
+                            "move-target": {
+                                "item_id": "move-item",
+                                "revision": 1,
+                                "key": "move_key",
+                                "summary": "Move reviewed value",
+                                "value": "move value",
+                            }
+                        },
+                        "tombstones": {},
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            destination_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_memory_scope/v2",
+                        "scope": {"kind": "run", "ref": "destination"},
+                        "items": [],
+                        "tombstones": {},
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            batch = _batch("move-target")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates[0].update(
+                {
+                    "op": "change_scope",
+                    "from_scope": {"kind": "project", "ref": "default"},
+                    "to_scope": {"kind": "run", "ref": "destination"},
+                    "key": "move_key",
+                }
+            )
+            staged = self._stage_and_remember(paths, batch)
+            source_bytes = source_path.read_bytes()
+            destination_bytes = destination_path.read_bytes()
+
+            first = apply_approved_memory_update_batch(paths, staged["batch_id"])
+            second = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(first["applied"])
+            self.assertEqual(first["reason_code"], "scope_precondition_changed")
+            self.assertEqual(second, first)
+            self.assertEqual(source_path.read_bytes(), source_bytes)
+            self.assertEqual(destination_path.read_bytes(), destination_bytes)
+            self.assertFalse(
+                (paths.memory_dir / "operations" / f"{staged['operation_id']}.json").exists()
+            )
+
     def test_multiscope_retry_recovers_after_first_durable_scope_write(self) -> None:
         with TemporaryDirectory() as home:
             paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
@@ -659,6 +739,63 @@ class MemoryBatchTests(TestCase):
                     "scope": {"kind": "project", "ref": "default"},
                 }
             )
+
+            with self.assertRaisesRegex(ValueError, "ambiguous"):
+                stage_memory_update_batch(paths, batch)
+
+    def test_stage_rejects_duplicate_candidate_item_id_across_scopes(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            scopes = (
+                (
+                    paths.memory_dir / "scopes" / "project.json",
+                    {"kind": "project", "ref": "default"},
+                    "project-target",
+                    "project_key",
+                ),
+                (
+                    paths.memory_dir / "scopes" / "runs" / "run-1.json",
+                    {"kind": "run", "ref": "run-1"},
+                    "run-target",
+                    "run_key",
+                ),
+            )
+            for path, scope, target_ref, key in scopes:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": "omh_memory_scope/v2",
+                            "scope": scope,
+                            "items": {
+                                target_ref: {
+                                    "item_id": "shared-id",
+                                    "revision": 1,
+                                    "key": key,
+                                    "summary": f"Existing {key}",
+                                    "value": f"value for {key}",
+                                }
+                            },
+                            "tombstones": {},
+                        },
+                        indent=2,
+                        sort_keys=True,
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+            batch = {
+                "schema_version": "memory_update_batch/v1",
+                "source_surface": "test",
+                "updates": [
+                    {
+                        "op": "update",
+                        "item_id": target_ref,
+                        "scope": scope,
+                    }
+                    for _path, scope, target_ref, _key in scopes
+                ],
+            }
 
             with self.assertRaisesRegex(ValueError, "ambiguous"):
                 stage_memory_update_batch(paths, batch)

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -826,6 +826,79 @@ class MemoryBatchTests(TestCase):
             self.assertEqual(source["tombstones"]["move-target"]["reason_code"], "scope_changed")
             self.assertIn("move-item", destination["items"])
 
+    def test_multiscope_retry_rejects_scope_identity_drift_after_partial_write(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            source_path = paths.memory_dir / "scopes" / "project.json"
+            source_path.parent.mkdir(parents=True)
+            source_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_memory_scope/v2",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "items": {
+                            "move-target": {
+                                "item_id": "move-item",
+                                "revision": 1,
+                                "key": "move_key",
+                                "summary": "Move reviewed value",
+                                "value": "move value",
+                            }
+                        },
+                        "tombstones": {},
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            batch = _batch("move-target")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates[0].update(
+                {
+                    "op": "change_scope",
+                    "from_scope": {"kind": "project", "ref": "default"},
+                    "to_scope": {"kind": "thread", "ref": "thread-1"},
+                    "key": "move_key",
+                    "summary": "Move reviewed value",
+                    "value": "move value",
+                }
+            )
+            staged = self._stage_and_remember(paths, batch)
+            real_write = memory_batches_workflow.atomic_write_json
+            crashed = False
+
+            def crash_after_first_scope(path, payload, **kwargs):
+                nonlocal crashed
+                real_write(path, payload, **kwargs)
+                if not crashed and "scopes" in Path(path).parts:
+                    crashed = True
+                    raise RuntimeError("injected crash after first durable scope write")
+
+            with patch.object(memory_batches_workflow, "atomic_write_json", crash_after_first_scope):
+                with self.assertRaisesRegex(RuntimeError, "injected crash"):
+                    apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            altered = json.loads(source_path.read_text(encoding="utf-8"))
+            altered["scope"] = {"kind": "thread", "ref": "forged-thread"}
+            source_path.write_text(
+                json.dumps(altered, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            altered_bytes = source_path.read_bytes()
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "scope_precondition_changed")
+            self.assertEqual(source_path.read_bytes(), altered_bytes)
+            self.assertFalse(
+                (paths.memory_dir / "scopes" / "threads" / "thread-1.json").exists()
+            )
+
     @requires_symlinks
     def test_multiscope_rejects_symlinked_destination_parent_without_external_write(self) -> None:
         for timing in ("before_apply", "after_preflight"):

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -368,6 +368,102 @@ class MemoryBatchTests(TestCase):
             self.assertNotIn("forged_authorization", stored)
             self.assertTrue(apply_approved_memory_update_batch(paths, staged["batch_id"])["applied"])
 
+    def test_deleting_or_rewriting_candidate_review_state_cannot_change_a_refusal(self) -> None:
+        for mutation in ("delete_seals", "rewrite_request"):
+            with self.subTest(mutation=mutation), TemporaryDirectory() as home:
+                paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+                staged = stage_memory_update_batch(paths, _batch(f"sealed-refusal-{mutation}"))
+                item_id = staged["items"][0]["item_id"]
+                review_memory_update_batch(
+                    paths,
+                    staged["batch_id"],
+                    {item_id: "refuse"},
+                    reviewer_label="operator-label",
+                )
+                candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+                candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+                candidate.pop("review_seals")
+                if mutation == "rewrite_request":
+                    candidate["review_request"]["decisions"][item_id] = "remember"
+                candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                with self.assertRaisesRegex(ValueError, "immutable"):
+                    review_memory_update_batch(
+                        paths,
+                        staged["batch_id"],
+                        {item_id: "remember"},
+                        reviewer_label="operator-label",
+                    )
+
+                result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+                self.assertFalse(result["applied"])
+                self.assertEqual(result["reason_code"], "review_linkage_invalid")
+                self.assertFalse((paths.memory_dir / "scopes").exists())
+
+    def test_apply_rejects_scope_drift_since_staging_before_overwrite(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            scope_path = paths.memory_dir / "scopes" / "project.json"
+            scope_path.parent.mkdir(parents=True)
+            original = {
+                "schema_version": "omh_memory_scope/v2",
+                "scope": {"kind": "project", "ref": "default"},
+                "items": {
+                    "live-target": {
+                        "item_id": "live-item",
+                        "revision": 1,
+                        "key": "live_key",
+                        "summary": "Original reviewed value",
+                        "value": "original",
+                    }
+                },
+                "tombstones": {},
+            }
+            scope_path.write_text(json.dumps(original, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            staged = self._stage_and_remember(paths, _batch("live-target"))
+            changed = json.loads(scope_path.read_text(encoding="utf-8"))
+            changed["items"]["live-target"]["revision"] = 2
+            changed["items"]["live-target"]["value"] = "changed-after-review"
+            scope_path.write_text(json.dumps(changed, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            changed_bytes = scope_path.read_bytes()
+
+            result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "scope_precondition_changed")
+            self.assertEqual(scope_path.read_bytes(), changed_bytes)
+
+    def test_stage_rejects_credential_shaped_legacy_item_id_without_echo(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            scope_path = paths.memory_dir / "scopes" / "project.json"
+            scope_path.parent.mkdir(parents=True)
+            scope_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_memory_scope/v2",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "items": {
+                            "legacy-target": {
+                                "item_id": credential,
+                                "key": "safe_key",
+                                "summary": "Safe legacy summary",
+                                "value": "safe legacy value",
+                            }
+                        },
+                        "tombstones": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError) as caught:
+                stage_memory_update_batch(paths, _batch("legacy-target"))
+
+            self.assertNotIn(credential, str(caught.exception))
+            self.assertFalse((paths.memory_dir / "candidates").exists())
+
     def test_apply_rejects_missing_wrong_or_extra_review_seals_before_any_write(self) -> None:
         for mutation in ("missing", "wrong", "extra"):
             with self.subTest(mutation=mutation), TemporaryDirectory() as home:

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -490,6 +490,149 @@ class MemoryBatchTests(TestCase):
             self.assertEqual(result["reason_code"], "scope_precondition_changed")
             self.assertEqual(source_path.read_bytes(), source_bytes)
 
+    def test_multiscope_post_preflight_drift_does_not_remove_source(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            source_path = paths.memory_dir / "scopes" / "project.json"
+            source_path.parent.mkdir(parents=True)
+            source = {
+                "schema_version": "omh_memory_scope/v2",
+                "scope": {"kind": "project", "ref": "default"},
+                "items": {
+                    "live-target": {
+                        "item_id": "live-item",
+                        "revision": 1,
+                        "key": "live_key",
+                        "summary": "Original reviewed value",
+                        "value": "original",
+                    }
+                },
+                "tombstones": {},
+            }
+            source_path.write_text(json.dumps(source, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            batch = _batch("live-target")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates[0].update(
+                {
+                    "op": "change_scope",
+                    "from_scope": {"kind": "project", "ref": "default"},
+                    "to_scope": {"kind": "run", "ref": "destination"},
+                }
+            )
+            staged = self._stage_and_remember(paths, batch)
+            source_bytes = source_path.read_bytes()
+            destination_path = paths.memory_dir / "scopes" / "runs" / "destination.json"
+            calls = 0
+
+            def drift_destination_after_preflight(_name: str) -> None:
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    destination_path.parent.mkdir(parents=True)
+                    destination_path.write_text(
+                        json.dumps(
+                            {
+                                "schema_version": "omh_memory_scope/v2",
+                                "scope": {"kind": "run", "ref": "destination"},
+                                "items": {"live-item": {"item_id": "live-item", "value": "concurrent"}},
+                                "tombstones": {},
+                            },
+                            indent=2,
+                            sort_keys=True,
+                        )
+                        + "\n",
+                        encoding="utf-8",
+                    )
+
+            result = apply_approved_memory_update_batch(
+                paths,
+                staged["batch_id"],
+                write_hook=drift_destination_after_preflight,
+            )
+
+            self.assertFalse(result["applied"])
+            self.assertEqual(result["reason_code"], "scope_precondition_changed")
+            self.assertEqual(source_path.read_bytes(), source_bytes)
+
+    def test_concurrent_add_of_same_logical_target_rejects_second_candidate(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            first = self._stage_and_remember(paths, _batch("shared-target"))
+            second = self._stage_and_remember(paths, _batch("shared-target"))
+
+            self.assertEqual(
+                apply_approved_memory_update_batch(paths, first["batch_id"])["status"],
+                "applied",
+            )
+            rejected = apply_approved_memory_update_batch(paths, second["batch_id"])
+
+            self.assertFalse(rejected["applied"])
+            self.assertEqual(rejected["reason_code"], "scope_precondition_changed")
+            scope = json.loads((paths.memory_dir / "scopes" / "project.json").read_text(encoding="utf-8"))
+            matching = [item for item in scope["items"].values() if item.get("key") == "shared_target"]
+            first_items = first["items"]
+            if not isinstance(first_items, list) or not isinstance(first_items[0], dict):
+                self.fail("staged batch items must contain a mapping")
+            self.assertEqual(len(matching), 1)
+            self.assertEqual(matching[0]["item_id"], first_items[0]["item_id"])
+
+    def test_unrelated_batch_does_not_poison_interrupted_batch_recovery(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            first_batch = {
+                "schema_version": "memory_update_batch/v1",
+                "source_surface": "test",
+                "updates": [
+                    {
+                        "op": "update",
+                        "item_id": "project-item",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "key": "project_item",
+                        "value": "project value",
+                        "summary": "Project item",
+                    },
+                    {
+                        "op": "update",
+                        "item_id": "thread-item",
+                        "scope": {"kind": "thread", "ref": "thread-1"},
+                        "key": "thread_item",
+                        "value": "thread value",
+                        "summary": "Thread item",
+                    },
+                ],
+            }
+            first = self._stage_and_remember(paths, first_batch)
+            calls = 0
+
+            def interrupt_second(_name: str) -> None:
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise RuntimeError("injected interruption")
+
+            with self.assertRaisesRegex(RuntimeError, "injected interruption"):
+                apply_approved_memory_update_batch(paths, first["batch_id"], write_hook=interrupt_second)
+            operation_paths = list((paths.memory_dir / "operations").glob("op_apply_*.json"))
+            self.assertEqual(len(operation_paths), 1)
+            operation_path = operation_paths[0]
+
+            second = self._stage_and_remember(
+                paths,
+                _batch("run-item", scope={"kind": "run", "ref": "run-2"}),
+            )
+            self.assertEqual(
+                apply_approved_memory_update_batch(paths, second["batch_id"])["status"],
+                "applied",
+            )
+            interrupted = json.loads(operation_path.read_text(encoding="utf-8"))
+            self.assertEqual(interrupted["state"], "interrupted")
+            self.assertEqual(
+                apply_approved_memory_update_batch(paths, first["batch_id"])["status"],
+                "applied",
+            )
+
     def test_stage_rejects_credential_shaped_legacy_item_id_without_echo(self) -> None:
         credential = "gh" + "u_" + "a" * 36
         with TemporaryDirectory() as home:

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -104,6 +104,90 @@ class MemoryBatchTests(TestCase):
 
             self.assertFalse(paths.memory_dir.exists())
 
+    def test_stage_rejects_structural_credentials_without_writing_a_candidate(self) -> None:
+        for value in ("gh" + "u_" + "a" * 36, "Ab3dEf4G" * 5 + "="):
+            with self.subTest(value_kind=value[:4]), TemporaryDirectory() as home:
+                paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+                unsafe = _batch("structural-credential")
+                updates = unsafe["updates"]
+                self.assertIsInstance(updates, list)
+                assert isinstance(updates, list)
+                update = updates[0]
+                self.assertIsInstance(update, dict)
+                assert isinstance(update, dict)
+                update["value"] = value
+
+                with self.assertRaisesRegex(ValueError, "unsafe"):
+                    stage_memory_update_batch(paths, unsafe)
+
+                self.assertFalse(paths.memory_dir.exists())
+
+    def test_batch_surface_and_reviewer_labels_reject_credentials_before_writes(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            unsafe_surface = _batch("unsafe-surface")
+            unsafe_surface["source_surface"] = credential
+
+            with self.assertRaises(ValueError) as surface_error:
+                stage_memory_update_batch(paths, unsafe_surface)
+
+            self.assertNotIn(credential, str(surface_error.exception))
+            self.assertFalse(paths.memory_dir.exists())
+
+            staged = stage_memory_update_batch(paths, _batch("unsafe-reviewer"))
+            decisions = {item["item_id"]: "remember" for item in staged["items"]}
+            with self.assertRaises(ValueError) as reviewer_error:
+                review_memory_update_batch(
+                    paths,
+                    staged["batch_id"],
+                    decisions,
+                    reviewer_label=credential,
+                )
+
+            self.assertNotIn(credential, str(reviewer_error.exception))
+            self.assertFalse((paths.memory_dir / "reviews").exists())
+
+    def test_batch_control_metadata_rejects_credentials_before_candidate_persistence(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        for field in ("item_id", "scope_ref", "retention_class"):
+            with self.subTest(field=field), TemporaryDirectory() as home:
+                paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+                batch = _batch("control-metadata")
+                updates = batch["updates"]
+                assert isinstance(updates, list)
+                update = updates[0]
+                assert isinstance(update, dict)
+                if field == "item_id":
+                    update["item_id"] = credential
+                    update["key"] = "safe_key"
+                elif field == "scope_ref":
+                    update["scope"] = {"kind": "project", "ref": credential}
+                else:
+                    update["retention_class"] = credential
+
+                with self.assertRaises(ValueError) as caught:
+                    stage_memory_update_batch(paths, batch)
+
+                self.assertNotIn(credential, str(caught.exception))
+                self.assertFalse(paths.memory_dir.exists())
+
+    def test_apply_revalidates_tampered_batch_scope_before_any_write(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            staged = self._stage_and_remember(paths, _batch("tampered-scope"))
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            candidate["items"][0]["scope"]["ref"] = credential
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            with self.assertRaises(ValueError) as caught:
+                apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertNotIn(credential, str(caught.exception))
+            self.assertFalse((paths.memory_dir / "scopes").exists())
+
     def test_refused_or_deferred_items_never_write(self) -> None:
         with TemporaryDirectory() as home:
             paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -556,6 +556,73 @@ class MemoryBatchTests(TestCase):
             self.assertEqual(result["reason_code"], "scope_precondition_changed")
             self.assertEqual(source_path.read_bytes(), source_bytes)
 
+    def test_multiscope_retry_recovers_after_first_durable_scope_write(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            source_path = paths.memory_dir / "scopes" / "project.json"
+            source_path.parent.mkdir(parents=True)
+            source_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_memory_scope/v2",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "items": {
+                            "move-target": {
+                                "item_id": "move-item",
+                                "revision": 1,
+                                "key": "move_key",
+                                "summary": "Move reviewed value",
+                                "value": "move value",
+                            }
+                        },
+                        "tombstones": {},
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            batch = _batch("move-target")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates[0].update(
+                {
+                    "op": "change_scope",
+                    "from_scope": {"kind": "project", "ref": "default"},
+                    "to_scope": {"kind": "thread", "ref": "thread-1"},
+                    "key": "move_key",
+                    "summary": "Move reviewed value",
+                    "value": "move value",
+                }
+            )
+            staged = self._stage_and_remember(paths, batch)
+            real_write = memory_batches_workflow.atomic_write_json
+            crashed = False
+
+            def crash_after_first_scope(path, payload, **kwargs):
+                nonlocal crashed
+                real_write(path, payload, **kwargs)
+                if not crashed and "scopes" in Path(path).parts:
+                    crashed = True
+                    raise RuntimeError("injected crash after first durable scope write")
+
+            with patch.object(memory_batches_workflow, "atomic_write_json", crash_after_first_scope):
+                with self.assertRaisesRegex(RuntimeError, "injected crash"):
+                    apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            recovered = apply_approved_memory_update_batch(paths, staged["batch_id"])
+
+            self.assertTrue(recovered["applied"])
+            source = json.loads(source_path.read_text(encoding="utf-8"))
+            destination = json.loads(
+                (paths.memory_dir / "scopes" / "threads" / "thread-1.json").read_text(encoding="utf-8")
+            )
+            self.assertNotIn("move-target", source["items"])
+            self.assertEqual(source["tombstones"]["move-target"]["reason_code"], "scope_changed")
+            self.assertIn("move-item", destination["items"])
+
     def test_concurrent_add_of_same_logical_target_rejects_second_candidate(self) -> None:
         with TemporaryDirectory() as home:
             paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -645,6 +645,45 @@ class MemoryBatchTests(TestCase):
             self.assertEqual(len(matching), 1)
             self.assertEqual(matching[0]["item_id"], first_items[0]["item_id"])
 
+    def test_stage_rejects_update_and_forget_for_same_scope_target(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            batch = _batch("shared-target")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates.append(
+                {
+                    "op": "forget",
+                    "item_id": "shared-target",
+                    "scope": {"kind": "project", "ref": "default"},
+                }
+            )
+
+            with self.assertRaisesRegex(ValueError, "ambiguous"):
+                stage_memory_update_batch(paths, batch)
+
+    def test_stage_rejects_duplicate_logical_key_in_same_scope(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            batch = _batch("first-target")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates.append(
+                {
+                    "op": "update",
+                    "item_id": "second-target",
+                    "scope": {"kind": "project", "ref": "default"},
+                    "key": updates[0]["key"],
+                    "summary": "Second logical copy",
+                    "value": "second value",
+                }
+            )
+
+            with self.assertRaisesRegex(ValueError, "ambiguous"):
+                stage_memory_update_batch(paths, batch)
+
     def test_unrelated_batch_does_not_poison_interrupted_batch_recovery(self) -> None:
         with TemporaryDirectory() as home:
             paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from _local_package import load_local_package
-from _platform_support import requires_fcntl_locks
+from _platform_support import requires_fcntl_locks, requires_symlinks
 
 load_local_package()
 from omh.paths import resolve_paths
@@ -702,6 +702,206 @@ class MemoryBatchTests(TestCase):
             self.assertNotIn("move-target", source["items"])
             self.assertEqual(source["tombstones"]["move-target"]["reason_code"], "scope_changed")
             self.assertIn("move-item", destination["items"])
+
+    @requires_symlinks
+    def test_multiscope_rejects_symlinked_destination_parent_without_external_write(self) -> None:
+        for timing in ("before_apply", "after_preflight"):
+            with self.subTest(timing=timing), TemporaryDirectory() as home:
+                paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+                source_path = paths.memory_dir / "scopes" / "project.json"
+                source_path.parent.mkdir(parents=True)
+                source_path.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": "omh_memory_scope/v2",
+                            "scope": {"kind": "project", "ref": "default"},
+                            "items": {
+                                "move-target": {
+                                    "item_id": "move-item",
+                                    "revision": 1,
+                                    "key": "move_key",
+                                    "summary": "Move reviewed value",
+                                    "value": "move value",
+                                }
+                            },
+                            "tombstones": {},
+                        },
+                        indent=2,
+                        sort_keys=True,
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                batch = _batch("move-target")
+                updates = batch["updates"]
+                if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                    self.fail("batch fixture updates must contain a mapping")
+                updates[0].update(
+                    {
+                        "op": "change_scope",
+                        "from_scope": {"kind": "project", "ref": "default"},
+                        "to_scope": {"kind": "run", "ref": "destination"},
+                        "key": "move_key",
+                    }
+                )
+                staged = self._stage_and_remember(paths, batch)
+                source_bytes = source_path.read_bytes()
+                destination_parent = paths.memory_dir / "scopes" / "runs"
+                outside = Path(home) / "outside"
+                outside.mkdir()
+
+                if timing == "before_apply":
+                    destination_parent.symlink_to(outside, target_is_directory=True)
+                    result = apply_approved_memory_update_batch(paths, staged["batch_id"])
+                else:
+                    calls = 0
+
+                    def replace_destination_parent(_name: str) -> None:
+                        nonlocal calls
+                        calls += 1
+                        if calls == 2:
+                            destination_parent.symlink_to(outside, target_is_directory=True)
+
+                    result = apply_approved_memory_update_batch(
+                        paths,
+                        staged["batch_id"],
+                        write_hook=replace_destination_parent,
+                    )
+
+                self.assertFalse(result["applied"])
+                self.assertEqual(result["reason_code"], "scope_precondition_changed")
+                self.assertEqual(source_path.read_bytes(), source_bytes)
+                self.assertFalse((outside / "destination.json").exists())
+
+    def test_stage_rejects_live_logical_key_under_a_different_ref(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            scope_path = paths.memory_dir / "scopes" / "project.json"
+            scope_path.parent.mkdir(parents=True)
+            scope_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_memory_scope/v2",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "items": {
+                            "item-a": {
+                                "item_id": "item-a",
+                                "revision": 1,
+                                "key": "shared_key",
+                                "summary": "Existing logical target",
+                                "value": "existing value",
+                            }
+                        },
+                        "tombstones": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            batch = _batch("target-b")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates[0]["key"] = "shared_key"
+
+            with self.assertRaisesRegex(ValueError, "ambiguous"):
+                stage_memory_update_batch(paths, batch)
+
+            self.assertFalse((paths.memory_dir / "candidates").exists())
+
+    def test_interrupted_review_request_binds_candidate_before_orphan_replacement(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            staged = stage_memory_update_batch(paths, _batch("request-binding"))
+            item_id = staged["items"][0]["item_id"]
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            real_write = memory_batches_workflow.atomic_write_json
+
+            def interrupt_seal(path, payload, **kwargs):
+                if Path(path) == candidate_path and isinstance(payload, dict) and "review_seals" in payload:
+                    raise RuntimeError("injected candidate seal interruption")
+                return real_write(path, payload, **kwargs)
+
+            with patch.object(memory_batches_workflow, "atomic_write_json", side_effect=interrupt_seal):
+                with self.assertRaisesRegex(RuntimeError, "candidate seal interruption"):
+                    review_memory_update_batch(
+                        paths,
+                        staged["batch_id"],
+                        {item_id: "remember"},
+                        reviewer_label="operator-label",
+                    )
+
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            review_path = paths.memory_dir / "reviews" / f"{candidate['items'][0]['review_id']}.json"
+            review_path.unlink()
+            candidate["source_surface"] = "mutated-after-review-request"
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "immutable"):
+                review_memory_update_batch(
+                    paths,
+                    staged["batch_id"],
+                    {item_id: "remember"},
+                    reviewer_label="operator-label",
+                )
+
+    def test_review_rejects_tampered_duplicate_candidate_item_id(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            batch = _batch("first-review-target")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates.append(
+                {
+                    "op": "update",
+                    "item_id": "second-review-target",
+                    "scope": {"kind": "run", "ref": "run-1"},
+                    "key": "second_review_target",
+                    "value": "second value",
+                    "summary": "Second review target",
+                }
+            )
+            staged = stage_memory_update_batch(paths, batch)
+            candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+            candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+            duplicate_id = candidate["items"][0]["item_id"]
+            candidate["items"][1]["item_id"] = duplicate_id
+            candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "ambiguous"):
+                review_memory_update_batch(
+                    paths,
+                    staged["batch_id"],
+                    {duplicate_id: "remember"},
+                    reviewer_label="operator-label",
+                )
+
+            self.assertFalse((paths.memory_dir / "reviews").exists())
+
+    def test_review_rejects_unbound_retention_and_unsafe_review_id(self) -> None:
+        for mutation in ("retention", "review_id"):
+            with self.subTest(mutation=mutation), TemporaryDirectory() as home:
+                paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+                staged = stage_memory_update_batch(paths, _batch(f"review-{mutation}"))
+                candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+                candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+                item_id = candidate["items"][0]["item_id"]
+                if mutation == "retention":
+                    candidate["items"][0]["retention"]["class"] = "durable"
+                else:
+                    candidate["items"][0]["review_id"] = "../escaped-review"
+                candidate_path.write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+                with self.assertRaises(ValueError):
+                    review_memory_update_batch(
+                        paths,
+                        staged["batch_id"],
+                        {item_id: "remember"},
+                        reviewer_label="operator-label",
+                    )
+
+                self.assertFalse((paths.memory_dir / "escaped-review.json").exists())
+                self.assertFalse((paths.memory_dir / "reviews").exists())
 
     def test_concurrent_add_of_same_logical_target_rejects_second_candidate(self) -> None:
         with TemporaryDirectory() as home:

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -663,6 +663,46 @@ class MemoryBatchTests(TestCase):
             with self.assertRaisesRegex(ValueError, "ambiguous"):
                 stage_memory_update_batch(paths, batch)
 
+    def test_stage_rejects_distinct_ref_update_and_forget_for_same_logical_key(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            scope_path = paths.memory_dir / "scopes" / "project.json"
+            scope_path.parent.mkdir(parents=True)
+            scope_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": "omh_memory_scope/v2",
+                        "scope": {"kind": "project", "ref": "default"},
+                        "items": {
+                            "old-ref": {
+                                "item_id": "old-ref",
+                                "revision": 1,
+                                "key": "shared_key",
+                                "summary": "Existing logical target",
+                                "value": "existing value",
+                            }
+                        },
+                        "tombstones": {},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            batch = _batch("new-ref")
+            updates = batch["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates[0]["key"] = "shared_key"
+            updates.append(
+                {
+                    "op": "forget",
+                    "item_id": "old-ref",
+                    "scope": {"kind": "project", "ref": "default"},
+                }
+            )
+
+            with self.assertRaisesRegex(ValueError, "ambiguous"):
+                stage_memory_update_batch(paths, batch)
+
     def test_stage_rejects_duplicate_logical_key_in_same_scope(self) -> None:
         with TemporaryDirectory() as home:
             paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -134,6 +134,32 @@ class MemoryBatchTests(TestCase):
             self.assertEqual(scope["items"][item_id]["value"], "second synthetic value")
             self.assertEqual(scope["items"][item_id]["batch_id"], second["batch_id"])
 
+    def test_reviewed_dismiss_conflict_persists_operation_and_dismissal_time(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            first = self._stage_and_remember(paths, _batch("conflict-target"))
+            self.assertTrue(
+                apply_approved_memory_update_batch(paths, first["batch_id"])["applied"]
+            )
+            item_id = str(first["items"][0]["item_id"])
+            dismiss = _batch(item_id)
+            updates = dismiss["updates"]
+            if not isinstance(updates, list) or not isinstance(updates[0], dict):
+                self.fail("batch fixture updates must contain a mapping")
+            updates[0]["op"] = "dismiss_conflict"
+            second = self._stage_and_remember(paths, dismiss)
+
+            applied = apply_approved_memory_update_batch(paths, second["batch_id"])
+            scope = json.loads(
+                (paths.memory_dir / "scopes" / "project.json").read_text(encoding="utf-8")
+            )
+            stored = scope["items"][item_id]
+
+            self.assertTrue(applied["applied"])
+            self.assertEqual(stored["operation"], "dismiss_conflict")
+            self.assertEqual(stored["dismissed_at"], stored["admission"]["admitted_at"])
+            self.assertEqual(stored["candidate_item_id"], second["items"][0]["item_id"])
+
     def test_stage_rejects_unsafe_content_without_writing_a_candidate(self) -> None:
         with TemporaryDirectory() as home:
             paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
@@ -167,6 +193,45 @@ class MemoryBatchTests(TestCase):
                     stage_memory_update_batch(paths, unsafe)
 
                 self.assertFalse(paths.memory_dir.exists())
+
+    @requires_symlinks
+    def test_batch_candidate_and_review_parent_symlinks_cannot_escape_store(self) -> None:
+        for phase in ("candidate", "review"):
+            with self.subTest(phase=phase), TemporaryDirectory() as home:
+                paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+                outside = Path(home) / "outside"
+                outside.mkdir()
+
+                if phase == "candidate":
+                    paths.memory_dir.mkdir(parents=True)
+                    (paths.memory_dir / "candidates").symlink_to(
+                        outside,
+                        target_is_directory=True,
+                    )
+                    with self.assertRaises(ValueError):
+                        stage_memory_update_batch(paths, _batch("candidate-symlink"))
+                else:
+                    staged = stage_memory_update_batch(paths, _batch("review-symlink"))
+                    candidate_path = paths.memory_dir / "candidates" / f"{staged['batch_id']}.json"
+                    candidate_bytes = candidate_path.read_bytes()
+                    (paths.memory_dir / "reviews").symlink_to(
+                        outside,
+                        target_is_directory=True,
+                    )
+                    decisions = {
+                        item["item_id"]: "remember"
+                        for item in staged["items"]
+                    }
+                    with self.assertRaises(ValueError):
+                        review_memory_update_batch(
+                            paths,
+                            staged["batch_id"],
+                            decisions,
+                            reviewer_label="operator-label",
+                        )
+                    self.assertEqual(candidate_path.read_bytes(), candidate_bytes)
+
+                self.assertEqual(list(outside.iterdir()), [])
 
     def test_batch_surface_and_reviewer_labels_reject_credentials_before_writes(self) -> None:
         credential = "gh" + "u_" + "a" * 36

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -146,6 +146,44 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                 self.assertEqual(governance.classify_memory_admission(content)["status"], "safe")
         self.assertEqual(governance.classify_memory_admission("token-based auth uses rotating tokens")["status"], "safe")
 
+    def test_bare_credential_shapes_are_blocked_and_unknown_opaque_values_need_review(self) -> None:
+        aws = "AK" + "IA" + "A" * 16
+        github = "gh" + "p_" + "a" * 36
+        openai = "sk" + "-" + "a" * 48
+        for content in (
+            aws,
+            github,
+            openai,
+            "https://user:pass@example.com",
+            "-----BEGIN RSA PRIVATE KEY-----",
+        ):
+            with self.subTest(content_kind=content[:4]):
+                self.assertEqual(governance.classify_memory_admission(content)["status"], "blocked")
+
+        self.assertEqual(governance.classify_memory_admission(f"safe {aws} and {github}")["status"], "blocked")
+        self.assertEqual(governance.classify_memory_admission("akia" + "a" * 16)["status"], "blocked")
+        for content in (
+            "AK" + "IA" + "A" * 15,
+            "gh" + "p_" + "a" * 15,
+            "sk" + "-" + "a" * 15,
+        ):
+            with self.subTest(short_shape=content[:4]):
+                self.assertEqual(governance.classify_memory_admission(content)["status"], "safe")
+
+        unknown = "credential: " + "Ab3_" * 12
+        self.assertEqual(governance.classify_memory_admission(unknown)["status"], "needs_review")
+        self.assertEqual(governance.classify_memory_admission("Ab3_" * 12)["status"], "needs_review")
+
+        for content in (
+            "token-based parsing",
+            "secret-management policy",
+            "API key rotation",
+            "Store the API token rotation runbook",
+            "A normal release identifier has no credential shape.",
+        ):
+            with self.subTest(ordinary=content):
+                self.assertEqual(governance.classify_memory_admission(content)["status"], "safe")
+
     def test_scope_invalid_and_scope_mismatch_are_distinct_fail_closed_results(self) -> None:
         with self.assertRaises(ValueError):
             governance.canonical_memory_scope({"kind": "project", "ref": "default", "unexpected": "field"})

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -305,6 +305,8 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         uppercase_alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWX12345678"
         split_opaque = "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz"
         uneven_parts = ("ABCDE", "FGHIJ", "KLMNO", "PQRSTUVWXYZaBcdef")
+        lowercase_parts = ("abcdefgh", "ijklmnop", "qrstuvwx", "yzabcdef")
+        lowercase_uneven_parts = ("abcde", "fghij", "klmno", "pqrstuvwxyzabcdefgh")
 
         for opaque in (*low_transition_base64, uppercase_alphanumeric):
             if opaque in low_transition_base64:
@@ -343,6 +345,18 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             ):
                 with self.subTest(separator=separator, uneven_container=container):
                     self.assertEqual(governance.classify_memory_admission(container)["status"], "needs_review")
+
+            for lowercase_variant in (lowercase_parts, lowercase_uneven_parts):
+                lowercase_split = separator.join(lowercase_variant)
+                for container in (
+                    lowercase_split,
+                    f"/safe/{lowercase_split}/artifact.txt",
+                    f"https://example.com/{lowercase_split}/artifact",
+                    f"@scope/{lowercase_split}",
+                    f"C:\\safe\\{lowercase_split}\\artifact.txt",
+                ):
+                    with self.subTest(separator=separator, lowercase_container=container):
+                        self.assertEqual(governance.classify_memory_admission(container)["status"], "needs_review")
 
         for semantic_identifier in (
             "projectMemorySchemaMigrationIdentifier",
@@ -407,6 +421,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "project-2026-memory-hardening-identifier",
             "secret-tokenizer-library-for-python-projects",
             "hf-transformers-inference-service-project",
+            "Unresolved memory conflicts block this context pack from executor handoff attachment.",
             "/private/var/folders/21/8zb1drv53h1d0vm3tv0f6mym0000gn/T/tmpabcd/.omh/memory",
             (
                 "/private/var/folders/21/8zb1drv53h1d0vm3tv0f6mym0000gn/T/tmpabcd/.omh/plans/"

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -252,6 +252,17 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         for opaque in (uppercase_base32, lowercase_alphanumeric):
             with self.subTest(opaque=opaque[:8]):
                 self.assertEqual(governance.classify_memory_admission(opaque)["status"], "needs_review")
+            for container in (
+                f"/safe/{opaque}/artifact.txt",
+                f"https://example.com/{opaque}/artifact",
+                f"@scope/{opaque}",
+                f"C:\\safe\\{opaque}\\artifact.txt",
+            ):
+                with self.subTest(opaque=opaque[:8], container=container[:16]):
+                    self.assertEqual(
+                        governance.classify_memory_admission(container)["status"],
+                        "needs_review",
+                    )
 
         self.assertEqual(
             governance.classify_memory_admission("project2026memoryhardeningidentifier")["status"],
@@ -349,7 +360,14 @@ class SafetyAndEvaluationTests(unittest.TestCase):
 
         credential = "gh" + "u_" + "a" * 36
         padded = "Ab3dEf4G" * 5 + "="
-        for unsafe_path in (f"C:\\safe\\{credential}\\artifact.txt", f"C:\\safe\\{padded}\\artifact.txt"):
+        uppercase_base32 = "JBSWY3DPEHPK3PXP" * 3
+        lowercase_alphanumeric = "a9b8c7d6e5f4g3h2j1k0m9n8p7q6r5s4"
+        for unsafe_path in (
+            f"C:\\safe\\{credential}\\artifact.txt",
+            f"C:\\safe\\{padded}\\artifact.txt",
+            f"C:\\safe\\{uppercase_base32}\\artifact.txt",
+            f"C:\\safe\\{lowercase_alphanumeric}\\artifact.txt",
+        ):
             with self.subTest(unsafe_path=unsafe_path), self.assertRaises(ValueError):
                 build_plan_handoff_context_pack({**artifact, "path": unsafe_path})
 

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -269,6 +269,15 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "safe",
         )
 
+    def test_source_syntax_is_not_reclassified_as_credential_material(self) -> None:
+        for source_line in (
+            'key = str(update.get("key", item_id))',
+            "default=DEFAULT_ARTIFACT_SCAN_LIMIT",
+            "class ExecutorGuidanceCompatibilityError(ValueError):",
+        ):
+            with self.subTest(source_line=source_line):
+                self.assertEqual(governance.classify_memory_admission(source_line)["status"], "safe")
+
     def test_single_case_alphanumeric_opaque_values_need_review(self) -> None:
         uppercase_base32 = "JBSWY3DPEHPK3PXP" * 3
         uppercase_letters_only_base32 = "JBSWYDPF" * 4
@@ -430,6 +439,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
 
     def test_opaque_values_need_review_without_reclassifying_common_identifiers(self) -> None:
         padded_base64 = "Ab3dEf4G" * 5 + "="
+        opaque = padded_base64.rstrip("=")
         unpadded_base64url = "Ab3d_Ef4Gh5Ij6Kl7Mn8Op9Qr0St1Uv2"
         split_opaque = "Ab3dEf4Gh5Ij6Kl7Mn8/Op9Qr0St1Uv2WxYz"
 
@@ -439,9 +449,9 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             split_opaque,
             f"https://example.com/{split_opaque}",
             r"C:\safe\Ab3dEf4Gh5Ij6Kl7Mn8\Op9Qr0St1Uv2WxYz",
-            "https://example.com/artifact?session=" + "a" * 64,
-            "https://example.com/artifact?access=" + "b" * 64,
-            "https://example.com/artifact?key=" + "c" * 64,
+            "https://example.com/artifact?session=" + opaque,
+            "https://example.com/artifact?access=" + opaque,
+            "https://example.com/artifact?key=" + opaque,
         ):
             with self.subTest(normalized_bypass=normalized_bypass):
                 self.assertEqual(governance.classify_memory_admission(normalized_bypass)["status"], "needs_review")

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -303,6 +303,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "abcdefghijklmnopqrstuvwxyzaaaaaaaa",
             "abcdefghijklmnopqrstuvwxyzaaaaaaaaa",
             "ABCDEFGHIJKLMNOPQRSTUVWXYZaBcdef",
+            "J" + "j" * 9 + "K" + "k" * 9 + "L" + "l" * 11,
         )
         uppercase_alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWX12345678"
         split_opaque = "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz"

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -123,6 +123,50 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         result = _evaluate(artifact, review)
         self.assertEqual(result["reason_code"], "safety_needs_review_in_summary")
 
+    def test_safety_rescan_covers_source_metadata_and_tags(self) -> None:
+        cases = (
+            ("source", "gh" + "u_" + "a" * 36, "safety_blocked_in_source"),
+            ("source_ref", "Ab3dEf4G" * 5 + "=", "safety_needs_review_in_source_ref"),
+            ("tags", ["Ab3d_Ef4Gh5Ij6Kl7Mn8Op9Qr0St1Uv2"], "safety_needs_review_in_tags"),
+            (
+                "source_evidence",
+                {"source_ref": "gh" + "u_" + "a" * 36},
+                "safety_blocked_in_source_evidence.source_ref",
+            ),
+            (
+                "scope",
+                {"kind": "project", "ref": "gh" + "u_" + "a" * 36},
+                "safety_blocked_in_scope.ref",
+            ),
+            ("derived_from", ["gh" + "u_" + "a" * 36], "safety_blocked_in_derived_from"),
+        )
+        for field, value, reason_code in cases:
+            with self.subTest(field=field):
+                artifact, review = _approved_artifact()
+                artifact[field] = value
+                digest = governance.canonical_payload_digest(artifact)
+                admission = artifact["admission"]
+                self.assertIsInstance(admission, dict)
+                assert isinstance(admission, dict)
+                admission["payload_digest"] = digest
+                review["payload_digest"] = digest
+                if field == "scope":
+                    identity = governance.stable_artifact_identity(artifact)
+                    admission["artifact_identity"] = identity
+                    review["artifact_identity"] = identity
+                    assert isinstance(value, dict)
+                    result = governance.evaluate_memory_replay(
+                        artifact,
+                        now=NOW,
+                        requested_scope=value,
+                        review_resolver={str(admission["review_id"]): review},
+                    )
+                else:
+                    result = _evaluate(artifact, review)
+
+                self.assertFalse(result["eligible"])
+                self.assertEqual(result["reason_code"], reason_code)
+
     def test_secret_token_forms_are_blocked_to_meet_the_remember_refuse_contract(self) -> None:
         """Hyphenated secret-token compounds are blocked; ordinary hyphenated prose is never admission-blocked."""
         for content in (
@@ -150,10 +194,14 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         aws = "AK" + "IA" + "A" * 16
         github = "gh" + "p_" + "a" * 36
         openai = "sk" + "-" + "a" * 48
+        stripe = "sk_" + "live_" + "a" * 32
+        google_oauth = "ya29." + "a" * 40
         for content in (
             aws,
             github,
             openai,
+            stripe,
+            google_oauth,
             "https://user:pass@example.com",
             "-----BEGIN RSA PRIVATE KEY-----",
         ):
@@ -183,6 +231,44 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         ):
             with self.subTest(ordinary=content):
                 self.assertEqual(governance.classify_memory_admission(content)["status"], "safe")
+
+    def test_source_host_token_prefixes_do_not_consume_ordinary_npm_prose(self) -> None:
+        github_user_token = "gh" + "u_" + "a" * 36
+        npm_token = "npm_" + "a" * 36
+
+        self.assertEqual(governance.classify_memory_admission(github_user_token)["status"], "blocked")
+        self.assertEqual(governance.classify_memory_admission(npm_token)["status"], "blocked")
+        self.assertEqual(
+            governance.classify_memory_admission("npm-package-name-with-long-suffix")["status"],
+            "safe",
+        )
+
+    def test_opaque_values_need_review_without_reclassifying_common_identifiers(self) -> None:
+        padded_base64 = "Ab3dEf4G" * 5 + "="
+        unpadded_base64url = "Ab3d_Ef4Gh5Ij6Kl7Mn8Op9Qr0St1Uv2"
+
+        self.assertEqual(governance.classify_memory_admission(padded_base64)["status"], "needs_review")
+        self.assertEqual(governance.classify_memory_admission(unpadded_base64url)["status"], "needs_review")
+        for ordinary in (
+            "0123456789abcdef0123456789abcdef01234567",
+            "123e4567-e89b-12d3-a456-426614174000",
+            "01890f3e-8b5a-7cc2-98c7-2f9c0b6a1d43",
+            "DeterministicProjectConfigurationManager",
+            "DeterministicProjectConfigurationManagerV2",
+            "AlicePlatformReviewer2026Account",
+            "direview_dprof_e9da83f21e46282d3a9ae020_r1",
+            "@scope/hermes-agent-runtime-v2-package",
+            "packages/hermes-agent-runtime-v2-package/src",
+            "https://example.com/releases/hermes-agent-v2-package",
+            "project-2026-memory-hardening-identifier",
+            "/private/var/folders/21/8zb1drv53h1d0vm3tv0f6mym0000gn/T/tmpabcd/.omh/memory",
+            (
+                "/private/var/folders/21/8zb1drv53h1d0vm3tv0f6mym0000gn/T/tmpabcd/.omh/plans/"
+                "2026-09-05T082831432517Z-implement-durable-observation-journal-with-tests-9f35ae.md"
+            ),
+        ):
+            with self.subTest(ordinary=ordinary):
+                self.assertEqual(governance.classify_memory_admission(ordinary)["status"], "safe")
 
     def test_scope_invalid_and_scope_mismatch_are_distinct_fail_closed_results(self) -> None:
         with self.assertRaises(ValueError):

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -296,13 +296,17 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "ABCDEFGHabcdIJKLMNOPQRSTUVWXwxyz",
             "ABCDabcdEFGHijklMNOPqrstUVWXYZAB",
             "ABCDabcdEFGHijklMNOPqrstUVWXyzab",
+            "abcdefghijklmnopqrstuvwxyzaaaaaa",
+            "abcdefghijklmnopqrstuvwxyzaaaaaaaaaa",
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZaBcdef",
         )
         uppercase_alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWX12345678"
         split_opaque = "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz"
+        uneven_parts = ("ABCDE", "FGHIJ", "KLMNO", "PQRSTUVWXYZaBcdef")
 
         for opaque in (*low_transition_base64, uppercase_alphanumeric):
             if opaque in low_transition_base64:
-                self.assertEqual(len(base64.b64decode(opaque, validate=True)), 24)
+                self.assertEqual(len(base64.b64decode(opaque, validate=True)), len(opaque) // 4 * 3)
             with self.subTest(opaque=opaque):
                 self.assertEqual(governance.classify_memory_admission(opaque)["status"], "needs_review")
             for container in (
@@ -324,6 +328,17 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                 f"C:\\safe\\{value}\\artifact.txt",
             ):
                 with self.subTest(separator=separator, container=container):
+                    self.assertEqual(governance.classify_memory_admission(container)["status"], "needs_review")
+
+            uneven = separator.join(uneven_parts)
+            for container in (
+                uneven,
+                f"/safe/{uneven}/artifact.txt",
+                f"https://example.com/{uneven}/artifact",
+                f"@scope/{uneven}",
+                f"C:\\safe\\{uneven}\\artifact.txt",
+            ):
+                with self.subTest(separator=separator, uneven_container=container):
                     self.assertEqual(governance.classify_memory_admission(container)["status"], "needs_review")
 
         for semantic_identifier in (

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -278,6 +278,31 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             with self.subTest(source_line=source_line):
                 self.assertEqual(governance.classify_memory_admission(source_line)["status"], "safe")
 
+    def test_split_google_token_prefixes_are_blocked(self) -> None:
+        for content in (
+            "ya29./f1/f2",
+            "AIza/f1/f2",
+            "AIza.f1.f2",
+        ):
+            with self.subTest(content=content):
+                self.assertEqual(governance.classify_memory_admission(content)["status"], "blocked")
+
+    def test_windows_and_unc_paths_are_safe(self) -> None:
+        for path in (
+            r"C:\Users\kim\AppData\Local\Programs\Python\Python313\python.exe",
+            r"\\server\share\AppData\Local\Programs\Python\Python313\python.exe",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(governance.classify_memory_admission(path)["status"], "safe")
+
+    def test_test_class_identifiers_are_safe(self) -> None:
+        for source_line in (
+            "class CategoryMaestroSetupIntegrationTests(unittest.TestCase):",
+            "class RuntimeArtifactShowShapeCliTests(unittest.TestCase):",
+        ):
+            with self.subTest(source_line=source_line):
+                self.assertEqual(governance.classify_memory_admission(source_line)["status"], "safe")
+
     def test_single_case_alphanumeric_opaque_values_need_review(self) -> None:
         uppercase_base32 = "JBSWY3DPEHPK3PXP" * 3
         uppercase_letters_only_base32 = "JBSWYDPF" * 4

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -14,6 +14,7 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.plugin_bundle.omh import memory_governance as governance
+from omh.workflows.hermes_planning import build_plan_handoff_context_pack
 
 
 NOW = datetime(2026, 7, 30, 12, 0, 0, tzinfo=timezone.utc)
@@ -202,6 +203,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             openai,
             stripe,
             google_oauth,
+            f"C:\\safe\\{github}\\artifact.txt",
             "https://user:pass@example.com",
             "-----BEGIN RSA PRIVATE KEY-----",
         ):
@@ -249,6 +251,11 @@ class SafetyAndEvaluationTests(unittest.TestCase):
 
         self.assertEqual(governance.classify_memory_admission(padded_base64)["status"], "needs_review")
         self.assertEqual(governance.classify_memory_admission(unpadded_base64url)["status"], "needs_review")
+        self.assertEqual(
+            governance.classify_memory_admission(f"C:\\safe\\{padded_base64}\\artifact.txt")["status"],
+            "needs_review",
+        )
+
         for ordinary in (
             "0123456789abcdef0123456789abcdef01234567",
             "123e4567-e89b-12d3-a456-426614174000",
@@ -270,9 +277,40 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                 "/private/var/folders/21/8zb1drv53h1d0vm3tv0f6mym0000gn/T/tmpabcd/.omh/plans/"
                 "2026-09-05T082831432517Z-implement-durable-observation-journal-with-tests-9f35ae.md"
             ),
+            (
+                "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\tmpmeqo2rx3\\.omh\\plans\\"
+                "2026-09-05T092408607631Z-risky-refactor-with-review-9f35ae.md"
+            ),
+            (
+                "D:\\a\\oh-my-hermes\\oh-my-hermes\\.hermes\\plans\\"
+                "2026-09-05T092408607631Z-implement-durable-observation-journal-with-tests-9f35ae.md"
+            ),
         ):
             with self.subTest(ordinary=ordinary):
                 self.assertEqual(governance.classify_memory_admission(ordinary)["status"], "safe")
+
+    def test_plan_handoff_accepts_literal_windows_paths_without_weakening_credential_checks(self) -> None:
+        artifact = {
+            "schema_version": "hermes_plan/v1",
+            "status": "accepted",
+            "sha256": "a" * 64,
+        }
+        safe_paths = (
+            "C:\\Users\\runneradmin\\AppData\\Local\\Temp\\tmpmeqo2rx3\\.omh\\plans\\"
+            "2026-09-05T092408607631Z-risky-refactor-with-review-9f35ae.md",
+            "\\\\build-server\\workspace\\.omh\\plans\\"
+            "2026-09-05T092408607631Z-risky-refactor-with-review-9f35ae.md",
+        )
+        for path in safe_paths:
+            with self.subTest(path=path):
+                pack = build_plan_handoff_context_pack({**artifact, "path": path})
+                self.assertEqual(pack["metadata"]["plan_artifact_path"], path)
+
+        credential = "gh" + "u_" + "a" * 36
+        padded = "Ab3dEf4G" * 5 + "="
+        for unsafe_path in (f"C:\\safe\\{credential}\\artifact.txt", f"C:\\safe\\{padded}\\artifact.txt"):
+            with self.subTest(unsafe_path=unsafe_path), self.assertRaises(ValueError):
+                build_plan_handoff_context_pack({**artifact, "path": unsafe_path})
 
     def test_scope_invalid_and_scope_mismatch_are_distinct_fail_closed_results(self) -> None:
         with self.assertRaises(ValueError):
@@ -321,6 +359,18 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         self.assertEqual(governance.validate_replay_evaluation(result), [])
         self.assertEqual(governance.external_context_label("hermes_native")["admission_status"], "not_omh_reviewed")
         self.assertEqual(governance.external_context_label("provider")["reason_code"], "external_not_omh_reviewed")
+
+    def test_fail_closed_replay_result_masks_credential_shaped_source_class(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+
+        result = governance.evaluate_memory_replay(
+            {"schema_version": "unsupported/v1", "source_class": credential},
+            now=NOW,
+        )
+
+        self.assertFalse(result["eligible"])
+        self.assertEqual(result["reason_code"], "unsupported_schema")
+        self.assertNotIn(credential, json.dumps(result, sort_keys=True))
 
     def test_b1_safety_rescan_blocks_secrets_in_value_and_label(self) -> None:
         """B1: Evaluate all renderable fields (summary, value, label) for secrets."""

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -421,6 +421,11 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "project-2026-memory-hardening-identifier",
             "secret-tokenizer-library-for-python-projects",
             "hf-transformers-inference-service-project",
+            "DECLARED_MODEL_CONTRACT_PROJECTIONS",
+            "CAPABILITY_EVIDENCE_STALE_AFTER_SECONDS",
+            "SOURCE_FINDER_OBSERVATION_PROVENANCE",
+            "let data = pipe.fileHandleForReading.readDataToEndOfFile()",
+            "Mirrors SHIPPED_MODEL_RECOMMENDATIONS categories in",
             "Unresolved memory conflicts block this context pack from executor handoff attachment.",
             "/private/var/folders/21/8zb1drv53h1d0vm3tv0f6mym0000gn/T/tmpabcd/.omh/memory",
             (

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -339,6 +339,12 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         lowercase_uneven_parts = ("abcde", "fghij", "klmno", "pqrstuvwxyzabcdefgh")
         three_part_camel = ("Qwertyuiopa", "Asdfghjklm", "Observation")
         uppercase_base32_parts = ("JBSWYDPE",) * 4
+        uneven_uppercase_base32_parts = (
+            "JBSWYDP",
+            "EJBSWYDPE",
+            "JBSWYDPE",
+            "JBSWYDPE",
+        )
 
         for opaque in (*low_transition_base64, uppercase_alphanumeric):
             if opaque in low_transition_base64:
@@ -356,7 +362,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                 with self.subTest(container=container):
                     self.assertEqual(governance.classify_memory_admission(container)["status"], "needs_review")
 
-        for separator in ("/", ".", "-", " "):
+        for separator in ("/", ".", "-", "_", " "):
             value = separator.join(split_opaque.split("."))
             for container in (
                 value,
@@ -391,7 +397,11 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                     with self.subTest(separator=separator, lowercase_container=container):
                         self.assertEqual(governance.classify_memory_admission(container)["status"], "needs_review")
 
-            for split_variant in (three_part_camel, uppercase_base32_parts):
+            for split_variant in (
+                three_part_camel,
+                uppercase_base32_parts,
+                uneven_uppercase_base32_parts,
+            ):
                 opaque_split = separator.join(split_variant)
                 for container in (
                     opaque_split,

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -245,6 +245,19 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "safe",
         )
 
+    def test_single_case_alphanumeric_opaque_values_need_review(self) -> None:
+        uppercase_base32 = "JBSWY3DPEHPK3PXP" * 3
+        lowercase_alphanumeric = "a9b8c7d6e5f4g3h2j1k0m9n8p7q6r5s4"
+
+        for opaque in (uppercase_base32, lowercase_alphanumeric):
+            with self.subTest(opaque=opaque[:8]):
+                self.assertEqual(governance.classify_memory_admission(opaque)["status"], "needs_review")
+
+        self.assertEqual(
+            governance.classify_memory_admission("project2026memoryhardeningidentifier")["status"],
+            "safe",
+        )
+
     def test_opaque_values_need_review_without_reclassifying_common_identifiers(self) -> None:
         padded_base64 = "Ab3dEf4G" * 5 + "="
         unpadded_base64url = "Ab3d_Ef4Gh5Ij6Kl7Mn8Op9Qr0St1Uv2"

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -256,6 +256,9 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             split_opaque,
             f"https://example.com/{split_opaque}",
             r"C:\safe\Ab3dEf4Gh5Ij6Kl7Mn8\Op9Qr0St1Uv2WxYz",
+            "https://example.com/artifact?session=" + "a" * 64,
+            "https://example.com/artifact?access=" + "b" * 64,
+            "https://example.com/artifact?key=" + "c" * 64,
         ):
             with self.subTest(normalized_bypass=normalized_bypass):
                 self.assertEqual(governance.classify_memory_admission(normalized_bypass)["status"], "needs_review")
@@ -304,6 +307,10 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                 "D:\\a\\oh-my-hermes\\oh-my-hermes\\.hermes\\plans\\"
                 "2026-09-05T092408607631Z-implement-durable-observation-journal-with-tests-9f35ae.md"
             ),
+            r"C:\Program Files\Hermes Agent\config.json",
+            r"C:\Users\Alice\myProject\README.md",
+            "packages/JSONRPC2ServerConfigurationManager/src",
+            "https://example.com/releases/TLS13ConnectionConfigurationManager",
         ):
             with self.subTest(ordinary=ordinary):
                 self.assertEqual(governance.classify_memory_admission(ordinary)["status"], "safe")

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -249,12 +249,14 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         uppercase_base32 = "JBSWY3DPEHPK3PXP" * 3
         uppercase_letters_only_base32 = "JBSWYDPF" * 4
         mixed_case_letters_only_base64 = "mQvHzLrNaPeTgWuYbJxDcFkSiOoUaZcV"
+        mixed_case_base64_with_lower_runs = "abCDefGHijKLmnOPqrSTuvWXyzABcDEF"
         lowercase_alphanumeric = "a9b8c7d6e5f4g3h2j1k0m9n8p7q6r5s4"
 
         for opaque in (
             uppercase_base32,
             uppercase_letters_only_base32,
             mixed_case_letters_only_base64,
+            mixed_case_base64_with_lower_runs,
             lowercase_alphanumeric,
         ):
             with self.subTest(opaque=opaque[:8]):
@@ -381,6 +383,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         uppercase_base32 = "JBSWY3DPEHPK3PXP" * 3
         uppercase_letters_only_base32 = "JBSWYDPF" * 4
         mixed_case_letters_only_base64 = "mQvHzLrNaPeTgWuYbJxDcFkSiOoUaZcV"
+        mixed_case_base64_with_lower_runs = "abCDefGHijKLmnOPqrSTuvWXyzABcDEF"
         lowercase_alphanumeric = "a9b8c7d6e5f4g3h2j1k0m9n8p7q6r5s4"
         for unsafe_path in (
             f"C:\\safe\\{credential}\\artifact.txt",
@@ -388,6 +391,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             f"C:\\safe\\{uppercase_base32}\\artifact.txt",
             f"C:\\safe\\{uppercase_letters_only_base32}\\artifact.txt",
             f"C:\\safe\\{mixed_case_letters_only_base64}\\artifact.txt",
+            f"C:\\safe\\{mixed_case_base64_with_lower_runs}\\artifact.txt",
             f"C:\\safe\\{lowercase_alphanumeric}\\artifact.txt",
         ):
             with self.subTest(unsafe_path=unsafe_path), self.assertRaises(ValueError):

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -169,6 +169,27 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                 self.assertFalse(result["eligible"])
                 self.assertEqual(result["reason_code"], reason_code)
 
+    def test_invalid_admission_state_fails_closed_without_echoing_unsafe_input(self) -> None:
+        unsafe_states = (
+            "QwertyuiopaAsdfghjklmObservationContext",
+            "rk_" + "live_" + "a" * 32,
+            "Ab3dEf4G" * 5 + "=",
+        )
+        for unsafe_state in unsafe_states:
+            with self.subTest(unsafe_state=unsafe_state[:8]):
+                artifact, review = _approved_artifact()
+                admission = artifact["admission"]
+                self.assertIsInstance(admission, dict)
+                assert isinstance(admission, dict)
+                admission["state"] = unsafe_state
+
+                result = _evaluate(artifact, review)
+
+                self.assertFalse(result["eligible"])
+                self.assertEqual(result["reason_code"], "admission_state_invalid")
+                self.assertIsNone(result["admission_state"])
+                self.assertNotIn(unsafe_state, json.dumps(result, sort_keys=True))
+
     def test_secret_token_forms_are_blocked_to_meet_the_remember_refuse_contract(self) -> None:
         """Hyphenated secret-token compounds are blocked; ordinary hyphenated prose is never admission-blocked."""
         for content in (
@@ -305,12 +326,17 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "ABCDEFGHIJKLMNOPQRSTUVWXYZaBcdef",
             "J" + "j" * 9 + "K" + "k" * 9 + "L" + "l" * 11,
             "QwertyuiopaAsdfghjklmObservation",
+            "QwertyuiopaAsdfghjklmObservationV2",
+            "QwertyuiopaAsdfghjklmObservationContext",
+            "AbcDefGhiJklMnoPqrStuVwxYzaBcdEfgJkl",
         )
         uppercase_alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWX12345678"
         split_opaque = "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz"
         uneven_parts = ("ABCDE", "FGHIJ", "KLMNO", "PQRSTUVWXYZaBcdef")
         lowercase_parts = ("abcdefgh", "ijklmnop", "qrstuvwx", "yzabcdef")
         lowercase_uneven_parts = ("abcde", "fghij", "klmno", "pqrstuvwxyzabcdefgh")
+        three_part_camel = ("Qwertyuiopa", "Asdfghjklm", "Observation")
+        uppercase_base32_parts = ("JBSWYDPE",) * 4
 
         for opaque in (*low_transition_base64, uppercase_alphanumeric):
             if opaque in low_transition_base64:
@@ -363,6 +389,21 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                     with self.subTest(separator=separator, lowercase_container=container):
                         self.assertEqual(governance.classify_memory_admission(container)["status"], "needs_review")
 
+            for split_variant in (three_part_camel, uppercase_base32_parts):
+                opaque_split = separator.join(split_variant)
+                for container in (
+                    opaque_split,
+                    f"/safe/{opaque_split}/artifact.txt",
+                    f"https://example.com/{opaque_split}/artifact",
+                    f"@scope/{opaque_split}",
+                    f"C:\\safe\\{opaque_split}\\artifact.txt",
+                ):
+                    with self.subTest(separator=separator, opaque_split=container):
+                        self.assertEqual(
+                            governance.classify_memory_admission(container)["status"],
+                            "needs_review",
+                        )
+
         for semantic_identifier in (
             "projectMemorySchemaMigrationIdentifier",
             "projectMemorySchemaMigrationIdentifierV2",
@@ -411,6 +452,14 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "/safe/AuthenticatedMaintainerObservation/artifact.txt",
             "https://example.com/AuthenticatedMaintainerObservation/artifact",
             "@scope/AuthenticatedMaintainerObservation",
+            "ABlockIsRecoverableAndNotTerminal",
+            "benchmarks/live-model-tools/v1/README.md",
+            "https://github.com/rlaope/oh-my-hermes/blob/main/docs/CAPABILITY_IMPACT.md",
+            "https://github.com/rlaope/oh-my-hermes/blob/6da2a3cac0ac854d475a930f8975208bc22b06c9/docs/CAPABILITY_IMPACT.md",
+            (
+                "https://github.com/rlaope/oh-my-hermes/blob/"
+                "0123456789abcdef0123456789abcdef01234567/docs/CAPABILITY_IMPACT.md"
+            ),
             "direview_dprof_e9da83f21e46282d3a9ae020_r1",
             "@scope/hermes-agent-runtime-v2-package",
             "@scope/HermesAgentRuntimeV2PackageManager",

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -280,6 +280,8 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "direview_dprof_e9da83f21e46282d3a9ae020_r1",
             "@scope/hermes-agent-runtime-v2-package",
             "@scope/HermesAgentRuntimeV2PackageManager",
+            "JSONRPC2ServerConfigurationManager",
+            "TLS13ConnectionConfigurationManager",
             "packages/hermes-agent-runtime-v2-package/src",
             "packages/HermesAgentRuntimeV2PackageManager/src",
             "https://example.com/releases/hermes-agent-v2-package",

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -6,6 +6,7 @@ scope validation, legacy artifact handling, and metadata-only results.
 
 from __future__ import annotations
 
+import base64
 import json
 from datetime import datetime, timezone
 import unittest
@@ -288,6 +289,54 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             governance.classify_memory_admission("project2026memoryhardeningidentifier")["status"],
             "safe",
         )
+
+    def test_low_transition_and_separator_split_opaque_values_need_review(self) -> None:
+        low_transition_base64 = (
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZABabcd",
+            "ABCDEFGHabcdIJKLMNOPQRSTUVWXwxyz",
+            "ABCDabcdEFGHijklMNOPqrstUVWXYZAB",
+            "ABCDabcdEFGHijklMNOPqrstUVWXyzab",
+        )
+        uppercase_alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWX12345678"
+        split_opaque = "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz"
+
+        for opaque in (*low_transition_base64, uppercase_alphanumeric):
+            if opaque in low_transition_base64:
+                self.assertEqual(len(base64.b64decode(opaque, validate=True)), 24)
+            with self.subTest(opaque=opaque):
+                self.assertEqual(governance.classify_memory_admission(opaque)["status"], "needs_review")
+            for container in (
+                f"/safe/{opaque}/artifact.txt",
+                f"https://example.com/{opaque}/artifact",
+                f"@scope/{opaque}",
+                f"C:\\safe\\{opaque}\\artifact.txt",
+            ):
+                with self.subTest(container=container):
+                    self.assertEqual(governance.classify_memory_admission(container)["status"], "needs_review")
+
+        for separator in ("/", ".", "-", " "):
+            value = separator.join(split_opaque.split("."))
+            for container in (
+                value,
+                f"/safe/{value}/artifact.txt",
+                f"https://example.com/{value}/artifact",
+                f"@scope/{value}",
+                f"C:\\safe\\{value}\\artifact.txt",
+            ):
+                with self.subTest(separator=separator, container=container):
+                    self.assertEqual(governance.classify_memory_admission(container)["status"], "needs_review")
+
+        for semantic_identifier in (
+            "projectMemorySchemaMigrationIdentifier",
+            "projectMemorySchemaMigrationIdentifierV2",
+            "DeterministicProjectConfigurationManager",
+            "HTTPServerConfigurationV2ProjectManager",
+            "JSONRPC2ServerConfigurationManager",
+            "TLS13ConnectionConfigurationManager",
+            "project2026schema2migration3identifier",
+        ):
+            with self.subTest(semantic_identifier=semantic_identifier):
+                self.assertEqual(governance.classify_memory_admission(semantic_identifier)["status"], "safe")
 
     def test_opaque_values_need_review_without_reclassifying_common_identifiers(self) -> None:
         padded_base64 = "Ab3dEf4G" * 5 + "="

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -247,9 +247,16 @@ class SafetyAndEvaluationTests(unittest.TestCase):
 
     def test_single_case_alphanumeric_opaque_values_need_review(self) -> None:
         uppercase_base32 = "JBSWY3DPEHPK3PXP" * 3
+        uppercase_letters_only_base32 = "JBSWYDPF" * 4
+        mixed_case_letters_only_base64 = "mQvHzLrNaPeTgWuYbJxDcFkSiOoUaZcV"
         lowercase_alphanumeric = "a9b8c7d6e5f4g3h2j1k0m9n8p7q6r5s4"
 
-        for opaque in (uppercase_base32, lowercase_alphanumeric):
+        for opaque in (
+            uppercase_base32,
+            uppercase_letters_only_base32,
+            mixed_case_letters_only_base64,
+            lowercase_alphanumeric,
+        ):
             with self.subTest(opaque=opaque[:8]):
                 self.assertEqual(governance.classify_memory_admission(opaque)["status"], "needs_review")
             for container in (
@@ -263,6 +270,17 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                         governance.classify_memory_admission(container)["status"],
                         "needs_review",
                     )
+
+        semantic_identifier = "project2026schema2migration3identifier"
+        for ordinary in (
+            semantic_identifier,
+            f"@scope/{semantic_identifier}",
+            f"/safe/{semantic_identifier}/artifact.txt",
+            f"C:\\safe\\{semantic_identifier}\\artifact.txt",
+            f"https://example.com/{semantic_identifier}/artifact",
+        ):
+            with self.subTest(ordinary=ordinary[:24]):
+                self.assertEqual(governance.classify_memory_admission(ordinary)["status"], "safe")
 
         self.assertEqual(
             governance.classify_memory_admission("project2026memoryhardeningidentifier")["status"],
@@ -361,11 +379,15 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         credential = "gh" + "u_" + "a" * 36
         padded = "Ab3dEf4G" * 5 + "="
         uppercase_base32 = "JBSWY3DPEHPK3PXP" * 3
+        uppercase_letters_only_base32 = "JBSWYDPF" * 4
+        mixed_case_letters_only_base64 = "mQvHzLrNaPeTgWuYbJxDcFkSiOoUaZcV"
         lowercase_alphanumeric = "a9b8c7d6e5f4g3h2j1k0m9n8p7q6r5s4"
         for unsafe_path in (
             f"C:\\safe\\{credential}\\artifact.txt",
             f"C:\\safe\\{padded}\\artifact.txt",
             f"C:\\safe\\{uppercase_base32}\\artifact.txt",
+            f"C:\\safe\\{uppercase_letters_only_base32}\\artifact.txt",
+            f"C:\\safe\\{mixed_case_letters_only_base64}\\artifact.txt",
             f"C:\\safe\\{lowercase_alphanumeric}\\artifact.txt",
         ):
             with self.subTest(unsafe_path=unsafe_path), self.assertRaises(ValueError):

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -253,6 +253,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "0123456789abcdef0123456789abcdef01234567",
             "123e4567-e89b-12d3-a456-426614174000",
             "01890f3e-8b5a-7cc2-98c7-2f9c0b6a1d43",
+            "01890f3e-8b5a-7cC2-98c7-2f9c0b6a1d43",
             "DeterministicProjectConfigurationManager",
             "DeterministicProjectConfigurationManagerV2",
             "AlicePlatformReviewer2026Account",
@@ -260,6 +261,9 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "@scope/hermes-agent-runtime-v2-package",
             "packages/hermes-agent-runtime-v2-package/src",
             "https://example.com/releases/hermes-agent-v2-package",
+            "@scope/HermesAgent-runtime-v2-package",
+            "packages/HermesAgent-runtime-v2-package/src",
+            "https://github.com/NousResearch/HermesAgent-runtime-v2-package",
             "project-2026-memory-hardening-identifier",
             "/private/var/folders/21/8zb1drv53h1d0vm3tv0f6mym0000gn/T/tmpabcd/.omh/memory",
             (

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -304,6 +304,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "abcdefghijklmnopqrstuvwxyzaaaaaaaaa",
             "ABCDEFGHIJKLMNOPQRSTUVWXYZaBcdef",
             "J" + "j" * 9 + "K" + "k" * 9 + "L" + "l" * 11,
+            "QwertyuiopaAsdfghjklmObservation",
         )
         uppercase_alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWX12345678"
         split_opaque = "ABCDEFGH.abcdIJKL.MNOPQRST.UVWXwxyz"
@@ -317,6 +318,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
                 self.assertGreater(len(decoded), 0)
             with self.subTest(opaque=opaque):
                 self.assertEqual(governance.classify_memory_admission(opaque)["status"], "needs_review")
+                self.assertTrue(governance.contains_credential_like_material(opaque))
             for container in (
                 f"/safe/{opaque}/artifact.txt",
                 f"https://example.com/{opaque}/artifact",
@@ -406,6 +408,9 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "HTTPServerConfigurationV2ProjectManager",
             "AlicePlatformReviewer2026Account",
             "AuthenticatedMaintainerObservation",
+            "/safe/AuthenticatedMaintainerObservation/artifact.txt",
+            "https://example.com/AuthenticatedMaintainerObservation/artifact",
+            "@scope/AuthenticatedMaintainerObservation",
             "direview_dprof_e9da83f21e46282d3a9ae020_r1",
             "@scope/hermes-agent-runtime-v2-package",
             "@scope/HermesAgentRuntimeV2PackageManager",

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -298,6 +298,8 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "ABCDabcdEFGHijklMNOPqrstUVWXyzab",
             "abcdefghijklmnopqrstuvwxyzaaaaaa",
             "abcdefghijklmnopqrstuvwxyzaaaaaaaaaa",
+            "abcdefghijklmnopqrstuvwxyzaaaaaaaa",
+            "abcdefghijklmnopqrstuvwxyzaaaaaaaaa",
             "ABCDEFGHIJKLMNOPQRSTUVWXYZaBcdef",
         )
         uppercase_alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWX12345678"
@@ -306,7 +308,8 @@ class SafetyAndEvaluationTests(unittest.TestCase):
 
         for opaque in (*low_transition_base64, uppercase_alphanumeric):
             if opaque in low_transition_base64:
-                self.assertEqual(len(base64.b64decode(opaque, validate=True)), len(opaque) // 4 * 3)
+                decoded = base64.b64decode(opaque + "=" * (-len(opaque) % 4), validate=True)
+                self.assertGreater(len(decoded), 0)
             with self.subTest(opaque=opaque):
                 self.assertEqual(governance.classify_memory_admission(opaque)["status"], "needs_review")
             for container in (

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -248,9 +248,17 @@ class SafetyAndEvaluationTests(unittest.TestCase):
     def test_opaque_values_need_review_without_reclassifying_common_identifiers(self) -> None:
         padded_base64 = "Ab3dEf4G" * 5 + "="
         unpadded_base64url = "Ab3d_Ef4Gh5Ij6Kl7Mn8Op9Qr0St1Uv2"
+        split_opaque = "Ab3dEf4Gh5Ij6Kl7Mn8/Op9Qr0St1Uv2WxYz"
 
         self.assertEqual(governance.classify_memory_admission(padded_base64)["status"], "needs_review")
         self.assertEqual(governance.classify_memory_admission(unpadded_base64url)["status"], "needs_review")
+        for normalized_bypass in (
+            split_opaque,
+            f"https://example.com/{split_opaque}",
+            r"C:\safe\Ab3dEf4Gh5Ij6Kl7Mn8\Op9Qr0St1Uv2WxYz",
+        ):
+            with self.subTest(normalized_bypass=normalized_bypass):
+                self.assertEqual(governance.classify_memory_admission(normalized_bypass)["status"], "needs_review")
         self.assertEqual(
             governance.classify_memory_admission(f"C:\\safe\\{padded_base64}\\artifact.txt")["status"],
             "needs_review",
@@ -258,20 +266,31 @@ class SafetyAndEvaluationTests(unittest.TestCase):
 
         for ordinary in (
             "0123456789abcdef0123456789abcdef01234567",
+            "0123456789AbCdEf0123456789aBcDeF0123456789AbCdEf01234567",
             "123e4567-e89b-12d3-a456-426614174000",
             "01890f3e-8b5a-7cc2-98c7-2f9c0b6a1d43",
             "01890f3e-8b5a-7cC2-98c7-2f9c0b6a1d43",
             "DeterministicProjectConfigurationManager",
             "DeterministicProjectConfigurationManagerV2",
+            "HTTPServerConfigurationV2ProjectManager",
             "AlicePlatformReviewer2026Account",
             "direview_dprof_e9da83f21e46282d3a9ae020_r1",
             "@scope/hermes-agent-runtime-v2-package",
+            "@scope/HermesAgentRuntimeV2PackageManager",
             "packages/hermes-agent-runtime-v2-package/src",
+            "packages/HermesAgentRuntimeV2PackageManager/src",
             "https://example.com/releases/hermes-agent-v2-package",
+            "https://example.com/releases/HermesAgentRuntimeV2PackageManager",
+            (
+                "https://example.com/artifact?id="
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            ),
             "@scope/HermesAgent-runtime-v2-package",
             "packages/HermesAgent-runtime-v2-package/src",
             "https://github.com/NousResearch/HermesAgent-runtime-v2-package",
             "project-2026-memory-hardening-identifier",
+            "secret-tokenizer-library-for-python-projects",
+            "hf-transformers-inference-service-project",
             "/private/var/folders/21/8zb1drv53h1d0vm3tv0f6mym0000gn/T/tmpabcd/.omh/memory",
             (
                 "/private/var/folders/21/8zb1drv53h1d0vm3tv0f6mym0000gn/T/tmpabcd/.omh/plans/"

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -197,12 +197,14 @@ class SafetyAndEvaluationTests(unittest.TestCase):
         github = "gh" + "p_" + "a" * 36
         openai = "sk" + "-" + "a" * 48
         stripe = "sk_" + "live_" + "a" * 32
+        stripe_restricted = "rk_" + "live_" + "a" * 32
         google_oauth = "ya29." + "a" * 40
         for content in (
             aws,
             github,
             openai,
             stripe,
+            stripe_restricted,
             google_oauth,
             f"C:\\safe\\{github}\\artifact.txt",
             "https://user:pass@example.com",
@@ -402,6 +404,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "DeterministicProjectConfigurationManagerV2",
             "HTTPServerConfigurationV2ProjectManager",
             "AlicePlatformReviewer2026Account",
+            "AuthenticatedMaintainerObservation",
             "direview_dprof_e9da83f21e46282d3a9ae020_r1",
             "@scope/hermes-agent-runtime-v2-package",
             "@scope/HermesAgentRuntimeV2PackageManager",

--- a/tests/test_memory_governance_evaluation.py
+++ b/tests/test_memory_governance_evaluation.py
@@ -328,6 +328,8 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "QwertyuiopaAsdfghjklmObservation",
             "QwertyuiopaAsdfghjklmObservationV2",
             "QwertyuiopaAsdfghjklmObservationContext",
+            "QwertyuiopaAsdefghijkObservationV2",
+            "QwertyuiopaAsdefghijkObservationContext",
             "AbcDefGhiJklMnoPqrStuVwxYzaBcdEfgJkl",
         )
         uppercase_alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWX12345678"
@@ -453,6 +455,7 @@ class SafetyAndEvaluationTests(unittest.TestCase):
             "https://example.com/AuthenticatedMaintainerObservation/artifact",
             "@scope/AuthenticatedMaintainerObservation",
             "ABlockIsRecoverableAndNotTerminal",
+            "English-Canonical Interview Protocol",
             "benchmarks/live-model-tools/v1/README.md",
             "https://github.com/rlaope/oh-my-hermes/blob/main/docs/CAPABILITY_IMPACT.md",
             "https://github.com/rlaope/oh-my-hermes/blob/6da2a3cac0ac854d475a930f8975208bc22b06c9/docs/CAPABILITY_IMPACT.md",

--- a/tests/test_memory_lifecycle.py
+++ b/tests/test_memory_lifecycle.py
@@ -112,6 +112,18 @@ class MemoryLifecycleTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 governance.build_retention("volatile", record_type="fact", admitted_at=NOW, ttl_days=ttl)
 
+    def test_lifecycle_replay_status_masks_credential_shaped_identity_and_scope(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        record, _ = _record("mem-safe", 1, "safe-scope", "volatile", admitted_at=NOW)
+        record["record_id"] = credential
+        record["scope"] = {"kind": "project", "ref": credential}
+
+        status = lifecycle_replay_status(record, now=NOW)
+
+        self.assertNotIn(credential, json.dumps(status, sort_keys=True))
+        self.assertEqual(status["record_id"], "redacted")
+        self.assertEqual(status["scope"]["ref"], "redacted")
+
     def test_retire_restore_reapprove_and_restore_conflict(self) -> None:
         with TemporaryDirectory() as tmp:
             paths, executor = _paths(tmp), _Executor()
@@ -241,6 +253,41 @@ class MemoryLifecycleTests(unittest.TestCase):
             self.assertEqual(plan.mutations, ())
             self.assertNotIn(credential, json.dumps(plan.report, sort_keys=True))
             self.assertTrue((paths.memory_dir / "records/mem-one.json").exists())
+
+    def test_lifecycle_candidate_ids_reject_credential_shapes_without_echo_or_write(self) -> None:
+        credential = "gh" + "u_" + "a" * 36
+        with TemporaryDirectory() as tmp:
+            paths, executor = _paths(tmp), _Executor()
+            _write_fixture(paths, retention="standard")
+
+            with self.assertRaises(ValueError) as correction_error:
+                build_memory_correction(
+                    paths,
+                    "mem-one",
+                    1,
+                    "safe corrected summary",
+                    now=NOW,
+                    candidate_id=credential,
+                )
+
+            self.assertNotIn(credential, str(correction_error.exception))
+            self.assertFalse((paths.memory_dir / "candidates" / f"{credential}.json").exists())
+
+            apply_memory_retirement(
+                paths,
+                build_memory_retirement(paths, "mem-one", 1, now=NOW),
+                transaction_executor=executor,
+            )
+            with self.assertRaises(ValueError) as restore_error:
+                build_memory_restore(paths, "mem-one", 1, now=NOW, candidate_id=credential)
+
+            self.assertNotIn(credential, str(restore_error.exception))
+            self.assertFalse((paths.memory_dir / "candidates" / f"{credential}.json").exists())
+
+            with self.assertRaises(ValueError) as reapproval_error:
+                build_memory_reapproval(paths, credential, reviewer_claim="reviewer", now=NOW)
+
+            self.assertNotIn(credential, str(reapproval_error.exception))
 
     def test_prune_is_scoped_and_manifest_mismatch_fails_closed(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory_lifecycle.py
+++ b/tests/test_memory_lifecycle.py
@@ -135,6 +135,76 @@ class MemoryLifecycleTests(unittest.TestCase):
             self.assertFalse(conflict.report["eligible"])
             self.assertEqual(conflict.report["reason_code"], "newer_live_revision_conflict")
 
+    def test_restore_rescans_legacy_archive_before_creating_a_candidate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, executor = _paths(tmp), _Executor()
+            _write_fixture(paths, retention="standard")
+            retirement = build_memory_retirement(paths, "mem-one", 1, now=NOW)
+            apply_memory_retirement(paths, retirement, transaction_executor=executor)
+            archive_path = paths.memory_dir / "archive/mem-one.r1.json"
+            archive = json.loads(archive_path.read_text())
+            credential = "gh" + "u_" + "a" * 36
+            archive["source"] = credential
+            atomic_write_json(archive_path, archive, private=True)
+
+            plan = build_memory_restore(paths, "mem-one", 1, now=NOW, candidate_id="cand-unsafe")
+
+            self.assertFalse(plan.report["eligible"])
+            self.assertEqual(plan.report["reason_code"], "safety_blocked_in_source")
+            self.assertEqual(plan.mutations, ())
+            self.assertNotIn(credential, json.dumps(plan.report, sort_keys=True))
+            self.assertFalse((paths.memory_dir / "candidates/cand-unsafe.json").exists())
+
+    def test_reapproval_rescans_existing_candidate_before_writing_a_record(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, executor = _paths(tmp), _Executor()
+            _write_fixture(paths, retention="standard")
+            apply_memory_retirement(
+                paths,
+                build_memory_retirement(paths, "mem-one", 1, now=NOW),
+                transaction_executor=executor,
+            )
+            restore = build_memory_restore(paths, "mem-one", 1, now=NOW, candidate_id="cand-existing")
+            apply_memory_restore(paths, restore, transaction_executor=executor)
+            candidate_path = paths.memory_dir / "candidates/cand-existing.json"
+            candidate = json.loads(candidate_path.read_text())
+            credential = "gh" + "u_" + "a" * 36
+            candidate["replacement"]["summary"] = credential
+            atomic_write_json(candidate_path, candidate, private=True)
+
+            plan = build_memory_reapproval(paths, "cand-existing", reviewer_claim="reviewer", now=NOW)
+
+            self.assertFalse(plan.report["eligible"])
+            self.assertEqual(plan.report["reason_code"], "safety_blocked_in_summary")
+            self.assertEqual(plan.mutations, ())
+            self.assertNotIn(credential, json.dumps(plan.report, sort_keys=True))
+            self.assertFalse((paths.memory_dir / "records/mem-one.json").exists())
+
+    def test_reapproval_rejects_credential_shaped_reviewer_claim(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths, executor = _paths(tmp), _Executor()
+            _write_fixture(paths, retention="standard")
+            apply_memory_retirement(
+                paths,
+                build_memory_retirement(paths, "mem-one", 1, now=NOW),
+                transaction_executor=executor,
+            )
+            restore = build_memory_restore(paths, "mem-one", 1, now=NOW, candidate_id="cand-reviewer")
+            apply_memory_restore(paths, restore, transaction_executor=executor)
+            credential = "gh" + "u_" + "a" * 36
+
+            plan = build_memory_reapproval(
+                paths,
+                "cand-reviewer",
+                reviewer_claim=credential,
+                now=NOW,
+            )
+
+            self.assertFalse(plan.report["eligible"])
+            self.assertEqual(plan.report["reason_code"], "unsafe_reviewer_claim")
+            self.assertEqual(plan.mutations, ())
+            self.assertNotIn(credential, json.dumps(plan.report, sort_keys=True))
+
     def test_correction_targets_one_revision_and_supersedes_before_replay(self) -> None:
         with TemporaryDirectory() as tmp:
             paths, executor = _paths(tmp), _Executor()
@@ -150,6 +220,27 @@ class MemoryLifecycleTests(unittest.TestCase):
             wrong = build_memory_correction(paths, "mem-one", 1, "ignored", now=NOW, candidate_id="cand-wrong")
             self.assertFalse(wrong.report["eligible"])
             self.assertEqual(original["revision"], 1)
+
+    def test_correction_rejects_credential_shaped_summary_before_creating_a_candidate(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _write_fixture(paths, retention="standard", admitted_at=NOW)
+            credential = "gh" + "u_" + "a" * 36
+
+            plan = build_memory_correction(
+                paths,
+                "mem-one",
+                1,
+                credential,
+                now=NOW,
+                candidate_id="cand-unsafe",
+            )
+
+            self.assertFalse(plan.report["eligible"])
+            self.assertEqual(plan.report["reason_code"], "safety_blocked_in_summary")
+            self.assertEqual(plan.mutations, ())
+            self.assertNotIn(credential, json.dumps(plan.report, sort_keys=True))
+            self.assertTrue((paths.memory_dir / "records/mem-one.json").exists())
 
     def test_prune_is_scoped_and_manifest_mismatch_fails_closed(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_memory_operations.py
+++ b/tests/test_memory_operations.py
@@ -100,6 +100,49 @@ class MemoryOperationTests(unittest.TestCase):
             self.assertTrue((paths.memory_dir / "records/two.json").exists())
             self.assertFalse((paths.memory_dir / "staging/second.json").exists())
 
+    def test_operation_id_cannot_be_reused_for_a_different_request(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            _stage(paths, "first.json", {"entry": "first"})
+            _stage(paths, "second.json", {"entry": "second"})
+            operation_id = "op-request-binding"
+            run_memory_operation(
+                paths,
+                operation_id=operation_id,
+                operation_type="write",
+                steps=[
+                    {
+                        "name": "write_first",
+                        "action": "copy",
+                        "source": "staging/first.json",
+                        "target": "records/first.json",
+                    }
+                ],
+                now=NOW,
+            )
+            operation_path = paths.memory_operations_dir / f"{operation_id}.json"
+            completed_bytes = operation_path.read_bytes()
+
+            with self.assertRaisesRegex(ValueError, "already bound"):
+                run_memory_operation(
+                    paths,
+                    operation_id=operation_id,
+                    operation_type="write",
+                    steps=[
+                        {
+                            "name": "write_second",
+                            "action": "copy",
+                            "source": "staging/second.json",
+                            "target": "records/second.json",
+                        }
+                    ],
+                    now=NOW,
+                )
+
+            self.assertEqual(operation_path.read_bytes(), completed_bytes)
+            self.assertTrue((paths.memory_dir / "records" / "first.json").exists())
+            self.assertFalse((paths.memory_dir / "records" / "second.json").exists())
+
     def test_interrupted_named_write_recovers_once_without_duplicate_move(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = _paths(tmp)

--- a/tests/test_memory_operations.py
+++ b/tests/test_memory_operations.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 from _local_package import load_local_package
-from _platform_support import requires_fcntl_locks
+from _platform_support import requires_fcntl_locks, requires_symlinks
 
 load_local_package()
 from omh.local_store import atomic_write_json, ensure_dir, read_json_object_result
@@ -66,6 +66,164 @@ class MemoryOperationTests(unittest.TestCase):
             self.assertEqual(paths.memory_migrations_dir, paths.memory_dir / "migrations")
             self.assertEqual(paths.memory_history_dir, paths.memory_dir / "history")
             self.assertEqual(paths.memory_archive_dir, paths.memory_dir / "archive")
+
+    def test_generic_operation_and_tombstone_writers_reject_credential_material_before_writes(self) -> None:
+        unsafe_values = (
+            "QwertyuiopaAsdfghjklmObservation",
+            "QwertyuiopaAsdfghjklmObservationContext",
+            "rk_" + "live_" + "a" * 32,
+        )
+        for unsafe in unsafe_values:
+            with self.subTest(unsafe=unsafe[:8]), TemporaryDirectory() as tmp:
+                paths = _paths(tmp)
+                safe_step = {
+                    "name": "write_safe",
+                    "action": "write_json",
+                    "target": "records/safe.json",
+                    "payload": {"summary": "safe value"},
+                }
+                attempts = (
+                    {
+                        "operation_id": unsafe,
+                        "operation_type": "write",
+                        "steps": [safe_step],
+                    },
+                    {
+                        "operation_id": "op-safe-target",
+                        "operation_type": "write",
+                        "steps": [{**safe_step, "target": f"records/{unsafe}.json"}],
+                    },
+                    {
+                        "operation_id": "op-safe-payload",
+                        "operation_type": "write",
+                        "steps": [{**safe_step, "payload": {"summary": unsafe}}],
+                    },
+                )
+                for request in attempts:
+                    with self.assertRaises(ValueError) as operation_error:
+                        run_memory_operation(paths, now=NOW, **request)
+                    self.assertNotIn(unsafe, str(operation_error.exception))
+
+                for field in ("tombstone_id", "record_id"):
+                    tombstone = {
+                        "tombstone_id": "tomb-safe",
+                        "record_id": "record-safe",
+                        "revision": 1,
+                        "tombstoned_at": NOW.isoformat().replace("+00:00", "Z"),
+                    }
+                    tombstone[field] = unsafe
+                    with self.assertRaises(ValueError) as tombstone_error:
+                        write_memory_tombstone(paths, tombstone)
+                    self.assertNotIn(unsafe, str(tombstone_error.exception))
+
+                persisted = "\n".join(
+                    path.read_text(encoding="utf-8")
+                    for path in paths.memory_dir.rglob("*")
+                    if path.is_file()
+                ) if paths.memory_dir.exists() else ""
+                self.assertNotIn(unsafe, persisted)
+                self.assertFalse((paths.memory_dir / "records").exists())
+                self.assertFalse(paths.memory_operations_dir.exists())
+                self.assertFalse(paths.memory_tombstones_dir.exists())
+
+    def test_copy_and_move_reject_credential_material_in_source_objects(self) -> None:
+        unsafe = "QwertyuiopaAsdfghjklmObservationContext"
+        for action in ("copy", "move"):
+            with self.subTest(action=action), TemporaryDirectory() as tmp:
+                paths = _paths(tmp)
+                source = paths.memory_dir / "records" / "source.json"
+                atomic_write_json(source, {"summary": unsafe}, private=True)
+
+                with self.assertRaises(ValueError) as error:
+                    run_memory_operation(
+                        paths,
+                        operation_id=f"op-safe-{action}",
+                        operation_type=action,
+                        steps=[
+                            {
+                                "name": f"{action}_safe",
+                                "action": action,
+                                "source": "records/source.json",
+                                "target": f"records/{action}-target.json",
+                            }
+                        ],
+                        now=NOW,
+                    )
+
+                self.assertNotIn(unsafe, str(error.exception))
+                self.assertTrue(source.exists())
+                self.assertFalse((paths.memory_dir / "records" / f"{action}-target.json").exists())
+                operation_files = list(paths.memory_operations_dir.glob("*.json"))
+                self.assertEqual(len(operation_files), 1)
+                self.assertNotIn(unsafe, operation_files[0].read_text(encoding="utf-8"))
+
+    def test_index_rebuild_omits_preexisting_unsafe_record_paths(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            unsafe = "QwertyuiopaAsdfghjklmObservation"
+            unsafe_path = paths.memory_dir / "records" / f"{unsafe}.json"
+            atomic_write_json(unsafe_path, {"summary": "synthetic fixture"}, private=True)
+
+            run_memory_operation(
+                paths,
+                operation_id="op-safe-index",
+                operation_type="write",
+                steps=[
+                    {
+                        "name": "write_safe",
+                        "action": "write_json",
+                        "target": "records/safe.json",
+                        "payload": {"summary": "safe value"},
+                    }
+                ],
+                now=NOW,
+            )
+            index = json.loads(paths.memory_index_path.read_text(encoding="utf-8"))
+
+            self.assertNotIn(unsafe, json.dumps(index, sort_keys=True))
+            self.assertEqual(index["record_files"], ["records/safe.json"])
+
+    @requires_symlinks
+    def test_operation_and_tombstone_parent_symlinks_cannot_escape_memory_store(self) -> None:
+        for directory_name in ("operations", "tombstones"):
+            with self.subTest(directory=directory_name), TemporaryDirectory() as tmp:
+                paths = _paths(tmp)
+                paths.memory_dir.mkdir(parents=True)
+                outside = Path(tmp) / "outside"
+                outside.mkdir()
+                (paths.memory_dir / directory_name).symlink_to(
+                    outside,
+                    target_is_directory=True,
+                )
+
+                with self.assertRaises(ValueError):
+                    if directory_name == "operations":
+                        run_memory_operation(
+                            paths,
+                            operation_id="op-symlink-parent",
+                            operation_type="write",
+                            steps=[
+                                {
+                                    "name": "write_safe",
+                                    "action": "write_json",
+                                    "target": "records/safe.json",
+                                    "payload": {"summary": "safe value"},
+                                }
+                            ],
+                            now=NOW,
+                        )
+                    else:
+                        write_memory_tombstone(
+                            paths,
+                            {
+                                "tombstone_id": "tomb-safe",
+                                "record_id": "record-safe",
+                                "revision": 1,
+                                "tombstoned_at": NOW.isoformat().replace("+00:00", "Z"),
+                            },
+                        )
+
+                self.assertEqual(list(outside.iterdir()), [])
 
     def test_multi_step_operation_completes_with_one_metadata_receipt(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_parser_memory.py
+++ b/tests/test_parser_memory.py
@@ -147,6 +147,28 @@ class MemoryReviewRevisionCliTests(unittest.TestCase):
             self.assertFalse(payload["applied"])
             self.assertFalse((root / ".omh" / "memory" / "records").exists())
 
+    def test_stale_review_refusal_never_echoes_caller_revision(self) -> None:
+        sensitive_revision = "JBSWY3DPEHPK3PXP" * 3
+        for action in ("approve", "reject"):
+            with self.subTest(action=action), TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                homes, candidate_id = self._capture(root)
+
+                status, stdout, stderr = run_cli(
+                    [*homes, "memory", action, candidate_id, "--candidate-revision", sensitive_revision]
+                )
+
+                payload = json.loads(stdout)
+                self.assertNotEqual(status, 0)
+                self.assertEqual(payload["reason_code"], "stale_review")
+                self.assertEqual(
+                    payload["detail"],
+                    "stale_review: the candidate changed after the reviewed card was rendered; re-read it and decide again",
+                )
+                self.assertNotIn(sensitive_revision, stdout)
+                self.assertNotIn(sensitive_revision, stderr)
+                self.assertFalse((root / ".omh" / "memory" / "records").exists())
+
     def test_approve_and_reject_with_the_displayed_revision_succeed(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- carry the useful implementation from #1342 on current `main` while preserving contributor authorship
- block known provider credentials and opaque credential-shaped values before memory persistence, review exposure, lifecycle replay, recall, status, retirement, or coding handoff
- detect padded and unpadded encoded material, mixed- and single-case opaque runs, and separator-split values inside paths, URLs, package-like containers, and structural selectors
- preserve normal SHAs, UUIDs, prose, CamelCase/version identifiers, semantic uppercase constants, code symbols, package/project identifiers, POSIX/Windows/UNC paths, URLs, and query metadata
- bind each staged batch, candidate subject, authorization decision, retention policy, review membership, scope, operation, and logical target before apply
- reject malformed scopes, duplicate identities, live logical-target collisions, target drift, symlink path escapes, interrupted review state, and partial-apply inconsistencies before unrelated writes
- recursively sanitize legacy candidates, records, review/rejection payloads, inspection/lineage/perspective output, lifecycle artifacts, generic memory read surfaces, and handoff metadata, including mapping keys

Closes #1329

## Verification

Exact head: `61abcfdbb1ffe3a9c015e867cea1432f751da34b`

- rebased onto current `origin/main` `6da2a3cac0ac854d475a930f8975208bc22b06c9`
- focused memory and parser-memory suites covering suffix/separator classification, generic persistence/copy/move/index safety, replay non-echo, metadata symlinks, dismissal semantics, review binding, scope/operation identity, interruption, and recovery — 576 passed
- repository source/Markdown separator-split corpus probe — no unexpected matches
- `uv run --group lint ruff check src tests` — passed
- `uv run python -m compileall -q src tests` — passed
- `git diff --check` — passed
- full repository suite and generated/static gates — running
- exact-head GitHub CI and DCO (`34000960631`) — running
- exact-head privacy/persistence-integrity and compatibility/batch-correctness rereviews — running

## Risk

Opaque-value recognition is intentionally conservative and heuristic: ambiguous values require review rather than being persisted automatically. Legacy or interrupted batch reviews without complete candidate bindings are not executable and require a fresh review. Hash linkage detects accidental, partial, and single-artifact local drift; it does not claim authentication against a writer that can rewrite every local artifact and recompute all hashes.
