### PR TITLE
fix(install): read the redirect Location header through a capability probe

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -604,6 +604,56 @@ function Get-OmhNormalizedTag {
     return "v$Version"
 }
 
+function Get-OmhRedirectLocation {
+    # Invoke-WebRequest exposes different header object types by PowerShell
+    # version and whether the redirect was returned or raised as an error.
+    param([object]$Response)
+    if ($null -eq $Response) { return '' }
+
+    $OmhHeadersProperty = $Response.PSObject.Properties['Headers']
+    if (-not $OmhHeadersProperty) { return '' }
+    try {
+        $OmhHeaders = $OmhHeadersProperty.Value
+    } catch {
+        return ''
+    }
+    if ($null -eq $OmhHeaders) { return '' }
+
+    # PowerShell 7's HttpResponseHeaders exposes Location as a Uri property.
+    $OmhLocationProperty = $OmhHeaders.PSObject.Properties['Location']
+    if ($OmhLocationProperty) {
+        try {
+            $OmhLocation = $OmhLocationProperty.Value
+            foreach ($OmhLocationValue in $OmhLocation) {
+                if ($null -ne $OmhLocationValue) { return [string]$OmhLocationValue }
+            }
+        } catch {}
+    }
+
+    # HttpResponseHeaders also provides TryGetValues; dictionaries do not.
+    $OmhTryGetValues = $OmhHeaders.PSObject.Methods['TryGetValues']
+    if ($OmhTryGetValues) {
+        try {
+            $OmhLocationValues = $null
+            if ($OmhHeaders.TryGetValues('Location', [ref]$OmhLocationValues)) {
+                foreach ($OmhLocationValue in $OmhLocationValues) {
+                    if ($null -ne $OmhLocationValue) { return [string]$OmhLocationValue }
+                }
+            }
+        } catch {}
+    }
+
+    # Windows PowerShell's WebHeaderCollection and response dictionaries use
+    # an indexer. Keep it isolated because HttpResponseHeaders has none.
+    try {
+        $OmhLocation = $OmhHeaders['Location']
+        foreach ($OmhLocationValue in $OmhLocation) {
+            if ($null -ne $OmhLocationValue) { return [string]$OmhLocationValue }
+        }
+    } catch {}
+    return ''
+}
+
 # ---------------------------------------------------------------------------
 # Main flow
 # ---------------------------------------------------------------------------
@@ -627,10 +677,10 @@ try {
                     $OmhLatestLocation = ''
                     try {
                         $OmhLatestResponse = Invoke-WebRequest -Uri $OmhRepoLatestUrl -Method Head -MaximumRedirection 0 -ErrorAction Stop
-                        $OmhLatestLocation = [string]$OmhLatestResponse.Headers['Location']
+                        $OmhLatestLocation = Get-OmhRedirectLocation $OmhLatestResponse
                     } catch {
                         $OmhLatestError = $_.Exception.Response
-                        if ($OmhLatestError) { $OmhLatestLocation = [string]$OmhLatestError.Headers['Location'] }
+                        $OmhLatestLocation = Get-OmhRedirectLocation $OmhLatestError
                     }
                     if ($OmhLatestLocation -match '/releases/tag/v([0-9]+\.[0-9]+\.[0-9]+)/?$') {
                         $OmhVersion = $Matches[1]
@@ -760,4 +810,10 @@ try {
 # `exit` only when this file was run as a script, which is what CI does. Under
 # `irm ... | iex` there is no script scope, so exiting would close the user's
 # shell on top of the diagnostic they still need to read.
-if ($OmhInstallFailed -and $MyInvocation.MyCommand.Path) { exit $OmhExitCode }
+$OmhInvocationPath = ''
+$OmhInvocationCommand = $MyInvocation.MyCommand
+if ($OmhInvocationCommand) {
+    $OmhInvocationPathProperty = $OmhInvocationCommand.PSObject.Properties['Path']
+    if ($OmhInvocationPathProperty) { $OmhInvocationPath = [string]$OmhInvocationPathProperty.Value }
+}
+if ($OmhInstallFailed -and $OmhInvocationPath) { exit $OmhExitCode }

--- a/tests/test_windows_install_path.py
+++ b/tests/test_windows_install_path.py
@@ -78,6 +78,25 @@ class WindowsInstallerPresenceTests(unittest.TestCase):
         self.assertNotIn(b"\r\n", INSTALL_PS1.read_bytes())
 
 
+class WindowsInstallerRedirectResponseTests(unittest.TestCase):
+    def test_redirect_headers_and_invocation_guard_are_capability_checked(self) -> None:
+        powershell = INSTALL_PS1.read_text(encoding="utf-8")
+
+        # PowerShell 7's HttpResponseHeaders has no indexer, while the other
+        # supported response shapes do. The installer must hand both response
+        # paths to one accessor that probes what the actual object supports.
+        self.assertNotIn("$OmhLatestResponse.Headers['Location']", powershell)
+        self.assertNotIn("$OmhLatestError.Headers['Location']", powershell)
+        self.assertEqual(powershell.count("Get-OmhRedirectLocation $OmhLatest"), 2)
+        self.assertIn("PSObject.Properties['Headers']", powershell)
+        self.assertIn("PSObject.Properties['Location']", powershell)
+
+        # `irm | iex` has no MyCommand.Path. StrictMode makes touching that
+        # absent property a terminating error, so the exit guard must probe it.
+        self.assertNotIn("$MyInvocation.MyCommand.Path", powershell)
+        self.assertIn("PSObject.Properties['Path']", powershell)
+
+
 class WindowsInstallerContractParityTests(unittest.TestCase):
     """install.ps1 must accept the same inputs install.sh does."""
 


### PR DESCRIPTION
Closes #1350.

## Feature Report

### What Changed

- `install.ps1` gains `Get-OmhRedirectLocation`, one accessor used by both redirect call sites, which probes what the header object it was handed actually supports: an adapted `Location` property, then `TryGetValues`, then the indexer, each attempt isolated so the one that cannot work is caught instead of fatal.
- The two call sites at the latest-release lookup no longer read `$OmhLatestResponse.Headers['Location']` / `$OmhLatestError.Headers['Location']`.
- The final exit guard probes `$MyInvocation.MyCommand.PSObject.Properties['Path']` instead of reading `.Path` directly.
- `tests/test_windows_install_path.py` gains a regression test pinning both contracts.

### Why This Exists

The documented Windows install path is `irm https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.ps1 | iex`. On Windows 11 25H2 it failed while resolving the latest stable release, reproduced by the reporter on both Windows PowerShell 5.1 and PowerShell 7.6:

```
Unable to index into an object of type "System.Net.Http.Headers.HttpResponseHeaders".
Invoke-Expression: The property 'Path' cannot be found on this object. Verify that the property exists.
```

The installer sends a HEAD request with `-MaximumRedirection 0` and reads the redirect target out of the `Location` header. PowerShell 7 raises that 302 as an error, and `$_.Exception.Response.Headers` is a `System.Net.Http.Headers.HttpResponseHeaders` -- a type that exposes `Location` as a `Uri` and a `TryGetValues` method, and no indexer at all. Index notation therefore threw on exactly the path the redirect always takes.

The second error is why the report reads as confusing rather than as one clear failure. `install.ps1` runs under `Set-StrictMode -Version 3.0`, and piping a script into `Invoke-Expression` leaves no script file, so the final `$MyInvocation.MyCommand.Path` guard was itself a terminating error that masked the real cause.

### User / Operator Impact

- A Windows user running the documented one-liner can install again; the latest stable release resolves on both PowerShell 5.1 and PowerShell 7.
- When something does go wrong, the diagnostic the installer prints is the one the user sees, instead of being replaced by a `The property 'Path' cannot be found` error from the guard.
- Running `./install.ps1` as a file still exits with the recorded failure code, which is what CI depends on; the piped form still returns control instead of closing the shell.

### How It Works

Four response shapes reach these call sites and they do not agree on how a header is read: a PowerShell 7 response dictionary, a PowerShell 7 `HttpResponseHeaders` on the error path, a Windows PowerShell 5.1 response dictionary, and a 5.1 `WebHeaderCollection`. `Get-OmhRedirectLocation` asks each object what it supports before using it -- `PSObject.Properties['Location']`, then `PSObject.Methods['TryGetValues']` with a `[ref]` out parameter, then the indexer inside its own `try` -- and returns an empty string when no `Location` is present, which is the value the caller already handled. The version-extracting regex still receives the same single string it did before.

### Files And Contracts Touched

- `install.ps1` — the accessor, its two call sites, and the exit guard.
- `tests/test_windows_install_path.py` — `WindowsInstallerRedirectResponseTests`.
- No generated artifact, schema, dependency, or CLI surface changed.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`

### Observed Evidence

- Full suite on this tree: 9346 tests, OK, 1 skipped. `docs ulw-inventory --check` and `docs ulw-site --check` also exit 0.
- The regression test was captured failing against the pre-fix installer and passing after, so it can fail for the regression it names.
- Independent gate review of the diff: approved, with a line-by-line reading of which branch fires for each of the four header shapes, confirmation that `param()` is the first statement of the function, that the function is defined before both call sites, that `[ref]` binds the `out IEnumerable<string>` parameter identically in 5.1 and 7, and that `Dictionary` exposes `TryGetValue` (singular) so the method probe correctly excludes it.

### Not Tested / Not Applicable

- **No PowerShell of either version exists on the authoring machine**, so `install.ps1` was neither parsed nor executed locally. The PowerShell 7 parse gate, the Windows PowerShell 5.1 parse gate, and the end-to-end install on `windows-latest` in this PR are the first execution of this code; treat them as the real evidence.
- The reporter's environment (Windows 11 25H2, PowerShell 5.1 and 7.6) was not reproduced directly.
- `omh harness validate`, `omh release checklist`, and `omh release hermes-smoke` are unrelated to this change and run in CI.

## Risk

The accessor is more defensive than the line it replaces, so the failure mode shifts from throwing to returning an empty string -- in which case the installer falls back exactly as it already did when no `Location` was present. The real risk is a syntax or member-access mistake that only Windows can reveal, which is why the change stays inside one function and why both CI parse gates and the end-to-end install must be green before merge.

## Compatibility / Rollout

No flag, output, or contract changed. Users on the current release are affected only in that the installer starts working; nothing needs migrating. `install.ps1` is served from `main`, so the fix reaches users as soon as this merges.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- The regression test pins call-site spelling (`Get-OmhRedirectLocation $OmhLatest` twice), so an innocent variable rename will break the test without breaking the installer. That is the cost of a source-text seam for a script that cannot run here; a behavioural PowerShell test would need Pester on a Windows runner.