### PR TITLE
fix(coding): declare the glued and encoded spellings a target token hides

### DIFF
--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -7,6 +7,7 @@ import hashlib
 from pathlib import Path
 import re
 from typing import Any, Mapping
+from urllib.parse import unquote
 
 from ..coding_contracts import (
     CLAUDE_CODE_SESSION_OBSERVATION_CONTRACT_SCHEMA_VERSION,
@@ -1199,8 +1200,22 @@ def _preflight_command_tokens() -> frozenset[str]:
     )
 
 
-def _preflight_path_candidate(token: str) -> str:
-    """Preserve the RHS filesystem anchor of an assignment or label."""
+# Delimiters can join an otherwise ordinary token to a second target. Only an
+# anchored remainder is a path: this keeps prose such as `12:30` and a second
+# project-relative name after `;` from manufacturing filesystem declarations.
+_PREFLIGHT_EMBEDDED_PATH_DELIMITERS = frozenset(";=:|&?,'\"`")
+_PERCENT_ESCAPE_RE = re.compile(r"%[0-9a-f]{2}", re.IGNORECASE)
+
+
+def _preflight_filesystem_anchor(token: str) -> bool:
+    """Recognize path starts that containment must inspect before label parsing."""
+    return token.startswith(("/", "\\", "~", "./", ".\\", "../", "..\\")) or bool(
+        re.match(r"^[a-z]:", token, re.IGNORECASE)
+    )
+
+
+def _preflight_assignment_path_candidate(token: str) -> str:
+    """Preserve the legacy RHS extraction so added spellings never replace it."""
     if "=" in token:
         _, value = token.split("=", 1)
         if value:
@@ -1211,6 +1226,52 @@ def _preflight_path_candidate(token: str) -> str:
     ):
         return value
     return token
+
+
+def _preflight_path_candidate(token: str) -> str:
+    """Keep an anchored target intact instead of rewriting it as a label value."""
+    return token if _preflight_filesystem_anchor(token) else _preflight_assignment_path_candidate(token)
+
+
+def _preflight_embedded_path_fragments(token: str) -> list[str]:
+    """Return only delimiter suffixes that independently begin at a filesystem root."""
+    fragments: list[str] = []
+    for index, character in enumerate(token):
+        if character not in _PREFLIGHT_EMBEDDED_PATH_DELIMITERS:
+            continue
+        # A drive letter's colon is part of its absolute anchor, not a label
+        # delimiter that should declare the same path a second time.
+        if character == ":" and index == 1 and token[0].isalpha():
+            continue
+        fragment = token[index + 1 :].rstrip(_CODE_REFERENCE_TRIM_CHARS).lstrip(_CODE_REFERENCE_OPENING_TRIM_CHARS)
+        if _preflight_filesystem_anchor(fragment):
+            fragments.append(fragment)
+    return fragments
+
+
+def _preflight_path_spellings(token: str) -> list[str]:
+    """Add anchored and decoded spellings without narrowing the legacy scan."""
+    spellings = [_preflight_path_candidate(token), _preflight_assignment_path_candidate(token)]
+    spellings.extend(_preflight_embedded_path_fragments(token))
+    # Decode only actual percent escapes and only after a raw URL was excluded
+    # by the caller. Decoding is deliberately single-pass: `%252e%252e` stays
+    # literal, matching a filesystem consumer's name. `unquote` leaves malformed
+    # escapes literal, while a second spelling exposes encoded separators and
+    # parent segments to containment. Several spellings can consume scan slots,
+    # so percent-encoded filenames practically allow roughly half MAX_TARGET_PATHS.
+    if _PERCENT_ESCAPE_RE.search(token):
+        decoded = unquote(token)
+        if decoded != token:
+            decoded = decoded.rstrip(_CODE_REFERENCE_TRIM_CHARS).lstrip(_CODE_REFERENCE_OPENING_TRIM_CHARS)
+            spellings.extend(
+                (
+                    decoded,
+                    _preflight_path_candidate(decoded),
+                    _preflight_assignment_path_candidate(decoded),
+                )
+            )
+            spellings.extend(_preflight_embedded_path_fragments(decoded))
+    return spellings
 
 
 def _preflight_file_uri_path(token: str) -> str | None:
@@ -1272,22 +1333,31 @@ def _safety_preflight_target_paths(message: str, *, excluded_path: str = "") -> 
         if not token:
             continue
         file_path = _preflight_file_uri_path(token)
-        if file_path is None:
+        if file_path is not None:
+            spellings = [file_path]
+        else:
+            # A pasted remote stays remote before decoding can make its escaped
+            # characters resemble a local traversal spelling.
             if _is_preflight_remote_location(token):
                 continue
-            token = _preflight_path_candidate(token)
-            file_path = _preflight_file_uri_path(token)
-            if file_path is None and _is_preflight_remote_location(token):
+            spellings = _preflight_path_spellings(token)
+        for spelling in spellings:
+            file_path = _preflight_file_uri_path(spelling)
+            if file_path is not None:
+                spelling = file_path
+            elif _is_preflight_remote_location(spelling):
                 continue
-        if file_path is not None:
-            token = file_path
-        # The plan artifact is OMH-generated context. Skip only its exact path
-        # before it can consume the scan slot reserved for a real user target.
-        if token == excluded_path or not _is_preflight_filesystem_target(token) or token in paths:
-            continue
-        paths.append(token)
-        if len(paths) >= _SAFETY_PREFLIGHT_TARGET_PATH_SCAN_LIMIT:
-            return paths
+            # The plan artifact is OMH-generated context. Skip only its exact
+            # path inside this scan before it consumes a real user target slot.
+            if (
+                spelling == excluded_path
+                or not _is_preflight_filesystem_target(spelling)
+                or spelling in paths
+            ):
+                continue
+            paths.append(spelling)
+            if len(paths) >= _SAFETY_PREFLIGHT_TARGET_PATH_SCAN_LIMIT:
+                return paths
     return paths
 
 

--- a/tests/test_task_authority_envelope.py
+++ b/tests/test_task_authority_envelope.py
@@ -874,6 +874,48 @@ class FilesystemTargetScopeRegressionTests(unittest.TestCase):
                 self.assertIn(expected_path, _safety_preflight_target_paths(message))
                 self._assert_denied_for_every_profile(message, reason_code)
 
+    def test_delimited_and_percent_encoded_paths_cannot_hide_workspace_escapes(self) -> None:
+        """Every local spelling remains visible to the containment rule."""
+        for message, expected_path, reason_code in (
+            ("fix x;../outside/marker.txt", "../outside/marker.txt", "target_path_escapes_project"),
+            ("fix a=b=../outside/marker.txt", "../outside/marker.txt", "target_path_escapes_project"),
+            ("fix a/b:../outside/marker.txt", "../outside/marker.txt", "target_path_escapes_project"),
+            ('fix"../outside/marker.txt"', "../outside/marker.txt", "target_path_escapes_project"),
+            ("fix x;/etc/marker.txt", "/etc/marker.txt", "target_path_absolute"),
+            ("fix src/a.py;../outside/b.py", "../outside/b.py", "target_path_escapes_project"),
+            ("fix ../outside/marker.py?v=1", "../outside/marker.py?v=1", "target_path_escapes_project"),
+            ("fix ../outside/marker.txt?a=b", "../outside/marker.txt?a=b", "target_path_escapes_project"),
+            ("fix ..%2foutside/marker.txt", "../outside/marker.txt", "target_path_escapes_project"),
+            ("fix ..%2Foutside/marker.txt", "../outside/marker.txt", "target_path_escapes_project"),
+            ("fix %2e%2e/outside/marker.txt", "../outside/marker.txt", "target_path_escapes_project"),
+            ("fix %2e%2e%2foutside%2fmarker.txt", "../outside/marker.txt", "target_path_escapes_project"),
+            ("fix %2fetc%2fmarker.txt", "/etc/marker.txt", "target_path_absolute"),
+            (r"fix x;..\outside\marker.txt", r"..\outside\marker.txt", "target_path_escapes_project"),
+            (r"fix x;.\..\outside\marker.txt", r".\..\outside\marker.txt", "target_path_escapes_project"),
+            (r"fix x%3b..%5coutside/marker.txt", r"..\outside/marker.txt", "target_path_escapes_project"),
+        ):
+            with self.subTest(message=message):
+                self.assertIn(expected_path, _safety_preflight_target_paths(message))
+                self._assert_denied_for_every_profile(message, reason_code)
+
+        for message in (
+            "fix src/routing/chat.py?v=1",
+            'fix "docs/my%20notes.md"',
+            "fix https://example.org/a%2e%2e/b.py",
+            "fix target=src/routing/chat.py",
+            "fix src/a.py;src/b.py",
+            "fix the 12:30 timeout in src/a.py",
+            "implement pagination and add a regression test",
+        ):
+            for target in self._PROFILE_HANDOFFS:
+                with self.subTest(message=message, target=target):
+                    payload = build_coding_delegation_payload(message, executor_target=target, include_message=True)
+                    self.assertEqual(payload["action_gate"]["outcome"], "allow")
+
+        self.assertEqual(_safety_preflight_target_paths("fix target=src/routing/chat.py"), ["src/routing/chat.py"])
+        self.assertEqual(_safety_preflight_target_paths("fix https://example.org/a%2e%2e/b.py"), [])
+        self._assert_denied_for_every_profile("fix note:../outside/marker.txt", "target_path_escapes_project")
+
     def test_supported_local_targets_and_remote_references_remain_usable(self) -> None:
         from omh.coding.coding_delegation import _safety_preflight_target_paths
 


### PR DESCRIPTION
Follow-up to #1351, closing the two findings its reviewer left open plus a third found while probing them.

## Feature Report

### What Changed

- `_safety_preflight_target_paths` in `src/coding/coding_delegation.py` now yields several spellings per token instead of one: the legacy candidate, the legacy assignment right-hand side, every delimiter suffix that independently begins at a filesystem anchor, and — when the token carries real percent escapes — the decoded spelling and its fragments.
- `_preflight_filesystem_anchor` recognises `../`, `./` and their backslash twins `..\` and `.\`, alongside `/`, `\`, `~` and a drive prefix.
- An already-anchored token is no longer rewritten to an assignment right-hand side.
- `tests/test_task_authority_envelope.py` gains `test_delimited_and_percent_encoded_paths_cannot_hide_workspace_escapes`: 16 unsafe inputs asserted across all 8 profile targets, plus 7 negative controls.

### Why This Exists

#1351 stopped the workspace boundary from depending on a file extension. Its reviewer then reported that a token gluing a path to a delimiter is declared verbatim, and that percent-encoded traversals are declared but never decoded — non-blocking at the time because neither traverses as a literal filesystem name. Probing those two turned up a third, sharper one. Every input below reached an allowed, dispatchable handoff on `main`:

```
fix x;../outside/marker.txt        declared ['x;../outside/marker.txt']   allow
fix a=b=../outside/marker.txt      declared ['b=../outside/marker.txt']   allow
fix a/b:../outside/marker.txt                                            allow
fix"../outside/marker.txt"                                               allow
fix x;..\outside\marker.txt                                              allow
fix ..%2foutside/marker.txt                                              allow
fix %2e%2e%2foutside%2fmarker.txt                                        allow
fix %2fetc%2fmarker.txt                                                  allow
fix ../outside/marker.py?v=1       declared NOTHING                      allow
```

One mechanism underneath all of them: extraction produced exactly one spelling per token, and containment reads segments. `_path_parts` (`src/quality/safety_preflight.py`) splits on `/` and `\` only, so a `..` glued to a delimiter is not a segment it can see, and a `..` spelled `%2e%2e` is not one either. The last line is the worst of them: the assignment right-hand-side rewrite discarded an already-anchored path and declared its query value instead, so naming an escaping file with a query string declared no target at all.

### User / Operator Impact

- A request naming a file outside the project is denied for every coding owner even when the path is glued to a delimiter, spelled with backslashes, percent-encoded, or carries a query suffix. No executor, prompt, or runtime handoff is prepared.
- Ordinary work is unchanged. `12:30` in prose, `a;b;c`, `src/a.py;src/b.py`, `target=src/routing/chat.py`, `src/routing/chat.py?v=1`, an in-project `"docs/my%20notes.md"`, a pasted `https://` URL containing `%2e%2e`, and requests naming no path at all all still prepare their handoff.
- What this does NOT change: nothing here confines a running executor process. That row stays `declared_not_enforced` under `WORKSPACE_RUNTIME_BLOCKER`. This PR fixes what a prepared handoff declares.

### How It Works

The rule is ADD, NEVER REPLACE: whatever a token declared before it still declares, and the new spellings are additional. Anchoring is what keeps that from exploding into noise — a delimiter suffix is only declared when it independently begins at a filesystem root, so `src/a.py;src/b.py` and `12:30` name nothing new. The raw-token remote skip runs before decoding, so a pasted URL cannot be decoded into something that looks local, and each spelling is re-checked for remote and against the plan-artifact exclusion inside the scan.

Two boundaries are written down at the decoding site rather than left implicit. Decoding is single-pass, so `%252e%252e` stays literal — which is how a filesystem consumer reads that name. And because one token can now produce several declarations, the practical allowance for percent-encoded filenames in one message is roughly half of `MAX_TARGET_PATHS` before the count rule denies. The limit itself is unchanged and an overflow is still deny-visible rather than trimmed to a passing set.

`_has_code_reference` and the `_CODE_REFERENCE_*` routing constants are untouched, so which messages count as coding requests is unchanged.

### Files And Contracts Touched

- `src/coding/coding_delegation.py` — the extraction helpers.
- `tests/test_task_authority_envelope.py` — one added regression test; the file diff is purely additive and no existing assertion moved.
- No generated artifact, schema version, dependency, or CLI surface changed. `urllib.parse` is stdlib.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`

### Observed Evidence

- Full suite on the final tree: 9346 tests, OK, 1 skipped. `docs ulw-inventory --check` and `docs ulw-site --check` also exit 0.
- Real-CLI matrix, 55 scenarios, one `omh coding delegate` process each in isolated temporary OMH and Hermes homes: 55/55 pass with zero wrong outcomes and the temporary tree removed. It carries all 13 unsafe inputs above plus the backslash trio, the 7 negative controls, the earlier extension/quoting/URI cases, a 33-target overflow, and cross-owner denial for `claude-code`, `hermes`, `generic` and the three runtime profiles. Every one of the new unsafe cases was captured allowing before the fix.
- Failing-first evidence was captured for every regression before the production change.
- Independent gate review, two passes. Pass 1 blocked: `..\` and `.\` were not recognised as anchors, so `fix x;..\outside\marker.txt` still allowed — reproduced by the reviewer across all profiles. Pass 2 approved after the three-line anchor widening, having re-verified the three reproductions, probed in-project backslash spellings and encoded drive/UNC siblings for false positives, and confirmed the documented boundaries match the code.
- Language-server diagnostics on the changed files match the recorded baseline; no new diagnostic on a changed line.

### Not Tested / Not Applicable

- `omh harness validate`, `omh release checklist`, `omh release hermes-smoke` and the install smoke commands: no installer, release, or harness contract changed here, and CI runs them on this PR.
- No manual Hermes or TUI session: this change has no TUI surface; the delegation lane was exercised through its real CLI instead.
- No executor CLI was dispatched, so executor-side behaviour after dispatch stays unobserved. Windows and UNC spellings were exercised as strings on macOS; CI runs the suite on windows-latest.

## Risk

Extraction declares strictly more than before, so the risk is a false denial rather than a missed target. The full suite, the 7 negative controls and the reviewer's own probes (in-project backslash paths, `git@github.com:a/b.git`, `set PATH=/usr/bin:/bin`, prose with colons and semicolons) found none. Two residuals are documented rather than fixed: a double-encoded spelling such as `%252e%252e` stays literal, which matches how a filesystem consumer reads that name, and the practical per-message allowance for percent-encoded filenames is roughly halved before the count rule denies.

## Compatibility / Rollout

No schema version, payload key, CLI flag, or generated artifact changed. A request that names an escaping path in one of these spellings now denies where it previously prepared a handoff; that is the point of the change. Ordinary stable channel, no migration.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- OS-level filesystem confinement for dispatched executors remains the open item behind `WORKSPACE_RUNTIME_BLOCKER`. It is a separate project — an executor-neutral confinement backend around the dispatch lane — and this PR deliberately does not claim it.
- If double-encoded spellings ever matter, that needs a decode-until-fixpoint pass with its own false-positive corpus, not a second decode bolted onto this one.