### PR TITLE
fix(coding): decode to a fixpoint, and charge a slot only when containment would read it

### DIFF
--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 import hashlib
 from pathlib import Path
 import re
-from typing import Any, Mapping
+from typing import Any, Mapping, cast
 from urllib.parse import unquote
 
 from ..coding_contracts import (
@@ -1205,6 +1205,15 @@ def _preflight_command_tokens() -> frozenset[str]:
 # project-relative name after `;` from manufacturing filesystem declarations.
 _PREFLIGHT_EMBEDDED_PATH_DELIMITERS = frozenset(";=:|&?,'\"`")
 _PERCENT_ESCAPE_RE = re.compile(r"%[0-9a-f]{2}", re.IGNORECASE)
+_PERCENT_DECODE_ROUNDS = 3
+
+
+@lru_cache(maxsize=1)
+def _preflight_containment_absolute_path_re() -> re.Pattern[str]:
+    """Resolve the evaluator's absolute-path rule without an import cycle."""
+    from ..quality import safety_preflight
+
+    return cast(re.Pattern[str], vars(safety_preflight)["_ABSOLUTE_PATH_RE"])
 
 
 def _preflight_filesystem_anchor(token: str) -> bool:
@@ -1249,28 +1258,65 @@ def _preflight_embedded_path_fragments(token: str) -> list[str]:
     return fragments
 
 
-def _preflight_path_spellings(token: str) -> list[str]:
-    """Add anchored and decoded spellings without narrowing the legacy scan."""
+def _preflight_containment_key(spelling: str) -> tuple[bool, bool, bool]:
+    """The path properties `_target_paths_denial` uses for an unrooted request."""
+    path_parts = tuple(part for part in spelling.replace("\\", "/").split("/") if part not in ("", "."))
+    return (
+        not spelling.strip(),
+        bool(_preflight_containment_absolute_path_re().match(spelling)),
+        ".." in path_parts,
+    )
+
+
+def _preflight_declared_containment_key(spelling: str, *, excluded_path: str) -> tuple[bool, bool, bool] | None:
+    """Return the evaluator key only for a spelling this parser will declare."""
+    file_path = _preflight_file_uri_path(spelling)
+    if file_path is None and _is_preflight_remote_location(spelling):
+        return None
+    declared_spelling = file_path if file_path is not None else spelling
+    if declared_spelling == excluded_path or not _is_preflight_filesystem_target(declared_spelling):
+        return None
+    return _preflight_containment_key(declared_spelling)
+
+
+def _preflight_path_spellings(token: str, *, excluded_path: str = "") -> list[str]:
+    """Add decoded spellings only when containment reads a new path property."""
     spellings = [_preflight_path_candidate(token), _preflight_assignment_path_candidate(token)]
     spellings.extend(_preflight_embedded_path_fragments(token))
+    declared_keys = {
+        key
+        for spelling in spellings
+        if (key := _preflight_declared_containment_key(spelling, excluded_path=excluded_path)) is not None
+    }
     # Decode only actual percent escapes and only after a raw URL was excluded
-    # by the caller. Decoding is deliberately single-pass: `%252e%252e` stays
-    # literal, matching a filesystem consumer's name. `unquote` leaves malformed
-    # escapes literal, while a second spelling exposes encoded separators and
-    # parent segments to containment. Several spellings can consume scan slots,
-    # so percent-encoded filenames practically allow roughly half MAX_TARGET_PATHS.
-    if _PERCENT_ESCAPE_RE.search(token):
-        decoded = unquote(token)
-        if decoded != token:
-            decoded = decoded.rstrip(_CODE_REFERENCE_TRIM_CHARS).lstrip(_CODE_REFERENCE_OPENING_TRIM_CHARS)
-            spellings.extend(
-                (
-                    decoded,
-                    _preflight_path_candidate(decoded),
-                    _preflight_assignment_path_candidate(decoded),
-                )
-            )
-            spellings.extend(_preflight_embedded_path_fragments(decoded))
+    # by the caller. The cap bounds parsing work: a spelling still encoded after
+    # it is reached is a literal filename spelling to this scanner, not a reason
+    # to recurse indefinitely. A decoded spelling consumes a declaration slot
+    # only when `_target_paths_denial` reads a containment property not already
+    # declared for this token; ordinary filename decodes do not.
+    decoded = token
+    for _ in range(_PERCENT_DECODE_ROUNDS):
+        if not _PERCENT_ESCAPE_RE.search(decoded):
+            break
+        next_decoded = unquote(decoded).rstrip(_CODE_REFERENCE_TRIM_CHARS).lstrip(
+            _CODE_REFERENCE_OPENING_TRIM_CHARS
+        )
+        if next_decoded == decoded:
+            break
+        decoded_spellings = [
+            next_decoded,
+            _preflight_path_candidate(next_decoded),
+            _preflight_assignment_path_candidate(next_decoded),
+            *_preflight_embedded_path_fragments(next_decoded),
+        ]
+        round_keys: set[tuple[bool, bool, bool]] = set()
+        for spelling in decoded_spellings:
+            key = _preflight_declared_containment_key(spelling, excluded_path=excluded_path)
+            if key is not None and key not in declared_keys:
+                spellings.append(spelling)
+                round_keys.add(key)
+        declared_keys.update(round_keys)
+        decoded = next_decoded
     return spellings
 
 
@@ -1340,7 +1386,7 @@ def _safety_preflight_target_paths(message: str, *, excluded_path: str = "") -> 
             # characters resemble a local traversal spelling.
             if _is_preflight_remote_location(token):
                 continue
-            spellings = _preflight_path_spellings(token)
+            spellings = _preflight_path_spellings(token, excluded_path=excluded_path)
         for spelling in spellings:
             file_path = _preflight_file_uri_path(spelling)
             if file_path is not None:

--- a/tests/test_task_authority_envelope.py
+++ b/tests/test_task_authority_envelope.py
@@ -916,6 +916,66 @@ class FilesystemTargetScopeRegressionTests(unittest.TestCase):
         self.assertEqual(_safety_preflight_target_paths("fix https://example.org/a%2e%2e/b.py"), [])
         self._assert_denied_for_every_profile("fix note:../outside/marker.txt", "target_path_escapes_project")
 
+    def test_percent_decoding_reaches_shape_fixpoint_without_halving_path_budget(self) -> None:
+        from omh.quality.safety_preflight import MAX_TARGET_PATHS
+
+        for target_path, decoded_path in (
+            ("%252e%252e/outside/marker.txt", "../outside/marker.txt"),
+            ("..%252foutside/marker.txt", "../outside/marker.txt"),
+            ("%25252e%25252e/outside/marker.txt", "../outside/marker.txt"),
+            ("%252e%252e%255coutside%255cmarker.txt", r"..\outside\marker.txt"),
+        ):
+            with self.subTest(target_path=target_path):
+                message = f"fix {target_path}"
+                self.assertIn(decoded_path, _safety_preflight_target_paths(message))
+                self._assert_denied_for_every_profile(message, "target_path_escapes_project")
+
+        for target_path, decoded_path in (
+            ("%7e/outside/marker.txt", "~/outside/marker.txt"),
+            ("%7E/outside/marker.txt", "~/outside/marker.txt"),
+            ("C%3a/outside/marker.txt", "C:/outside/marker.txt"),
+            ("x;C%3a/outside/marker.txt", "C:/outside/marker.txt"),
+        ):
+            with self.subTest(target_path=target_path):
+                message = f"fix {target_path}"
+                self.assertIn(decoded_path, _safety_preflight_target_paths(message))
+                self._assert_denied_for_every_profile(message, "target_path_absolute")
+
+        unc_message = "fix %5c%5cserver/share/marker.txt"
+        self.assertIn(r"\\server/share/marker.txt", _safety_preflight_target_paths(unc_message))
+        self._assert_denied_for_every_profile(unc_message, "target_path_absolute")
+
+        for target_path, reason_code in (
+            ("%43:./marker.txt", "target_path_absolute"),
+            ("%43:../", "target_path_absolute"),
+            ("%43:~", "target_path_absolute"),
+            ("%43:=/", "target_path_absolute"),
+            ("%43:x;~", "target_path_absolute"),
+            ("%7emarker.txt?/x", "target_path_absolute"),
+            ("%25%37%65:/..\\", "target_path_escapes_project"),
+            (r"./%3b..\%20", "target_path_escapes_project"),
+        ):
+            with self.subTest(target_path=target_path):
+                self._assert_denied_for_every_profile(f"fix {target_path}", reason_code)
+
+        encoded_filename_message = 'fix "docs/my%20notes.md"'
+        self.assertEqual(_safety_preflight_target_paths(encoded_filename_message), ["docs/my%20notes.md"])
+
+        encoded_filenames = [f"docs/my%20notes-{index}.md" for index in range(MAX_TARGET_PATHS)]
+        allowed_message = "fix " + " ".join(encoded_filenames)
+        self.assertEqual(_safety_preflight_target_paths(allowed_message), encoded_filenames)
+        for message in (encoded_filename_message, allowed_message):
+            for target in self._PROFILE_HANDOFFS:
+                with self.subTest(message=message, target=target):
+                    payload = build_coding_delegation_payload(message, executor_target=target)
+                    self.assertEqual(payload["action_gate"]["outcome"], "allow")
+
+        overflow_message = "fix " + " ".join(
+            [*encoded_filenames, f"docs/my%20notes-{MAX_TARGET_PATHS}.md"]
+        )
+        self.assertEqual(len(_safety_preflight_target_paths(overflow_message)), MAX_TARGET_PATHS + 1)
+        self._assert_denied_for_every_profile(overflow_message, "target_path_count_exceeded")
+
     def test_supported_local_targets_and_remote_references_remain_usable(self) -> None:
         from omh.coding.coding_delegation import _safety_preflight_target_paths
 


### PR DESCRIPTION
Follow-up to #1353, closing the two residuals it documented.

## Feature Report

### What Changed

- Percent-decoding in `_safety_preflight_target_paths` runs to a bounded fixpoint (3 rounds) instead of once, so a double- or triple-encoded traversal reaches the containment rule.
- A decoded spelling consumes a declaration slot only when the containment rule would read something new about it, so ordinary encoded filenames no longer cost two slots and the per-message allowance is back to `MAX_TARGET_PATHS`.
- The absolute-path rule is read from `src/quality/safety_preflight.py` instead of being mirrored as a second constant.

### Why This Exists

#1353 shipped with two residuals written into a comment at the decoding site:

1. **Single-pass decoding.** `fix %252e%252e/outside/marker.txt` decoded once to `%2e%2e/outside/marker.txt`, stopped, was declared as a literal filename, and **allowed**.
2. **The halved allowance.** Every decoded spelling was declared beside its original, so a message naming ordinary `%20` filenames burned two slots each and denied on count at roughly half of `MAX_TARGET_PATHS`.

### User / Operator Impact

- A request naming an escaping path encoded two or three deep is now denied for every coding owner, with no handoff prepared.
- A request naming ordinary percent-encoded filenames gets the full `MAX_TARGET_PATHS` allowance again instead of denying at about half of it.
- Nothing else moves: a spelling encoded deeper than three rounds is still declared literally and allowed, which is the documented bound.

### How It Works

**The interesting part is the design that was rejected.** The obvious fix for residual 2 is to declare a decode only when it "changed the path shape" — count separators and dot segments before and after. That was implemented first, and an independent differential fuzz against base `f4b80d79` found **75 inputs that denied on main and allowed with it**:

- any pre-existing anchored fragment in the token masked a **new token-start anchor** produced by decoding — `fix %43:./marker.txt`, `fix %43:~`, `fix %7emarker.txt?/x`, and `fix %25%37%65:/..\` where the masking compounds across rounds;
- a decode that created the **delimiter** in front of a literal `..` produced a denying fragment with no whole-token change — `fix ./%3b..\%20`.

Counting shape is a proxy for the rule, and a proxy is a second rule that eventually disagrees with the first. So the shipped version asks what containment actually reads. Every candidate spelling gets a key built from the three properties `_target_paths_denial` inspects per item — emptiness, the absolute-path rule, and whether `_path_parts` contains a `..` segment — computed only for spellings this parser will really declare. A decoded spelling is declared when its key is not already present for that token. `docs/my%20notes.md` keeps its key and declares one path; every masking construction above produces a new key, declares, and denies.

The count itself is deliberately not in the key — that is the residual being fixed — and the scan still runs one past `MAX_TARGET_PATHS`, so a real overflow denies on count rather than being trimmed to a passing set.

### Files And Contracts Touched

- `src/coding/coding_delegation.py` — decoding loop, containment key, and the lazily-imported absolute-path rule.
- `tests/test_task_authority_envelope.py` — additive only; no existing assertion moved.
- No generated artifact, schema, dependency, or routing predicate changed.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`

### Observed Evidence

- Full suite on the final tree: 9348 tests, OK, 1 skipped. `docs ulw-inventory --check` and `docs ulw-site --check` also exit 0.
- Real-CLI matrix, 75 scenarios, one `omh coding delegate` process each in isolated temporary homes: **75/75** with zero wrong outcomes and the temporary tree removed.
- **Two independent differential fuzzes against base `f4b80d79`.** The author's: 50,000 inputs, 0 base-denies-now-allows. The reviewer's, deliberately built with a wider alphabet and multi-token messages: 55,000 inputs, 4,640 diffs — **every one `target_path_count_exceeded` on messages of 17-32 benign `%20` filenames**, which is precisely the allowance restoration this PR exists to make. The reviewer then took all 633 mixed-family diffs and all 416 masking allows and ran an unbounded decode over each core, finding **zero** spellings the containment rule would have refused.
- RED was captured before each production change, including against the rejected shape-change design.
- Independent gate review, two passes: pass 1 BLOCKED with the 75-regression fuzz above; pass 2 approved after the redesign, having re-probed all eight blocker inputs itself and audited the key against `_target_paths_denial` line by line.

### Not Tested / Not Applicable

- No executor CLI was dispatched, so executor-side behaviour after dispatch stays unobserved.
- Windows and UNC spellings were exercised as strings on macOS; CI runs the suite on windows-latest.
- `omh harness validate`, `omh release checklist` and the install smoke commands are unrelated and run in CI.

## Risk

Deeper decoding declares more, so the risk is a false denial. The reviewer's fuzz shows the only behavioural difference from base is the count family, and that difference is the intended one — messages that used to deny on an exhausted budget now allow. The `_within_roots` branch of the rule is not in the key; it is unreachable in this lane, which builds its request with `workspace_roots: []`, and decoding cannot move a spelling across a declared root without introducing a `..` segment the key already carries.

## Compatibility / Rollout

No schema version, payload key, CLI flag, or generated artifact changed. Ordinary stable channel, no migration.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- A spelling encoded more than three rounds deep stays literal. Going further needs decode-until-fixpoint with no bound plus its own false-positive corpus, and the bound is the honest place to stop until someone shows a consumer that decodes four times.