### PR TITLE
feat(coding): put fanout dispatch under an OS write fence, proven per run

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2722,12 +2722,14 @@ itself (#844); **account authorization** — the projection names the account,
 the minimum scopes, and a readiness state, but grants, verifies, and refuses
 nothing, because a consent flow owned by a provider's website is not observable
 from here (`host_owned_consent_flow_is_not_observable_by_omh`); and the three
-runtime `data_*` rows — the cross-harness adapter lane builds an OS confinement
-sandbox that no delegation or fanout lane places an executor under
-(`no_delegation_or_fanout_lane_places_an_executor_under_the_sandbox` on a
-capable host, and the host's own missing backend elsewhere; the advisory row
+runtime `data_*` rows — fanout places its owner and dispatcher verification
+processes under the cross-harness adapter OS sandbox, but a claim requires that
+dispatch's same-root probe receipt to show an outside-write refusal
+(`no_observed_fanout_filesystem_confinement_probe_receipt` before that receipt;
+the network row remains `fanout_lane_does_not_request_network_confinement`, and
+a host without a backend names that capability boundary). The advisory row
 reports `no_omh_side_measurement_observes_whether_an_executor_honoured_its_targets`
-on every host). All three used to cite #820, which was a mis-citation even
+on every host. All three used to cite #820, which was a mis-citation even
 before that issue landed — it shipped a workspace reservation, not an executor
 sandbox — and would have become a dangling pointer once it closed.
 

--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -867,13 +867,12 @@ _DATA_BOUNDARY_STATEMENTS = {
         "the approval does not cover, so a prepared handoff cannot reach somewhere nobody approved."
     ),
     "runtime_filesystem_confinement": (
-        "Confining a running executor's filesystem access needs an OS-level confinement backend. The "
-        "cross-harness adapter lane builds one; no delegation or fanout lane places an executor under "
-        "it, so the limit is declared rather than applied."
+        "Fanout places its owner and dispatcher verification processes under the existing OS sandbox. "
+        "It confines writes, not reads. A particular run reports confinement only after its same-root probe was "
+        "refused outside the unit worktree."
     ),
     "runtime_network_confinement": (
-        "Confining a running executor's network access needs the same OS-level backend and the same "
-        "unused sandbox, so the limit is declared rather than applied."
+        "Fanout preserves its existing network behavior, so the OS sandbox is not requested to confine network access."
     ),
     "executor_honours_declared_targets": (
         "The declared targets are a statement the executor is trusted to honour. Nothing measures "

--- a/src/coding/fanout_confinement.py
+++ b/src/coding/fanout_confinement.py
@@ -1,0 +1,312 @@
+"""Filesystem confinement for the local fanout subprocess boundary."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import shutil
+import subprocess
+from uuid import uuid4
+
+from ..quality.cross_harness_adapter_sandbox import (
+    ChildContext,
+    backend,
+    backend_available,
+    preflight,
+    read_roots_are_safe,
+    runtime_roots,
+    sandbox_command,
+    unique_roots,
+)
+
+FANOUT_FILESYSTEM_CONFINEMENT_SCHEMA_VERSION = "fanout_filesystem_confinement/v1"
+FANOUT_FILESYSTEM_CONFINEMENT_CLAIM_BOUNDARY = (
+    "A confinement receipt is observed only when its same-run sandbox probe wrote inside the unit worktree "
+    "and was refused outside it. Backend availability, preflight, and a prepared command alone are not confinement evidence."
+)
+# Fanout confines writes, not reads: an invited coding CLI needs its own toolchain,
+# configuration, credentials, and caches. The receipt attests only the write boundary.
+_FANOUT_MACOS_TOOLCHAIN_WRITE_DATA_LITERALS = (Path("/dev/null"),)
+_FANOUT_MACOS_TOOLCHAIN_TEMP_DIRECTORY = Path(".omh") / "confinement-tmp"
+
+
+@dataclass(frozen=True, slots=True)
+class FanoutFilesystemConfinement:
+    """One backend/root set that can wrap every process in one unit run."""
+
+    selected: str
+    roots: tuple[Path, ...]
+    child: ChildContext | None
+    environment: Mapping[str, str]
+    backend_digest: str
+    executables: Mapping[str, str]
+    receipt: dict[str, object]
+
+    def command(self, argv: Sequence[str]) -> tuple[str, ...] | None:
+        """Return the same-root sandbox command, or None when no receipt proved it."""
+        if self.receipt.get("enforced") is not True or not argv or self.child is None:
+            return None
+        executable = self.executables.get(str(argv[0]))
+        if not executable:
+            return None
+        return sandbox_command(
+            (executable, *[str(argument) for argument in argv[1:]]),
+            self.selected,
+            self.roots,
+            self.child,
+            True,
+            self.environment,
+            self.backend_digest,
+            allow_broad_process_exec=True,
+            macos_write_data_literals=_FANOUT_MACOS_TOOLCHAIN_WRITE_DATA_LITERALS,
+            allow_broad_file_read=True,
+        )
+
+    def command_environment(self) -> dict[str, str]:
+        """Keep macOS toolchain scratch writes within the confined worktree."""
+        if (
+            self.receipt.get("enforced") is not True
+            or self.child is None
+            or self.selected != "sandbox-exec"
+        ):
+            return dict(self.environment)
+        return {
+            **self.environment,
+            "TMPDIR": str(self.child.work / _FANOUT_MACOS_TOOLCHAIN_TEMP_DIRECTORY),
+        }
+
+
+def planned_fanout_filesystem_confinement(worktree: Path) -> dict[str, object]:
+    """Describe a dry-run boundary without claiming the probe ran."""
+    selected = backend("auto")
+    reason_code = "dry_run_no_confinement_probe"
+    if selected == "unsupported":
+        reason_code = "no_os_confinement_backend_on_this_platform"
+    return _receipt(
+        status="prepared_not_observed",
+        selected=selected,
+        worktree=worktree,
+        enforced=False,
+        reason_code=reason_code,
+    )
+
+
+def prepare_fanout_filesystem_confinement(
+    worktree: Path,
+    environment: Mapping[str, str],
+    commands: Sequence[Sequence[str]],
+) -> FanoutFilesystemConfinement:
+    """Probe one unit's backend before allowing its owner or checks to use it."""
+    worktree = worktree.resolve()
+    selected = backend("auto")
+    if selected == "unsupported":
+        return _unconfined(worktree, selected, environment, "no_os_confinement_backend_on_this_platform")
+    if not backend_available(selected):
+        return _unconfined(worktree, selected, environment, "sandbox_backend_unavailable")
+    if not commands:
+        return _unconfined(worktree, selected, environment, "sandbox_no_runnable_command")
+    executables = _resolve_executables(commands, environment)
+    if not executables:
+        return _unconfined(worktree, selected, environment, "sandbox_executable_not_found")
+    roots = unique_roots(
+        (worktree, *(Path(executable).parent for executable in executables.values()), *runtime_roots(selected))
+    )
+    if not read_roots_are_safe(roots):
+        return _unconfined(
+            worktree, selected, environment, "unsafe_sandbox_read_root", roots=roots, executables=executables
+        )
+    if selected == "sandbox-exec":
+        scratch_directory = worktree / _FANOUT_MACOS_TOOLCHAIN_TEMP_DIRECTORY
+        scratch_directory.mkdir(parents=True, exist_ok=True)
+        _ = (scratch_directory / ".gitignore").write_text("*\n", encoding="utf-8")
+    child = ChildContext(
+        worktree,
+        worktree,
+        worktree,
+        worktree,
+        worktree,
+        worktree / ".omh-confinement-request",
+        worktree / ".omh-confinement-artifact",
+        "fanout-filesystem-confinement",
+    )
+    ready, backend_digest = preflight(selected, roots, child, True, environment)
+    if not ready:
+        return _unconfined(
+            worktree,
+            selected,
+            environment,
+            "sandbox_preflight_failed",
+            roots=roots,
+            child=child,
+            backend_digest=backend_digest,
+            executables=executables,
+        )
+    receipt = _probe(selected, roots, child, environment, backend_digest)
+    return FanoutFilesystemConfinement(
+        selected,
+        roots,
+        child,
+        environment,
+        backend_digest,
+        executables,
+        receipt,
+    )
+
+
+def confinement_receipt(
+    confinement: FanoutFilesystemConfinement | None,
+    worktree: Path,
+) -> dict[str, object]:
+    """Return the receipt, keeping non-spawning injected runners explicit."""
+    if confinement is not None:
+        return confinement.receipt
+    return _receipt(
+        status="prepared_not_observed",
+        selected=backend("auto"),
+        worktree=worktree,
+        enforced=False,
+        reason_code="sandbox_not_applied_to_injected_runner",
+    )
+
+
+def _unconfined(
+    worktree: Path,
+    selected: str,
+    environment: Mapping[str, str],
+    reason_code: str,
+    *,
+    roots: tuple[Path, ...] = (),
+    child: ChildContext | None = None,
+    backend_digest: str = "",
+    executables: Mapping[str, str] | None = None,
+) -> FanoutFilesystemConfinement:
+    return FanoutFilesystemConfinement(
+        selected,
+        roots,
+        child,
+        environment,
+        backend_digest,
+        {} if executables is None else executables,
+        _receipt(
+            status="prepared_not_observed",
+            selected=selected,
+            worktree=worktree,
+            enforced=False,
+            reason_code=reason_code,
+        ),
+    )
+
+
+def _resolve_executables(
+    commands: Sequence[Sequence[str]], environment: Mapping[str, str]
+) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    path = environment.get("PATH")
+    for command in commands:
+        if not command:
+            continue
+        name = str(command[0])
+        located = name if Path(name).is_absolute() else shutil.which(name, path=path)
+        if located is None:
+            return {}
+        resolved[name] = str(Path(located).resolve())
+    return resolved
+
+
+def _probe(
+    selected: str,
+    roots: tuple[Path, ...],
+    child: ChildContext,
+    environment: Mapping[str, str],
+    backend_digest: str,
+) -> dict[str, object]:
+    token = uuid4().hex
+    inside = child.work / f".omh-confinement-inside-{token}"
+    outside = child.work.parent / f".omh-confinement-outside-{token}"
+    script = (
+        'printf inside > "$1"; inside=$?; printf outside > "$2"; outside=$?; '
+        'printf "inside_exit=%s outside_exit=%s\\n" "$inside" "$outside"; '
+        'test "$inside" -eq 0 -a "$outside" -ne 0'
+    )
+    argv = ("/bin/sh", "-c", script, "omh-confinement-probe", str(inside), str(outside))
+    try:
+        completed = subprocess.run(
+            sandbox_command(argv, selected, roots, child, True, environment, backend_digest),
+            cwd=child.work,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+        match = re.search(r"inside_exit=(\d+) outside_exit=(\d+)", completed.stdout)
+        inside_code = int(match.group(1)) if match else None
+        outside_code = int(match.group(2)) if match else None
+        enforced = (
+            completed.returncode == 0
+            and inside_code == 0
+            and outside_code is not None
+            and outside_code != 0
+            and inside.is_file()
+            and not outside.exists()
+        )
+        return {
+            **_receipt(
+                status="observed",
+                selected=selected,
+                worktree=child.work,
+                enforced=enforced,
+                reason_code="" if enforced else "sandbox_probe_failed",
+            ),
+            "probe": {
+                "status": "observed",
+                "command": list(argv),
+                "exit_code": completed.returncode,
+                "inside_write_exit_code": inside_code,
+                "outside_write_exit_code": outside_code,
+                "refusal": completed.stderr.strip()[:300],
+            },
+        }
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            **_receipt(
+                status="observed",
+                selected=selected,
+                worktree=child.work,
+                enforced=False,
+                reason_code="sandbox_probe_failed",
+            ),
+            "probe": {
+                "status": "observed",
+                "command": list(argv),
+                "exit_code": None,
+                "inside_write_exit_code": None,
+                "outside_write_exit_code": None,
+                "refusal": str(exc)[:300],
+            },
+        }
+    finally:
+        inside.unlink(missing_ok=True)
+        outside.unlink(missing_ok=True)
+
+
+def _receipt(
+    *,
+    status: str,
+    selected: str,
+    worktree: Path,
+    enforced: bool,
+    reason_code: str,
+) -> dict[str, object]:
+    return {
+        "schema_version": FANOUT_FILESYSTEM_CONFINEMENT_SCHEMA_VERSION,
+        "status": status,
+        "backend": selected,
+        "write_root": str(worktree.resolve()),
+        "enforced": enforced,
+        "reason_code": reason_code,
+        "claim_boundary": FANOUT_FILESYSTEM_CONFINEMENT_CLAIM_BOUNDARY,
+    }

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -83,6 +83,12 @@ from .fanout_health_events import (
     monotonic_milliseconds,
     write_fanout_health_event,
 )
+from .fanout_confinement import (
+    FanoutFilesystemConfinement,
+    confinement_receipt,
+    planned_fanout_filesystem_confinement,
+    prepare_fanout_filesystem_confinement,
+)
 from .diagnostic_execution import DiagnosticExecutionEngine
 from .fanout_contracts import (
     FANOUT_CLAIM_BOUNDARY,
@@ -199,6 +205,7 @@ def signal_safe_unit_runner(
     timeout: float | None = None,
     on_spawn: Callable[[subprocess.Popen], None] | None = None,
     on_output: Callable[[str], None] | None = None,
+    confinement_command: Sequence[str] | None = None,
 ) -> subprocess.CompletedProcess:
     """Drop-in for `subprocess.run` that owns each child as a process group.
 
@@ -217,7 +224,7 @@ def signal_safe_unit_runner(
     """
     pipe = subprocess.PIPE if capture_output else None
     process = subprocess.Popen(
-        list(argv),
+        list(confinement_command or argv),
         cwd=cwd,
         env=dict(env) if env is not None else None,
         text=text,
@@ -1124,6 +1131,7 @@ def _run_verification_command(
     child_env: Mapping[str, str] | None = None,
     spill_dir: Path | None = None,
     timeout: int | None = None,
+    confinement: FanoutFilesystemConfinement | None = None,
 ) -> tuple[str, str, dict[str, Any] | None]:
     """Run one command in the unit worktree; return status, bounded tail, truncation record.
 
@@ -1146,16 +1154,28 @@ def _run_verification_command(
     except FanoutContractError as exc:
         return "failed", str(exc), None
     try:
+        environment = {**(os.environ if child_env is None else child_env), **env_overrides}
+        active_confinement = confinement
+        if runner is signal_safe_unit_runner and active_confinement is None:
+            active_confinement = prepare_fanout_filesystem_confinement(
+                worktree, environment, (argv,)
+            )
+        confinement_command = (
+            active_confinement.command(argv) if active_confinement is not None else None
+        )
+        if active_confinement is not None:
+            environment = {**active_confinement.command_environment(), **env_overrides}
         completed = runner(
             argv,
             cwd=str(worktree),
             # The dispatcher's lineage stamp when the caller passed one: a
             # declared verification command is a child of this dispatch too,
             # and a depth guard a command can shell around is not a guard.
-            env={**(os.environ if child_env is None else child_env), **env_overrides},
+            env=environment,
             text=True,
             capture_output=True,
             timeout=effective_timeout,
+            **({"confinement_command": confinement_command} if confinement_command is not None else {}),
         )
         exit_code = int(getattr(completed, "returncode", 1))
         combined = (
@@ -1203,6 +1223,7 @@ def _run_planned_verification(
     required_revision: str | None = None,
     post_integration: bool = False,
     producer_evidence: bool = False,
+    confinement: FanoutFilesystemConfinement | None = None,
 ) -> dict[str, Any]:
     """Run a metadata-carrying unit's checks through the revision-bound plan engine.
 
@@ -1244,6 +1265,7 @@ def _run_planned_verification(
             execution_environment,
             spill_dir=paths.runtime_output_spills_dir,
             timeout=node.timeout,
+            confinement=confinement,
         )
 
     result = (
@@ -1400,6 +1422,23 @@ def _run_integration_verification_wave(
         unit = units.get(unit_id)
         if entry is None or unit is None or not entry.get("verification_integration_deferred"):
             continue
+        integration_environment = verification_execution_environment(os.environ)
+        integration_argv: list[list[str]] = []
+        for command in declared_verification_commands(unit):
+            try:
+                _overrides, check_argv = verification_command_argv(command)
+            except FanoutContractError:
+                continue
+            integration_argv.append(check_argv)
+        integration_confinement = (
+            prepare_fanout_filesystem_confinement(
+                integrated_worktree, integration_environment, tuple(integration_argv)
+            )
+            if runner is signal_safe_unit_runner
+            else None
+        )
+        if integration_confinement is not None:
+            integration_environment = integration_confinement.command_environment()
         rerun = _run_planned_verification(
             paths,
             unit,
@@ -1409,13 +1448,14 @@ def _run_integration_verification_wave(
             worktree=integrated_worktree,
             owner=str(entry.get("owner") or "choose"),
             runner=runner,
-            child_env=None,
+            child_env=integration_environment,
             wave_width=wave_width,
             execution_gate=execution_gate,
             integration_ready=lambda: True,
             required_revision=integrated_revision,
             post_integration=True,
             producer_evidence=producer_evidence,
+            confinement=integration_confinement,
         )
         if not rerun:
             continue
@@ -1424,6 +1464,9 @@ def _run_integration_verification_wave(
             row for row in entry.get("verification_checks", []) if row.get("tier") != "integration"
         ]
         entry["verification_checks"] = [*unit_rows, *integration_rows]
+        entry["integration_filesystem_confinement"] = confinement_receipt(
+            integration_confinement, integrated_worktree
+        )
         entry.pop("verification_integration_deferred", None)
         entry.pop("verification_failures", None)
         entry.update(rerun)
@@ -1459,6 +1502,7 @@ def _run_unit_verification(
     fanout_id: str = "",
     wave_width: int = 1,
     execution_gate: VerificationExecutionGate | None = None,
+    confinement: FanoutFilesystemConfinement | None = None,
 ) -> dict[str, Any]:
     """Run one unit's declared verification commands and record what was observed.
 
@@ -1490,6 +1534,7 @@ def _run_unit_verification(
             wave_width=wave_width,
             execution_gate=execution_gate,
             integration_ready=lambda: False,
+            confinement=confinement,
         )
     rows: list[dict[str, object]] = []
     failures: list[str] = []
@@ -1502,6 +1547,7 @@ def _run_unit_verification(
                 runner,
                 child_env,
                 spill_dir=paths.runtime_output_spills_dir,
+                confinement=confinement,
             )
 
         outcome = (
@@ -3148,6 +3194,10 @@ def _dispatch_unit(
         repair_card = probe.get("repair_card")
         if isinstance(repair_card, Mapping):
             not_ready["repair_card"] = dict(repair_card)
+        if dry_run:
+            not_ready["filesystem_confinement"] = planned_fanout_filesystem_confinement(
+                _worktree_path(repo_root, unit_id)
+            )
         return not_ready
     discovery = (discoveries or {}).get(owner)
     sidecar_path = None
@@ -3196,6 +3246,7 @@ def _dispatch_unit(
             "status": "dry_run_planned",
             "planned_argv": [part if part != prompt else "<unit prompt>" for part in argv],
             "worktree_path": str(worktree),
+            "filesystem_confinement": planned_fanout_filesystem_confinement(worktree),
             **_dispatch_status_ladder(),
         }
         if fingerprint_note is not None:
@@ -3308,6 +3359,23 @@ def _dispatch_unit(
             **_dispatch_status_ladder(),
         }
     worktree = Path(str(worktree_record["worktree_path"]))
+    verification_argv: list[list[str]] = []
+    for command in declared_verification_commands(unit):
+        try:
+            _overrides, check_argv = verification_command_argv(command)
+        except FanoutContractError:
+            continue
+        verification_argv.append(check_argv)
+    confinement = (
+        prepare_fanout_filesystem_confinement(
+            worktree, child_env, (argv, *verification_argv)
+        )
+        if runner is signal_safe_unit_runner
+        else None
+    )
+    filesystem_confinement = confinement_receipt(confinement, worktree)
+    if confinement is not None:
+        child_env = confinement.command_environment()
     # After the worktree exists and before anything else touches it: a linked
     # artifact must be in place before the unit's process spawns to be worth
     # anything, and re-checking from inside the worktree (see
@@ -3447,6 +3515,9 @@ def _dispatch_unit(
                 binding_ref=lambda: progress_binding,
                 binding_set=_replace_binding,
             )
+        confinement_command = confinement.command(argv) if confinement is not None else None
+        if confinement_command is not None:
+            spawn_kwargs["confinement_command"] = confinement_command
         while True:
             attempt += 1
             output_tail = ""
@@ -3686,6 +3757,7 @@ def _dispatch_unit(
             fanout_id=fanout_id,
             wave_width=verification_wave_width,
             execution_gate=verification_execution_gate,
+            confinement=confinement,
         )
         if health_events is not None:
             health_events.finished(
@@ -3722,6 +3794,7 @@ def _dispatch_unit(
         "status": "completed" if exit_code == 0 else "failed",
         "exit_code": exit_code,
         "worktree_path": str(worktree),
+        "filesystem_confinement": filesystem_confinement,
         "shared_artifacts": shared_artifacts,
         **_dispatch_status_ladder(
             process_succeeded=exit_code == 0,

--- a/src/quality/cross_harness_adapter_sandbox.py
+++ b/src/quality/cross_harness_adapter_sandbox.py
@@ -39,6 +39,7 @@ _MACOS_RUNTIME_ROOTS: Final = tuple(
     Path(item) for item in (
         "/usr/lib", "/System/Library", "/Library/Apple/System/Library",
         "/private/var/db/dyld",
+        "/private/var/select",
     )
 )
 PopenFactory = Callable[..., subprocess.Popen[bytes]]
@@ -253,12 +254,46 @@ def sandbox_command(
     allow_network: bool,
     environment: Mapping[str, str],
     backend_digest: str | None = None,
+    allow_broad_process_exec: bool = False,
+    macos_read_root_aliases: Sequence[Path] = (),
+    macos_read_literals: Sequence[Path] = (),
+    macos_write_data_literals: Sequence[Path] = (),
+    allow_broad_file_read: bool = False,
 ) -> tuple[str, ...]:
     if selected == "sandbox-exec":
-        literals = " ".join(f'(literal {json.dumps(str(Path(item).resolve()))})' for item in (argv[0], "/usr/bin/true"))
-        subpaths = " ".join(f'(subpath {json.dumps(str(root))})' for root in unique_roots((*roots, child.root)))
+        executables = (argv[0], "/usr/bin/true")
+        if Path(argv[0]).resolve() == Path("/bin/sh").resolve():
+            # macOS dispatches `/bin/sh` through `/bin/bash` after consulting
+            # `/private/var/select`; the same narrow allowance lets the
+            # confinement probe run without widening ordinary adapter argv.
+            executables += ("/bin/bash",)
+        literals = " ".join(
+            f'(literal {json.dumps(str(Path(item).resolve()))})'
+            for item in executables
+        )
+        process_exec = "(allow process-exec*)" if allow_broad_process_exec else f"(allow process-exec {literals})"
+        canonical_roots = unique_roots((*roots, child.root))
+        canonical_root_names = {str(root) for root in canonical_roots}
+        policy_roots = (
+            *canonical_roots,
+            *(root for root in macos_read_root_aliases if str(root) not in canonical_root_names),
+        )
+        subpaths = " ".join(f'(subpath {json.dumps(str(root))})' for root in policy_roots)
+        read_literals = " ".join(
+            f'(literal {json.dumps(str(root))})' for root in macos_read_literals
+        )
+        read_literal_clause = f" {read_literals}" if read_literals else ""
+        file_read = (
+            "(allow file-read*)"
+            if allow_broad_file_read
+            else f'(allow file-read* (literal "/") {literals}{read_literal_clause} {subpaths})'
+        )
+        write_data_literals = "".join(
+            f'(allow file-write-data (literal {json.dumps(str(root))}))'
+            for root in macos_write_data_literals
+        )
         network = "(allow network*)" if allow_network else ""
-        policy = f'(version 1)(deny default)(deny syscall-unix (syscall-number 147 82))(allow process-fork)(allow process-exec {literals})(allow sysctl-read)(allow file-read* (literal "/") {literals} {subpaths})(allow file-write* (subpath {json.dumps(str(child.root))})){network}'
+        policy = f'(version 1)(deny default)(deny syscall-unix (syscall-number 147 82))(allow process-fork){process_exec}(allow sysctl-read){file_read}{write_data_literals}(allow file-write* (subpath {json.dumps(str(child.root))})){network}'
         return ("/usr/bin/sandbox-exec", "-p", policy, *argv)
     tool = _trusted_bwrap(backend_digest)
     assert tool is not None

--- a/src/quality/safety_preflight.py
+++ b/src/quality/safety_preflight.py
@@ -462,13 +462,13 @@ DATA_BOUNDARY_ENFORCEMENT_KINDS: Final = ("refused_before_handoff", "host_confin
 # Both of these used to name `#820`, which was a mis-citation even before that
 # issue landed. #820 is about two handoffs sharing one workspace, and it shipped
 # `workspace_binding_guard/v1` for exactly that -- a pre-dispatch reservation.
-# Neither of these limits is about reservations. Every `host_confinement` limit
-# is unenforced because no delegation or fanout lane places an executor under
-# the sandbox the cross-harness adapter lane already builds, which is real,
-# fileable work that #820 was never going to do. A host that *could* confine
-# still reports the limit as unenforced; it reports a different blocker from a
-# host that could not.
-_HOST_CONFINEMENT_BLOCKER: Final = "no_delegation_or_fanout_lane_places_an_executor_under_the_sandbox"
+# The fanout lane now places its owner and dispatcher verification processes
+# under the existing sandbox. A process-neutral handoff record still cannot
+# claim that a particular run was confined: only its same-run probe receipt can
+# do that. Network is deliberately separate because the fanout owner retains
+# its existing network behavior.
+_FANOUT_FILESYSTEM_CONFINEMENT_BLOCKER: Final = "no_observed_fanout_filesystem_confinement_probe_receipt"
+_RUNTIME_NETWORK_CONFINEMENT_BLOCKER: Final = "fanout_lane_does_not_request_network_confinement"
 # The advisory limit is not fileable at all. Measuring whether a running
 # executor stayed inside its declared targets needs the same OS-level
 # confinement the host owns; on this side of the wall there is nothing to
@@ -516,14 +516,15 @@ DATA_BOUNDARY_LIMITS: Final = (
         (
             "omh.quality.cross_harness_adapter_sandbox.sandbox_command",
             "omh.quality.cross_harness_adapter_sandbox.read_roots_are_safe",
+            "omh.coding.fanout_confinement.prepare_fanout_filesystem_confinement",
         ),
-        _HOST_CONFINEMENT_BLOCKER,
+        _FANOUT_FILESYSTEM_CONFINEMENT_BLOCKER,
     ),
     (
         "runtime_network_confinement",
         "host_confinement",
         ("omh.quality.cross_harness_adapter_sandbox.sandbox_command",),
-        _HOST_CONFINEMENT_BLOCKER,
+        _RUNTIME_NETWORK_CONFINEMENT_BLOCKER,
     ),
     (
         "executor_honours_declared_targets",
@@ -699,11 +700,12 @@ def data_boundary_enforcement_facts() -> dict[str, object]:
       blocker on every host: no host fact bears on them, so a missing
       confinement backend is not an explanation for one.
 
-    Today every `host_confinement` limit is still unenforced even where the
-    host is capable, because no delegation or fanout lane places an executor
-    under the sandbox the cross-harness adapter lane builds. The capability flag
-    is what separates "the host could, once a lane does that" from "this host
-    never could", and that separation is the deliverable.
+    Fanout now supplies filesystem confinement, but this process-neutral fact
+    surface has no run receipt to inspect. Its filesystem row therefore remains
+    declared until a particular dispatch records a successful same-run probe;
+    the network row remains declared because fanout preserves network access.
+    The capability flag separates a host that can produce such a receipt from
+    one that cannot.
 
     Deliberately not part of `safety_rule_profile()`: the answer differs per
     machine, and a host-dependent digest would read as profile drift on every

--- a/tests/test_cross_harness_adapter_security.py
+++ b/tests/test_cross_harness_adapter_security.py
@@ -164,6 +164,32 @@ class AdapterSandboxSecurityTests(_RunnerMixin, unittest.TestCase):
         self.assertEqual((network.status, allowed.status, outside.status, allowed.network_allowed), ("observed_success", "observed_success", "observed_success", True))
 
     @unittest.skipUnless(sys.platform == "darwin", "sandbox-exec is macOS-only")
+    def test_macos_default_process_exec_policy_remains_strict(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            child = ChildContext(
+                root,
+                root / "home",
+                root / "work",
+                root / "tmp",
+                root / "output",
+                root / "request.json",
+                root / "output" / "result.json",
+                "f" * 64,
+            )
+            policy = sandbox_command(
+                ("/bin/sh", "-c", "exit 0"), "sandbox-exec", (), child, False, {}
+            )[2]
+
+        self.assertNotIn("(allow process-exec*)", policy)
+        self.assertNotIn("(allow file-read*)", policy)
+        self.assertIn(
+            '(allow process-exec (literal "/bin/sh") (literal "/usr/bin/true") '
+            '(literal "/bin/bash"))',
+            policy,
+        )
+
+    @unittest.skipUnless(sys.platform == "darwin", "sandbox-exec is macOS-only")
     def test_macos_session_and_process_group_escape_syscalls_are_denied(self) -> None:
         outcome = self._run("session-escape-denied", sandbox=True)
         self.assertEqual(outcome.status, "observed_success")

--- a/tests/test_data_boundary.py
+++ b/tests/test_data_boundary.py
@@ -334,9 +334,9 @@ class EnforcementFactsTests(unittest.TestCase):
     def test_a_host_confinement_limit_is_unenforced_and_says_which_kind_of_unenforced(self) -> None:
         """The genuine per-host difference: which blocker stands in the way.
 
-        A host with a confinement backend is blocked only on no lane placing an
-        executor under the sandbox; a host with none could not enforce a runtime
-        limit even after such a lane exists, and says so with its own reason.
+        A host with a confinement backend still needs a dispatch-specific
+        filesystem probe receipt (and fanout deliberately preserves network
+        access); a host with none names that capability boundary instead.
         """
         facts = self.facts()
         entries = [entry for entry in facts["limits"] if entry["enforcement_kind"] == "host_confinement"]
@@ -346,7 +346,10 @@ class EnforcementFactsTests(unittest.TestCase):
                 self.assertFalse(entry["enforced_here"])
                 self.assertEqual(entry["host_can_enforce"], facts["host_confinement_available"])
                 expected = (
-                    "no_delegation_or_fanout_lane_places_an_executor_under_the_sandbox"
+                    {
+                        "runtime_filesystem_confinement": "no_observed_fanout_filesystem_confinement_probe_receipt",
+                        "runtime_network_confinement": "fanout_lane_does_not_request_network_confinement",
+                    }[entry["limit"]]
                     if facts["host_confinement_available"]
                     else facts["host_confinement_unavailable_reason"]
                 )

--- a/tests/test_fanout_confinement.py
+++ b/tests/test_fanout_confinement.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.fanout_confinement import prepare_fanout_filesystem_confinement  # noqa: E402
+from omh.coding.fanout_dispatch import (  # noqa: E402
+    _run_planned_verification,
+    _run_verification_command,
+    signal_safe_unit_runner,
+)
+from omh.system.paths import OmhPaths  # noqa: E402
+
+
+def _linked_worktree(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir()
+    _ = subprocess.run(("/usr/bin/git", "init", "-q"), cwd=repo, check=True)
+    (repo / "seed").write_text("seed", encoding="utf-8")
+    _ = subprocess.run(("/usr/bin/git", "add", "seed"), cwd=repo, check=True)
+    _ = subprocess.run(
+        ("/usr/bin/git", "-c", "user.name=test", "-c", "user.email=test@example.test", "commit", "-qm", "init"),
+        cwd=repo,
+        check=True,
+    )
+    worktree = root / "linked-worktree"
+    _ = subprocess.run(("/usr/bin/git", "worktree", "add", "-qb", "agent/unit", str(worktree), "HEAD"), cwd=repo, check=True)
+    return worktree
+
+
+@unittest.skipUnless(sys.platform == "darwin", "sandbox-exec confinement is exercised on macOS")
+class FanoutFilesystemConfinementTests(unittest.TestCase):
+    def test_probe_receipt_requires_an_inside_write_and_an_outside_refusal(self) -> None:
+        with TemporaryDirectory() as temporary:
+            worktree = Path(temporary) / "worktree"
+            worktree.mkdir()
+
+            confinement = prepare_fanout_filesystem_confinement(
+                worktree,
+                {},
+                (("/bin/sh", "-c", "exit 0"),),
+            )
+
+            self.assertEqual(confinement.receipt["status"], "observed")
+            self.assertTrue(confinement.receipt["enforced"])
+            self.assertEqual(confinement.receipt["probe"]["inside_write_exit_code"], 0)
+            self.assertEqual(confinement.receipt["probe"]["outside_write_exit_code"], 1)
+            self.assertIn("Operation not permitted", confinement.receipt["probe"]["refusal"])
+
+    def test_confined_command_can_exec_a_real_binary_without_widening_writes(self) -> None:
+        with TemporaryDirectory() as temporary:
+            worktree = (Path(temporary) / "worktree").resolve()
+            worktree.mkdir()
+            inside = worktree / "inside"
+            outside = worktree.parent / "outside"
+            confinement = prepare_fanout_filesystem_confinement(
+                worktree,
+                {},
+                (("/bin/sh", "-c", "exit 0"),),
+            )
+            argv = (
+                "/bin/sh",
+                "-c",
+                '"/bin/ls" / > "$1"; inside=$?; printf x > "$2"; outside=$?; '
+                'printf "inside_exit=%s outside_exit=%s\\n" "$inside" "$outside"; '
+                'test "$inside" -eq 0 -a "$outside" -ne 0',
+                "omh-confinement-exec-probe",
+                str(inside),
+                str(outside),
+            )
+
+            completed = subprocess.run(
+                confinement.command(argv),
+                cwd=worktree,
+                env={},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0)
+            self.assertEqual(completed.stdout.strip(), "inside_exit=0 outside_exit=1")
+            self.assertTrue(inside.is_file())
+            self.assertFalse(outside.exists())
+
+    def test_confined_toolchain_shims_run(self) -> None:
+        with TemporaryDirectory() as temporary:
+            worktree = _linked_worktree(Path(temporary))
+            confinement = prepare_fanout_filesystem_confinement(
+                worktree,
+                {},
+                (("/usr/bin/git", "--version"), ("/usr/bin/python3", "-c", "print('python-ok')")),
+            )
+
+            git = subprocess.run(
+                confinement.command(("/usr/bin/git", "--version")),
+                cwd=worktree,
+                env=confinement.command_environment(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            python = subprocess.run(
+                confinement.command(("/usr/bin/python3", "-c", "print('python-ok')")),
+                cwd=worktree,
+                env=confinement.command_environment(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            status = subprocess.run(
+                confinement.command(("/usr/bin/git", "status", "--porcelain")),
+                cwd=worktree,
+                env=confinement.command_environment(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(git.returncode, 0, git.stderr)
+            self.assertEqual(python.returncode, 0, python.stderr)
+            self.assertEqual(status.stdout, "", status.stderr)
+
+    def test_passed_confinement_preserves_verification_environment_overrides(self) -> None:
+        with TemporaryDirectory() as temporary:
+            worktree = Path(temporary) / "worktree"
+            worktree.mkdir()
+            confinement = prepare_fanout_filesystem_confinement(
+                worktree, {}, (("/bin/sh", "-c", "exit 0"),)
+            )
+
+            status, _detail, _truncation = _run_verification_command(
+                'OMH_MARK=present /bin/sh -c \'test "$OMH_MARK" = present\'',
+                worktree,
+                signal_safe_unit_runner,
+                confinement=confinement,
+            )
+
+            self.assertEqual(status, "passed")
+
+    def test_integration_plan_preserves_confined_verification_environment_overrides(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            worktree = _linked_worktree(root)
+            revision = subprocess.run(
+                ("/usr/bin/git", "rev-parse", "HEAD^{tree}"),
+                cwd=worktree,
+                text=True,
+                capture_output=True,
+                check=True,
+            ).stdout.strip()
+            command = 'OMH_MARK=present /bin/sh -c \'test "$OMH_MARK" = present\''
+            confinement = prepare_fanout_filesystem_confinement(
+                worktree, {}, (("/bin/sh", "-c", "exit 0"),)
+            )
+            unit = {
+                "unit_id": "core",
+                "verification_commands": [command],
+                "verification_checks": [
+                    {"id": "integration-env", "command": command, "tier": "integration", "safety": "read_only"}
+                ],
+            }
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            with mock.patch("omh.coding.fanout_dispatch.append_journal_observation"):
+                result = _run_planned_verification(
+                    paths,
+                    unit,
+                    fanout_id="fanout",
+                    run_ref="run",
+                    unit_id="core",
+                    worktree=worktree,
+                    owner="codex",
+                    runner=signal_safe_unit_runner,
+                    child_env={},
+                    wave_width=1,
+                    execution_gate=None,
+                    integration_ready=lambda: True,
+                    required_revision=revision,
+                    post_integration=True,
+                    producer_evidence=True,
+                    confinement=confinement,
+                )
+
+            self.assertEqual(result["verification_status"], "passed")
+
+    def test_empty_command_list_is_not_reported_as_a_missing_executable(self) -> None:
+        with TemporaryDirectory() as temporary:
+            worktree = Path(temporary) / "worktree"
+            worktree.mkdir()
+            no_command = prepare_fanout_filesystem_confinement(worktree, {}, ())
+            missing_executable = prepare_fanout_filesystem_confinement(
+                worktree, {}, (("omh-command-that-does-not-exist",),)
+            )
+
+            self.assertEqual(no_command.receipt["status"], "prepared_not_observed")
+            self.assertFalse(no_command.receipt["enforced"])
+            self.assertEqual(no_command.receipt["reason_code"], "sandbox_no_runnable_command")
+            self.assertEqual(missing_executable.receipt["reason_code"], "sandbox_executable_not_found")
+            self.assertNotEqual(
+                no_command.receipt["reason_code"], missing_executable.receipt["reason_code"]
+            )
+
+    def test_preflight_failure_is_recorded_as_unconfined(self) -> None:
+        with TemporaryDirectory() as temporary:
+            worktree = Path(temporary) / "worktree"
+            worktree.mkdir()
+            with mock.patch("omh.coding.fanout_confinement.preflight", return_value=(False, "test-digest")):
+                confinement = prepare_fanout_filesystem_confinement(
+                    worktree,
+                    {},
+                    (("/bin/sh", "-c", "exit 0"),),
+                )
+
+            self.assertEqual(confinement.receipt["status"], "prepared_not_observed")
+            self.assertFalse(confinement.receipt["enforced"])
+            self.assertEqual(confinement.receipt["reason_code"], "sandbox_preflight_failed")
+
+    def test_verification_command_is_confined_when_it_has_no_owner_receipt(self) -> None:
+        with TemporaryDirectory() as temporary:
+            worktree = Path(temporary) / "worktree"
+            worktree.mkdir()
+            inside = worktree / "inside"
+            outside = worktree.parent / "outside"
+            command = shlex.join(
+                [
+                    "/bin/sh",
+                    "-c",
+                    'printf inside > inside; inside_code=$?; printf outside > ../outside; outside_code=$?; test "$inside_code" -eq 0 -a "$outside_code" -ne 0',
+                ]
+            )
+
+            status, _detail, _truncation = _run_verification_command(
+                command, worktree, signal_safe_unit_runner
+            )
+
+            self.assertEqual(status, "passed")
+            self.assertTrue(inside.is_file())
+            self.assertFalse(outside.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -1329,9 +1329,35 @@ class FanoutDispatchEngineTests(unittest.TestCase):
             )
 
             self.assertTrue(all(entry["status"] == "dry_run_planned" for entry in summary["units"]))
+            self.assertTrue(
+                all(entry["filesystem_confinement"]["status"] == "prepared_not_observed" for entry in summary["units"])
+            )
             self.assertEqual(runner.spawned, [])
             self.assertFalse(paths.runtime_runs_dir.exists())
             self.assertFalse((repo.parent / "repo-fanout-core").exists())
+
+    @unittest.skipUnless(sys.platform == "darwin", "sandbox-exec confinement is exercised on macOS")
+    def test_live_dispatch_records_a_probe_backed_filesystem_confinement_receipt(self) -> None:
+        """A working directory alone is not an observed filesystem boundary."""
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+
+            with mock.patch("omh.coding.fanout_dispatch.build_dispatch_argv", return_value=["/bin/sh", "-c", "exit 0"]):
+                summary = dispatch_fanout(
+                    paths,
+                    contract,
+                    goal_text=_GOAL,
+                    repo_root=repo,
+                    base_sha=sha,
+                    only_units=["core"],
+                    readiness=_ready,
+                )
+
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+            receipt = core["filesystem_confinement"]
+            self.assertEqual(receipt["status"], "observed")
+            self.assertTrue(receipt["enforced"])
+            self.assertEqual(receipt["probe"]["outside_write_exit_code"], 1)
 
     def test_resume_skips_completed_units(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -4033,6 +4059,11 @@ class FanoutDispatchPlannedVerificationTests(unittest.TestCase):
             # The unit-tier check ran once in its producer worktree; the full
             # gate ran once after fan-in against the explicit integrated tree.
             self.assertEqual(len(runner.verified), 2)
+            integration_confinement = core["integration_filesystem_confinement"]
+            self.assertEqual(integration_confinement["status"], "prepared_not_observed")
+            self.assertEqual(
+                integration_confinement["reason_code"], "sandbox_not_applied_to_injected_runner"
+            )
             self.assertTrue(core["unit_verification_observed"])
             self.assertTrue(core["integration_ready"])
 

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -141,6 +141,10 @@ PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
         "`omh coding fanout dispatch` -- the one opt-in bridge that spawns local agent CLIs, "
         "documented as the scoped exception in CLAUDE.md."
     ),
+    "src/coding/fanout_confinement.py": (
+        "`omh coding fanout dispatch`; runs only the same-backend `/bin/sh` filesystem-refusal "
+        "probe before the opt-in fanout owner or verification process is sandboxed."
+    ),
     "src/coding/diagnostic_execution_engine.py": (
         "`omh coding fanout dispatch --diagnostics`; imports only subprocess exception classes "
         "to classify an injected or built-in runner's bounded failure and contains no "

--- a/tests/test_risky_action_confirmation.py
+++ b/tests/test_risky_action_confirmation.py
@@ -1194,7 +1194,7 @@ class ContractTests(unittest.TestCase):
         # The host_confinement rows still do move, which is the distinction.
         self.assertEqual(
             capable["runtime_network_confinement"]["blocked_by"],
-            "no_delegation_or_fanout_lane_places_an_executor_under_the_sandbox",
+            "fanout_lane_does_not_request_network_confinement",
         )
         self.assertEqual(
             bare["runtime_network_confinement"]["blocked_by"],


### PR DESCRIPTION
Closes the `WORKSPACE_RUNTIME_BLOCKER` follow-up left open by #1351, #1353 and #1355.

## Feature Report

### What Changed

- New `src/coding/fanout_confinement.py`: prepares an OS filesystem sandbox for one dispatch unit, probes it, and hands back a receipt.
- `omh coding fanout dispatch` now runs the owner CLI **and** the dispatcher's verification commands under that sandbox, with writes confined to the unit worktree. The integration wave records its own separate receipt.
- `sandbox_command` gains three defaulted parameters (broad exec, broad reads, write-data literals). Every cross-harness adapter call site keeps the strict policy it had, now pinned by its own test.
- `_HOST_CONFINEMENT_BLOCKER` is replaced by two honest ones: `no_observed_fanout_filesystem_confinement_probe_receipt` for the filesystem row, `fanout_lane_does_not_request_network_confinement` for the network row.

### Why This Exists

`src/quality/safety_preflight.py` said the quiet part out loud: `no_delegation_or_fanout_lane_places_an_executor_under_the_sandbox`. The sandbox existed and the cross-harness adapter lane used it; `fanout_dispatch` meanwhile spawned the owner CLI with nothing but `cwd=<worktree>`. A working directory is a suggestion. Nothing stopped a dispatched agent from writing anywhere the user could.

### User / Operator Impact

- On macOS, a dispatched agent CLI that tries to write outside its unit worktree is refused by the OS. Verified against child processes, `rename`, hardlinks, symlinks pointing outside the root, `mkdir`, `O_CREAT`, and a chdir-then-relative escape.
- A host with no backend, or one whose sandbox preflight fails, dispatches **exactly as before** and records which of those it was. Nothing new can block a dispatch.
- Windows has no backend; that is recorded as a capability boundary, not a failure. Linux has one in the tree but it has never been run — see the Not Tested section.

### How It Works

**The load-bearing decision is what may be claimed.** Confinement is reported as observed only when a probe process — spawned in that run, under the same backend, the same roots and the same environment as the real spawn — wrote inside the worktree and was refused outside it. `FanoutFilesystemConfinement.command()` returns `None` unless that receipt exists, so a backend that merely *looks* available cannot produce a wrapper, and no code path can report confinement that a probe did not attest.

**This confines writes, not reads, deliberately.** An invited coding CLI must reach its own credentials, config, language runtime and caches. Narrowing reads per tool was implemented first and immediately produced a policy where `git` died on a home `.gitconfig` read — the start of an unbounded list, with the next CLI needing the next root. Reads and network were not confined before this change either, so a write fence is a strict improvement over a bare `cwd` and exposes nothing that was not already exposed. The receipt, the boundary row and the module comment all say writes only.

The complete write set under the fanout policy is the unit worktree subpath plus `file-write-data` on `/dev/null`, which git opens read-write and which persists nothing. Toolchain scratch (`TMPDIR`) is redirected into `.omh/confinement-tmp` inside the worktree, and that directory carries its own `.gitignore` so it is invisible to `git status` without touching git metadata.

### Files And Contracts Touched

- `src/coding/fanout_confinement.py`, `tests/test_fanout_confinement.py` (new)
- `src/coding/fanout_dispatch.py` — owner spawn, verification spawn, integration wave, dry run
- `src/quality/cross_harness_adapter_sandbox.py` — three defaulted parameters; adapter behaviour unchanged
- `src/quality/safety_preflight.py`, `src/coding/action_gate.py` — the two blocker strings and the rows citing them
- `docs/ARCHITECTURE.md`
- No generated artifact, no new dependency, no network or LLM call.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`

### Observed Evidence

Everything below was captured on this macOS host under `.omc/artifacts/dispatch-confinement/`:

- **Write refusal**: the probe wrote inside the worktree (exit 0) and was refused outside it (exit 1, `Operation not permitted`), with the outside file absent afterwards.
- **Exec under the policy**: `/bin/sh` exec'd `/bin/ls` and wrote its output inside the root, while the outside write was still refused — the fence survives broad exec.
- **Toolchain under a real dispatch environment, in a linked worktree**: `git --version`, `git status --porcelain` (empty) and `python3 -c` all exit 0; child-process write outside, `rename` out, hardlink out and a write through an in-root symlink pointing outside are each refused.
- **Dry run**: `omh coding fanout dispatch --dry-run` records the planned confinement as `prepared_not_observed` and spawns nothing.
- Full suite: 9357 tests, OK, 1 skipped. `docs ulw-inventory --check` and `docs ulw-site --check` also exit 0.
- **Five independent gate-review passes, two of them blocking.** Pass 3 blocked because declared `NAME=VALUE` verification overrides were silently replaced by the confinement environment, so contract-frozen checks ran against the wrong environment while the journal reported success. Pass 4 blocked because the scratch exclusion was written to a linked worktree's per-worktree gitdir, which git does not read — inert in the only worktree shape dispatch creates, and invisible because the test used a plain checkout. Both are fixed, each with a test rebuilt in the shape the feature actually runs in. The reviewer independently reproduced the escape battery, the linked-worktree cleanliness, and the adapter lane's unchanged policy.

### Not Tested / Not Applicable

- **Linux is unexercised.** `bwrap` is not installed on the authoring machine and no Linux host was available, so every Linux claim rests on code reading. Filed as #1356 rather than asserted.
- **Windows has no backend at all.** Filed as #1357.
- **No agent CLI was ever spawned.** Every probe used `/bin/sh`; this PR does not claim any particular CLI runs correctly under the policy beyond git and python3.

## Risk

The dispatch lane spawns processes, so the risk is a dispatch that used to work and now fails. Three things bound it: the wrapper is only produced when a probe in that run proved the fence, any failure to prepare degrades to today's behaviour with a named reason, and the policy allows reads and network broadly so a CLI cannot fail for lack of config or credentials. The residual is a CLI that needs to write outside its worktree — which is the behaviour this change exists to stop.

## Compatibility / Rollout

No flag, schema, or output contract changed. On macOS a dispatch that previously wrote outside its worktree will now fail those writes; that is the point. Elsewhere behaviour is byte-identical to today.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- #1356 — run and verify the Linux `bwrap` path on a real Linux host.
- #1357 — design a Windows backend, or record that none is workable without a dependency.
- The scratch `.gitignore` is written unconditionally. A repo that tracks `.omh/confinement-tmp/.gitignore` with different content would show it as modified. Contrived enough to leave; a compare-before-write would close it.