### PR TITLE
fix(coding): let a confined owner CLI write its own state, or the fence breaks it

### DIFF
--- a/src/coding/action_gate.py
+++ b/src/coding/action_gate.py
@@ -868,8 +868,9 @@ _DATA_BOUNDARY_STATEMENTS = {
     ),
     "runtime_filesystem_confinement": (
         "Fanout places its owner and dispatcher verification processes under the existing OS sandbox. "
-        "It confines writes, not reads. A particular run reports confinement only after its same-root probe was "
-        "refused outside the unit worktree."
+        "It confines writes, not reads, to the unit worktree and the selected owner's state directories, with any "
+        "owner state file granted as an exact literal and only the two named credential mach-lookup allowances. "
+        "A particular run reports confinement only after its same-run probe wrote every directory root and was refused outside them."
     ),
     "runtime_network_confinement": (
         "Fanout preserves its existing network behavior, so the OS sandbox is not requested to confine network access."

--- a/src/coding/fanout_confinement.py
+++ b/src/coding/fanout_confinement.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from importlib import import_module
 from pathlib import Path
 import re
 import shutil
 import subprocess
+from typing import cast
 from uuid import uuid4
 
 from ..quality.cross_harness_adapter_sandbox import (
@@ -24,12 +26,117 @@ from ..quality.cross_harness_adapter_sandbox import (
 FANOUT_FILESYSTEM_CONFINEMENT_SCHEMA_VERSION = "fanout_filesystem_confinement/v1"
 FANOUT_FILESYSTEM_CONFINEMENT_CLAIM_BOUNDARY = (
     "A confinement receipt is observed only when its same-run sandbox probe wrote inside the unit worktree "
-    "and was refused outside it. Backend availability, preflight, and a prepared command alone are not confinement evidence."
+    "and every selected owner state directory, then was refused outside every write root. Owner state may also "
+    "include an exact file literal and the two named credential mach-lookup allowances; neither expands into a "
+    "directory or broader IPC permission. Backend availability, preflight, and a prepared command alone are not "
+    "confinement evidence."
 )
 # Fanout confines writes, not reads: an invited coding CLI needs its own toolchain,
 # configuration, credentials, and caches. The receipt attests only the write boundary.
 _FANOUT_MACOS_TOOLCHAIN_WRITE_DATA_LITERALS = (Path("/dev/null"),)
+# Claude Code retrieves its OAuth credential through securityd. This named IPC
+# lookup is orthogonal to file-write*: a Keychain ACL denial can invoke the
+# external SecurityAgent prompt rather than hard-failing here, and still governs
+# credential access.
+_FANOUT_MACOS_CREDENTIAL_MACH_SERVICES = ("com.apple.securityd.xpc", "com.apple.SecurityServer")
 _FANOUT_MACOS_TOOLCHAIN_TEMP_DIRECTORY = Path(".omh") / "confinement-tmp"
+
+
+@dataclass(frozen=True, slots=True)
+class _OwnerStatePath:
+    environment_variable: str | None
+    default: Path
+    fallback_environment_variables: tuple[str, ...] = ()
+    is_file: bool = False
+    configured_relative: bool = False
+
+
+# The argv table in fanout_dispatch identifies the executable profile. These defaults
+# are each CLI's state home; an explicit environment value wins. OMO state follows
+# the resolved host, rather than Hermes state, because those are distinct owners.
+_OWNER_STATE_DIRECTORIES: dict[str, dict[str | None, tuple[_OwnerStatePath, ...]]] = {
+    "codex": {None: (_OwnerStatePath("CODEX_HOME", Path(".codex")),)},
+    "claude-code": {
+        # Claude's config directory is one owner-owned state tree, while the
+        # home-level config file remains an exact literal outside that tree.
+        None: (
+            _OwnerStatePath("CLAUDE_CONFIG_DIR", Path(".claude")),
+            _OwnerStatePath("CLAUDE_CONFIG_DIR", Path(".claude.json"), is_file=True, configured_relative=True),
+        )
+    },
+    "hermes": {None: (_OwnerStatePath("HERMES_HOME", Path(".hermes")),)},
+    "omo-runtime": {
+        "pi": (_OwnerStatePath("PI_CODING_AGENT_DIR", Path(".pi") / "agent"),),
+        # omh resolves and invokes senpi directly, never the branded `omo`
+        # launcher. The latter owns the observed ~/.omo tree beyond agent/
+        # (memory, codegraph, lsp-daemon, and config.jsonc), but that tree is
+        # not direct-senpi state. Senpi itself has only agent/ on this host;
+        # its resolver reads SENPI_CODING_AGENT_DIR then PI_CODING_AGENT_DIR,
+        # never OMO_CODING_AGENT_DIR.
+        "senpi": (
+            _OwnerStatePath(
+                "SENPI_CODING_AGENT_DIR",
+                Path(".senpi") / "agent",
+                fallback_environment_variables=("PI_CODING_AGENT_DIR",),
+            ),
+        ),
+        # UNVERIFIED against a running OpenCode CLI: it is absent on this
+        # host. Lead-observed XDG data contains logs/repos and XDG state is
+        # present; ~/.opencode is absent and ~/.config/opencode is empty.
+        # No OpenCode environment override is named without CLI evidence.
+        "opencode": (
+            _OwnerStatePath(None, Path(".local") / "share" / "opencode"),
+            _OwnerStatePath(None, Path(".local") / "state" / "opencode"),
+        ),
+    },
+}
+
+
+def _owner_state_paths(owner: str, environment: Mapping[str, str]) -> tuple[tuple[Path, bool], ...]:
+    profiles = _OWNER_STATE_DIRECTORIES.get(owner)
+    if profiles is None:
+        return ()
+    host = None
+    if owner == "omo-runtime":
+        runtime_host = cast(
+            Callable[[], str | None],
+            getattr(import_module("omh.coding.fanout_dispatch"), "omo_runtime_host"),
+        )
+        host = runtime_host()
+    profile = profiles.get(host)
+    if profile is None:
+        return ()
+    paths: list[tuple[Path, bool]] = []
+    for entry in profile:
+        configured = ""
+        for environment_variable in (entry.environment_variable, *entry.fallback_environment_variables):
+            if environment_variable is not None and environment_variable in environment:
+                configured = str(environment.get(environment_variable, "") or "").strip()
+                break
+        path = (
+            (Path(configured).expanduser() / entry.default).resolve()
+            if configured and entry.configured_relative
+            else Path(configured).expanduser().resolve()
+            if configured
+            else (Path.home() / entry.default).resolve()
+        )
+        paths.append((path, entry.is_file))
+    return tuple(paths)
+
+
+def owner_state_directories(owner: str, environment: Mapping[str, str]) -> tuple[Path, ...]:
+    """Return only the dispatched owner's state directories without creating them."""
+    return unique_roots(tuple(path for path, is_file in _owner_state_paths(owner, environment) if not is_file))
+
+
+def owner_state_files(owner: str, environment: Mapping[str, str]) -> tuple[Path, ...]:
+    """Return only the dispatched owner's state files without creating them."""
+    return unique_roots(tuple(path for path, is_file in _owner_state_paths(owner, environment) if is_file))
+
+
+def owner_state_directory(owner: str, environment: Mapping[str, str]) -> Path | None:
+    """Return the first state directory for compatibility with singular callers."""
+    return next(iter(owner_state_directories(owner, environment)), None)
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,6 +145,8 @@ class FanoutFilesystemConfinement:
 
     selected: str
     roots: tuple[Path, ...]
+    write_roots: tuple[Path, ...]
+    write_literals: tuple[Path, ...]
     child: ChildContext | None
     environment: Mapping[str, str]
     backend_digest: str
@@ -61,7 +170,10 @@ class FanoutFilesystemConfinement:
             self.backend_digest,
             allow_broad_process_exec=True,
             macos_write_data_literals=_FANOUT_MACOS_TOOLCHAIN_WRITE_DATA_LITERALS,
+            write_literals=self.write_literals,
+            macos_mach_lookup_names=_FANOUT_MACOS_CREDENTIAL_MACH_SERVICES,
             allow_broad_file_read=True,
+            write_roots=self.write_roots,
         )
 
     def command_environment(self) -> dict[str, str]:
@@ -78,16 +190,26 @@ class FanoutFilesystemConfinement:
         }
 
 
-def planned_fanout_filesystem_confinement(worktree: Path) -> dict[str, object]:
+def planned_fanout_filesystem_confinement(
+    worktree: Path,
+    *,
+    owner: str = "",
+    environment: Mapping[str, str] | None = None,
+) -> dict[str, object]:
     """Describe a dry-run boundary without claiming the probe ran."""
     selected = backend("auto")
     reason_code = "dry_run_no_confinement_probe"
     if selected == "unsupported":
         reason_code = "no_os_confinement_backend_on_this_platform"
+    owner_state_roots = owner_state_directories(owner, {} if environment is None else environment)
+    write_roots = unique_roots((worktree, *owner_state_roots))
+    write_literals = owner_state_files(owner, {} if environment is None else environment)
     return _receipt(
         status="prepared_not_observed",
         selected=selected,
         worktree=worktree,
+        write_roots=write_roots,
+        write_literals=write_literals,
         enforced=False,
         reason_code=reason_code,
     )
@@ -97,30 +219,50 @@ def prepare_fanout_filesystem_confinement(
     worktree: Path,
     environment: Mapping[str, str],
     commands: Sequence[Sequence[str]],
+    *,
+    owner: str = "",
 ) -> FanoutFilesystemConfinement:
     """Probe one unit's backend before allowing its owner or checks to use it."""
     worktree = worktree.resolve()
+    owner_state_roots = owner_state_directories(owner, environment)
+    write_roots = unique_roots((worktree, *owner_state_roots))
+    write_literals = owner_state_files(owner, environment)
     selected = backend("auto")
     if selected == "unsupported":
-        return _unconfined(worktree, selected, environment, "no_os_confinement_backend_on_this_platform")
+        return _unconfined(
+            worktree, selected, environment, "no_os_confinement_backend_on_this_platform",
+            write_roots=write_roots, write_literals=write_literals,
+        )
     if not backend_available(selected):
-        return _unconfined(worktree, selected, environment, "sandbox_backend_unavailable")
+        return _unconfined(
+            worktree, selected, environment, "sandbox_backend_unavailable",
+            write_roots=write_roots, write_literals=write_literals,
+        )
     if not commands:
-        return _unconfined(worktree, selected, environment, "sandbox_no_runnable_command")
+        return _unconfined(
+            worktree, selected, environment, "sandbox_no_runnable_command",
+            write_roots=write_roots, write_literals=write_literals,
+        )
     executables = _resolve_executables(commands, environment)
     if not executables:
-        return _unconfined(worktree, selected, environment, "sandbox_executable_not_found")
+        return _unconfined(
+            worktree, selected, environment, "sandbox_executable_not_found",
+            write_roots=write_roots, write_literals=write_literals,
+        )
     roots = unique_roots(
         (worktree, *(Path(executable).parent for executable in executables.values()), *runtime_roots(selected))
     )
     if not read_roots_are_safe(roots):
         return _unconfined(
-            worktree, selected, environment, "unsafe_sandbox_read_root", roots=roots, executables=executables
+            worktree, selected, environment, "unsafe_sandbox_read_root", roots=roots,
+            write_roots=write_roots, write_literals=write_literals, executables=executables,
         )
     if selected == "sandbox-exec":
         scratch_directory = worktree / _FANOUT_MACOS_TOOLCHAIN_TEMP_DIRECTORY
         scratch_directory.mkdir(parents=True, exist_ok=True)
-        _ = (scratch_directory / ".gitignore").write_text("*\n", encoding="utf-8")
+        gitignore = scratch_directory / ".gitignore"
+        if not gitignore.is_file() or gitignore.read_text(encoding="utf-8") != "*\n":
+            _ = gitignore.write_text("*\n", encoding="utf-8")
     child = ChildContext(
         worktree,
         worktree,
@@ -139,14 +281,18 @@ def prepare_fanout_filesystem_confinement(
             environment,
             "sandbox_preflight_failed",
             roots=roots,
+            write_roots=write_roots,
+            write_literals=write_literals,
             child=child,
             backend_digest=backend_digest,
             executables=executables,
         )
-    receipt = _probe(selected, roots, child, environment, backend_digest)
+    receipt = _probe(selected, roots, write_roots, write_literals, child, environment, backend_digest)
     return FanoutFilesystemConfinement(
         selected,
         roots,
+        write_roots,
+        write_literals,
         child,
         environment,
         backend_digest,
@@ -166,6 +312,8 @@ def confinement_receipt(
         status="prepared_not_observed",
         selected=backend("auto"),
         worktree=worktree,
+        write_roots=(worktree,),
+        write_literals=(),
         enforced=False,
         reason_code="sandbox_not_applied_to_injected_runner",
     )
@@ -178,6 +326,8 @@ def _unconfined(
     reason_code: str,
     *,
     roots: tuple[Path, ...] = (),
+    write_roots: tuple[Path, ...] = (),
+    write_literals: tuple[Path, ...] = (),
     child: ChildContext | None = None,
     backend_digest: str = "",
     executables: Mapping[str, str] | None = None,
@@ -185,6 +335,8 @@ def _unconfined(
     return FanoutFilesystemConfinement(
         selected,
         roots,
+        write_roots,
+        write_literals,
         child,
         environment,
         backend_digest,
@@ -193,6 +345,8 @@ def _unconfined(
             status="prepared_not_observed",
             selected=selected,
             worktree=worktree,
+            write_roots=write_roots,
+            write_literals=write_literals,
             enforced=False,
             reason_code=reason_code,
         ),
@@ -218,6 +372,8 @@ def _resolve_executables(
 def _probe(
     selected: str,
     roots: tuple[Path, ...],
+    write_roots: tuple[Path, ...],
+    write_literals: tuple[Path, ...],
     child: ChildContext,
     environment: Mapping[str, str],
     backend_digest: str,
@@ -225,15 +381,24 @@ def _probe(
     token = uuid4().hex
     inside = child.work / f".omh-confinement-inside-{token}"
     outside = child.work.parent / f".omh-confinement-outside-{token}"
-    script = (
-        'printf inside > "$1"; inside=$?; printf outside > "$2"; outside=$?; '
-        'printf "inside_exit=%s outside_exit=%s\\n" "$inside" "$outside"; '
-        'test "$inside" -eq 0 -a "$outside" -ne 0'
+    state_writes = tuple(
+        owner_state / f".omh-confinement-state-{token}" for owner_state in write_roots[1:]
     )
-    argv = ("/bin/sh", "-c", script, "omh-confinement-probe", str(inside), str(outside))
+    script = (
+        'inside_path=$1; outside_path=$2; shift 2; printf inside > "$inside_path"; inside=$?; '
+        'state=0; for state_path do printf state > "$state_path"; state_write=$?; '
+        'printf "owner_state_exit=%s\\n" "$state_write"; test "$state_write" -eq 0 || state=$state_write; done; '
+        'printf outside > "$outside_path"; outside=$?; '
+        'printf "inside_exit=%s owner_state_exit=%s outside_exit=%s\\n" "$inside" "$state" "$outside"; '
+        'test "$inside" -eq 0 -a "$state" -eq 0 -a "$outside" -ne 0'
+    )
+    argv = ("/bin/sh", "-c", script, "omh-confinement-probe", str(inside), str(outside), *(str(path) for path in state_writes))
     try:
         completed = subprocess.run(
-            sandbox_command(argv, selected, roots, child, True, environment, backend_digest),
+            sandbox_command(
+                argv, selected, roots, child, True, environment, backend_digest,
+                write_roots=write_roots, write_literals=write_literals,
+            ),
             cwd=child.work,
             env=environment,
             stdin=subprocess.DEVNULL,
@@ -242,12 +407,19 @@ def _probe(
             timeout=5,
             check=False,
         )
-        match = re.search(r"inside_exit=(\d+) outside_exit=(\d+)", completed.stdout)
+        match = re.search(r"inside_exit=(\d+) owner_state_exit=(\d+) outside_exit=(\d+)", completed.stdout)
         inside_code = int(match.group(1)) if match else None
-        outside_code = int(match.group(2)) if match else None
+        state_code = int(match.group(2)) if match and state_writes else None
+        state_codes = tuple(
+            int(code) for code in cast(list[str], re.findall(r"^owner_state_exit=(\d+)$", completed.stdout, re.MULTILINE))
+        )
+        outside_code = int(match.group(3)) if match else None
         enforced = (
             completed.returncode == 0
             and inside_code == 0
+            and len(state_codes) == len(state_writes)
+            and all(code == 0 for code in state_codes)
+            and (not state_writes or state_code == 0)
             and outside_code is not None
             and outside_code != 0
             and inside.is_file()
@@ -258,6 +430,8 @@ def _probe(
                 status="observed",
                 selected=selected,
                 worktree=child.work,
+                write_roots=write_roots,
+                write_literals=write_literals,
                 enforced=enforced,
                 reason_code="" if enforced else "sandbox_probe_failed",
             ),
@@ -266,6 +440,8 @@ def _probe(
                 "command": list(argv),
                 "exit_code": completed.returncode,
                 "inside_write_exit_code": inside_code,
+                "owner_state_write_exit_code": state_code,
+                "owner_state_write_exit_codes": list(state_codes),
                 "outside_write_exit_code": outside_code,
                 "refusal": completed.stderr.strip()[:300],
             },
@@ -276,6 +452,8 @@ def _probe(
                 status="observed",
                 selected=selected,
                 worktree=child.work,
+                write_roots=write_roots,
+                write_literals=write_literals,
                 enforced=False,
                 reason_code="sandbox_probe_failed",
             ),
@@ -284,13 +462,22 @@ def _probe(
                 "command": list(argv),
                 "exit_code": None,
                 "inside_write_exit_code": None,
+                "owner_state_write_exit_code": None,
+                "owner_state_write_exit_codes": [],
                 "outside_write_exit_code": None,
                 "refusal": str(exc)[:300],
             },
         }
     finally:
+        # This is best-effort cleanup, not an unconditional guarantee: a
+        # SIGKILL between a sandboxed state write and this block leaves one
+        # small marker per state root. `subprocess.run` also kills only the
+        # direct sandbox-exec child on timeout, so a blocked grandchild can
+        # outlive that timeout.
         inside.unlink(missing_ok=True)
         outside.unlink(missing_ok=True)
+        for state_write in state_writes:
+            state_write.unlink(missing_ok=True)
 
 
 def _receipt(
@@ -298,14 +485,18 @@ def _receipt(
     status: str,
     selected: str,
     worktree: Path,
-    enforced: bool,
-    reason_code: str,
+    write_roots: Sequence[Path],
+    write_literals: Sequence[Path] = (),
+    enforced: bool = False,
+    reason_code: str = "",
 ) -> dict[str, object]:
     return {
         "schema_version": FANOUT_FILESYSTEM_CONFINEMENT_SCHEMA_VERSION,
         "status": status,
         "backend": selected,
         "write_root": str(worktree.resolve()),
+        "write_roots": [str(root.resolve()) for root in write_roots],
+        "write_literals": [str(path.resolve()) for path in write_literals],
         "enforced": enforced,
         "reason_code": reason_code,
         "claim_boundary": FANOUT_FILESYSTEM_CONFINEMENT_CLAIM_BOUNDARY,

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -86,6 +86,7 @@ from .fanout_health_events import (
 from .fanout_confinement import (
     FanoutFilesystemConfinement,
     confinement_receipt,
+    owner_state_directories,
     planned_fanout_filesystem_confinement,
     prepare_fanout_filesystem_confinement,
 )
@@ -438,8 +439,9 @@ def fanout_child_env(
     depth: int,
     fanout_id: str,
     unit_id: str,
+    owner: str = "",
 ) -> dict[str, str]:
-    """`base_env` plus this dispatcher's lineage stamp, for one child spawn.
+    """`base_env` plus this dispatcher's lineage and owner-state pins, for one child spawn.
 
     Every process this module starts gets the stamp, verification commands
     included: a guard a child sidesteps by shelling out one more level is not
@@ -448,11 +450,25 @@ def fanout_child_env(
     lineage_step = f"{fanout_id or 'unrecorded'}:{unit_id}"
     parent_lineage = str(base_env.get(FANOUT_LINEAGE_ENV_VAR, "") or "").strip()
     lineage = f"{parent_lineage}/{lineage_step}" if parent_lineage else lineage_step
-    return {
+    child_env = {
         **dict(base_env),
         FANOUT_DEPTH_ENV_VAR: str(depth + 1),
         FANOUT_LINEAGE_ENV_VAR: lineage[-_MAX_LINEAGE_CHARS:],
     }
+    if owner != "omo-runtime":
+        return child_env
+    host = omo_runtime_host()
+    environment_variable = {"pi": "PI_CODING_AGENT_DIR", "senpi": "SENPI_CODING_AGENT_DIR"}.get(host)
+    if environment_variable is None:
+        return child_env
+    state_directories = owner_state_directories(owner, child_env)
+    if len(state_directories) != 1:
+        return child_env
+    # A direct pi/senpi spawn must not inherit an ambient Senpi brand: it
+    # changes both the config directory and environment-prefix precedence.
+    child_env.pop("SENPI_BRAND", None)
+    child_env[environment_variable] = str(state_directories[0])
+    return child_env
 
 
 class _SpawnLedger:
@@ -3196,7 +3212,9 @@ def _dispatch_unit(
             not_ready["repair_card"] = dict(repair_card)
         if dry_run:
             not_ready["filesystem_confinement"] = planned_fanout_filesystem_confinement(
-                _worktree_path(repo_root, unit_id)
+                _worktree_path(repo_root, unit_id),
+                owner=owner,
+                environment=os.environ if base_env is None else base_env,
             )
         return not_ready
     discovery = (discoveries or {}).get(owner)
@@ -3246,7 +3264,11 @@ def _dispatch_unit(
             "status": "dry_run_planned",
             "planned_argv": [part if part != prompt else "<unit prompt>" for part in argv],
             "worktree_path": str(worktree),
-            "filesystem_confinement": planned_fanout_filesystem_confinement(worktree),
+            "filesystem_confinement": planned_fanout_filesystem_confinement(
+                worktree,
+                owner=owner,
+                environment=os.environ if base_env is None else base_env,
+            ),
             **_dispatch_status_ladder(),
         }
         if fingerprint_note is not None:
@@ -3335,6 +3357,7 @@ def _dispatch_unit(
         depth=dispatch_depth,
         fanout_id=fanout_id,
         unit_id=unit_id,
+        owner=owner,
     )
     from .worktree_creator import ensure_fanout_unit_worktree
 
@@ -3368,7 +3391,7 @@ def _dispatch_unit(
         verification_argv.append(check_argv)
     confinement = (
         prepare_fanout_filesystem_confinement(
-            worktree, child_env, (argv, *verification_argv)
+            worktree, child_env, (argv, *verification_argv), owner=owner
         )
         if runner is signal_safe_unit_runner
         else None

--- a/src/quality/cross_harness_adapter_sandbox.py
+++ b/src/quality/cross_harness_adapter_sandbox.py
@@ -258,7 +258,12 @@ def sandbox_command(
     macos_read_root_aliases: Sequence[Path] = (),
     macos_read_literals: Sequence[Path] = (),
     macos_write_data_literals: Sequence[Path] = (),
+    write_literals: Sequence[Path] = (),
+    macos_mach_lookup_names: Sequence[str] = (),
     allow_broad_file_read: bool = False,
+    # A write root is not screened as a read root: this is an explicit execution
+    # allowance, while `read_roots_are_safe` protects data exposed to a child.
+    write_roots: Sequence[Path] = (),
 ) -> tuple[str, ...]:
     if selected == "sandbox-exec":
         executables = (argv[0], "/usr/bin/true")
@@ -292,8 +297,22 @@ def sandbox_command(
             f'(allow file-write-data (literal {json.dumps(str(root))}))'
             for root in macos_write_data_literals
         )
+        write_subpaths = " ".join(
+            f'(subpath {json.dumps(str(root))})' for root in unique_roots((child.root, *write_roots))
+        )
+        # Seatbelt's literal grants operations on the exact name. If an
+        # external writer removes that file and replaces it with a directory,
+        # the literal rule still denies writes below the replacement directory.
+        write_literal_policy = "".join(
+            f'(allow file-write* (literal {json.dumps(str(path.resolve()))}))'
+            for path in unique_roots(write_literals)
+        )
+        mach_lookup = "".join(
+            f'(allow mach-lookup (global-name {json.dumps(name)}))'
+            for name in macos_mach_lookup_names
+        )
         network = "(allow network*)" if allow_network else ""
-        policy = f'(version 1)(deny default)(deny syscall-unix (syscall-number 147 82))(allow process-fork){process_exec}(allow sysctl-read){file_read}{write_data_literals}(allow file-write* (subpath {json.dumps(str(child.root))})){network}'
+        policy = f'(version 1)(deny default)(deny syscall-unix (syscall-number 147 82))(allow process-fork){process_exec}(allow sysctl-read){file_read}{write_data_literals}{write_literal_policy}(allow file-write* {write_subpaths}){mach_lookup}{network}'
         return ("/usr/bin/sandbox-exec", "-p", policy, *argv)
     tool = _trusted_bwrap(backend_digest)
     assert tool is not None
@@ -302,8 +321,13 @@ def sandbox_command(
         flags.insert(3, "--unshare-net")
     bind_roots = unique_roots((*roots, Path(argv[0]).resolve().parent))
     binds = [part for root in bind_roots for part in ("--ro-bind", str(root), str(root))]
+    writable_roots = tuple(root for root in unique_roots((*write_roots, *write_literals)) if root != child.root)
+    # --bind-try keeps preparation non-fatal when an allowed state directory has
+    # not been created yet; it never grants the broad parent directory instead.
+    # In particular, it cannot create an absent exact file literal (#1356).
+    write_binds = [part for root in writable_roots for part in ("--bind-try", str(root), str(root))]
     env_flags = [part for key, value in sorted(environment.items()) for part in ("--setenv", key, value)]
-    return (tool, *flags, "--tmpfs", "/", *binds, "--bind", str(child.root), str(child.root), "--chdir", str(child.work), *env_flags, "--", *argv)
+    return (tool, *flags, "--tmpfs", "/", *binds, "--bind", str(child.root), str(child.root), *write_binds, "--chdir", str(child.work), *env_flags, "--", *argv)
 
 
 def _trusted_bwrap(expected_digest: str | None = None) -> str | None:

--- a/tests/test_cross_harness_adapter_security.py
+++ b/tests/test_cross_harness_adapter_security.py
@@ -261,6 +261,22 @@ class AdapterSandboxSecurityTests(_RunnerMixin, unittest.TestCase):
         self.assertEqual(command, expected)
         self.assertFalse(any("try" in part or part in {str(Path.home()), "--share-net"} for part in command))
 
+    def test_linux_owner_state_write_root_is_writable_without_broadening_reads(self) -> None:
+        child = ChildContext(Path("/tmp/scratch"), Path("/tmp/scratch/home"), Path("/tmp/scratch/work"), Path("/tmp/scratch/tmp"), Path("/tmp/scratch/output"), Path("/tmp/scratch/request.json"), Path("/tmp/scratch/output/result.json"), "f" * 64)
+        environment = {"HOME": "/tmp/scratch/home", "PATH": "/usr/bin:/bin", "PYTHONNOUSERSITE": "1"}
+        with patch("src.quality.cross_harness_adapter_sandbox._trusted_bwrap", return_value="/usr/bin/bwrap"):
+            command = sandbox_command(
+                ("/opt/runtime/bin/tool", "run"), "bwrap", (Path("/opt/fixtures"),), child, False, environment,
+                write_roots=(Path("/home/operator/.claude"),),
+                write_literals=(Path("/home/operator/.claude.json"),),
+            )
+        self.assertIn("--bind-try", command)
+        state_index = command.index("--bind-try")
+        state = str(Path("/home/operator/.claude").resolve())
+        state_file = str(Path("/home/operator/.claude.json").resolve())
+        self.assertEqual(command[state_index:state_index + 6], ("--bind-try", state, state, "--bind-try", state_file, state_file))
+        self.assertNotIn("--ro-bind", command[state_index:])
+
     def test_ambient_path_bwrap_is_never_executed(self) -> None:
         with TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/test_fanout_confinement.py
+++ b/tests/test_fanout_confinement.py
@@ -12,10 +12,21 @@ from _local_package import load_local_package
 
 load_local_package()
 
-from omh.coding.fanout_confinement import prepare_fanout_filesystem_confinement  # noqa: E402
+from omh.coding.fanout_confinement import (  # noqa: E402
+    _probe,
+    owner_state_directories,
+    owner_state_files,
+    prepare_fanout_filesystem_confinement,
+)
+from omh.quality.cross_harness_adapter_sandbox import (  # noqa: E402
+    ChildContext,
+    runtime_roots,
+    sandbox_command,
+)
 from omh.coding.fanout_dispatch import (  # noqa: E402
     _run_planned_verification,
     _run_verification_command,
+    fanout_child_env,
     signal_safe_unit_runner,
 )
 from omh.system.paths import OmhPaths  # noqa: E402
@@ -39,6 +50,124 @@ def _linked_worktree(root: Path) -> Path:
 
 @unittest.skipUnless(sys.platform == "darwin", "sandbox-exec confinement is exercised on macOS")
 class FanoutFilesystemConfinementTests(unittest.TestCase):
+    def test_owner_state_directories_allow_only_the_selected_owner_state(self) -> None:
+        home = Path("/tmp/fanout-owner-home").resolve()
+        with mock.patch("omh.coding.fanout_confinement.Path.home", return_value=home):
+            self.assertEqual(owner_state_directories("codex", {}), (home / ".codex",))
+            self.assertEqual(owner_state_directories("claude-code", {}), (home / ".claude",))
+            self.assertEqual(owner_state_files("claude-code", {}), (home / ".claude.json",))
+            configured_claude = {"CLAUDE_CONFIG_DIR": str(home / "configured-claude")}
+            self.assertEqual(owner_state_directories("claude-code", configured_claude), (home / "configured-claude",))
+            self.assertEqual(
+                owner_state_files("claude-code", configured_claude),
+                (home / "configured-claude" / ".claude.json",),
+            )
+            self.assertEqual(owner_state_directories("hermes", {}), (home / ".hermes",))
+            for host, expected in {
+                "pi": (home / ".pi" / "agent",),
+                "senpi": (home / ".senpi" / "agent",),
+                "opencode": (
+                    home / ".local" / "share" / "opencode",
+                    home / ".local" / "state" / "opencode",
+                ),
+            }.items():
+                with self.subTest(host=host):
+                    with mock.patch("omh.coding.fanout_dispatch.omo_runtime_host", return_value=host):
+                        self.assertEqual(owner_state_directories("omo-runtime", {}), expected)
+            with mock.patch("omh.coding.fanout_dispatch.omo_runtime_host", return_value="pi"):
+                self.assertEqual(
+                    owner_state_directories("omo-runtime", {"PI_CODING_AGENT_DIR": str(home / "pi-override")}),
+                    (home / "pi-override",),
+                )
+            with mock.patch("omh.coding.fanout_dispatch.omo_runtime_host", return_value="senpi"):
+                self.assertEqual(
+                    owner_state_directories("omo-runtime", {"OMO_CODING_AGENT_DIR": str(home / "omo-state")}),
+                    (home / ".senpi" / "agent",),
+                )
+                self.assertEqual(
+                    owner_state_directories("omo-runtime", {"PI_CODING_AGENT_DIR": str(home / "legacy-pi-override")}),
+                    (home / "legacy-pi-override",),
+                )
+                self.assertEqual(
+                    owner_state_directories(
+                        "omo-runtime",
+                        {
+                            "SENPI_CODING_AGENT_DIR": str(home / "senpi-override"),
+                            "PI_CODING_AGENT_DIR": str(home / "ignored-pi-override"),
+                        },
+                    ),
+                    (home / "senpi-override",),
+                )
+        self.assertEqual(owner_state_directories("unassigned", {}), ())
+
+    def test_omo_runtime_child_env_pins_agent_dir_and_scrubs_senpi_brand(self) -> None:
+        home = Path("/tmp/fanout-owner-home").resolve()
+        cases = {
+            "pi": ("PI_CODING_AGENT_DIR", {}, home / ".pi" / "agent"),
+            "senpi": (
+                "SENPI_CODING_AGENT_DIR",
+                {"PI_CODING_AGENT_DIR": str(home / "legacy-senpi-override")},
+                home / "legacy-senpi-override",
+            ),
+        }
+        for host, (environment_variable, overrides, expected) in cases.items():
+            with (
+                self.subTest(host=host),
+                mock.patch("omh.coding.fanout_confinement.Path.home", return_value=home),
+                mock.patch("omh.coding.fanout_dispatch.omo_runtime_host", return_value=host),
+            ):
+                child_env = fanout_child_env(
+                    {
+                        "SENPI_BRAND": '{"name":"omo","envPrefix":"OMO","configDir":".omo"}',
+                        **overrides,
+                    },
+                    depth=0,
+                    fanout_id="fanout",
+                    unit_id="unit",
+                    owner="omo-runtime",
+                )
+                self.assertEqual(child_env[environment_variable], str(expected))
+                self.assertEqual(owner_state_directories("omo-runtime", child_env), (expected,))
+                self.assertNotIn("SENPI_BRAND", child_env)
+        with mock.patch("omh.coding.fanout_dispatch.omo_runtime_host", return_value="opencode"):
+            child_env = fanout_child_env(
+                {"SENPI_BRAND": "ambient"},
+                depth=0,
+                fanout_id="fanout",
+                unit_id="unit",
+                owner="omo-runtime",
+            )
+        self.assertEqual(child_env["SENPI_BRAND"], "ambient")
+
+    def test_probe_writes_every_owner_state_root(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            worktree = root / "worktree"
+            worktree.mkdir()
+            first_state = root / "first-state"
+            second_state = root / "second-state"
+            first_state.mkdir()
+            second_state.mkdir()
+            child = ChildContext(
+                worktree, worktree, worktree, worktree, worktree,
+                worktree / "request", worktree / "artifact", "confinement-probe",
+            )
+            with (
+                mock.patch("omh.coding.fanout_confinement.sandbox_command", side_effect=lambda argv, *_args, **_kwargs: argv),
+                mock.patch(
+                    "omh.coding.fanout_confinement.subprocess.run",
+                    return_value=subprocess.CompletedProcess(
+                        (),
+                        0,
+                        "owner_state_exit=0\nowner_state_exit=0\ninside_exit=0 owner_state_exit=0 outside_exit=1\n",
+                        "",
+                    ),
+                ),
+            ):
+                receipt = _probe("sandbox-exec", (), (worktree, first_state, second_state), (), child, {}, "digest")
+            command = receipt["probe"]["command"]
+            self.assertTrue(any(str(second_state) in argument for argument in command))
+
     def test_probe_receipt_requires_an_inside_write_and_an_outside_refusal(self) -> None:
         with TemporaryDirectory() as temporary:
             worktree = Path(temporary) / "worktree"
@@ -55,6 +184,114 @@ class FanoutFilesystemConfinementTests(unittest.TestCase):
             self.assertEqual(confinement.receipt["probe"]["inside_write_exit_code"], 0)
             self.assertEqual(confinement.receipt["probe"]["outside_write_exit_code"], 1)
             self.assertIn("Operation not permitted", confinement.receipt["probe"]["refusal"])
+
+    def test_selected_owner_state_is_a_write_only_root_and_escape_routes_stay_refused(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            worktree = root / "worktree"
+            worktree.mkdir()
+            state = root / "claude-state"
+            state.mkdir()
+            outside = root / "outside"
+            unrelated_repo = root / "unrelated-repo"
+            unrelated_repo.mkdir()
+            _ = subprocess.run(("/usr/bin/git", "init", "-q"), cwd=unrelated_repo, check=True)
+            source = worktree / "rename-source"
+            source.write_text("source", encoding="utf-8")
+            linked_outside = root / "linked-outside"
+            linked_outside.mkdir()
+            symlink = worktree / "outside-link"
+            symlink.symlink_to(linked_outside, target_is_directory=True)
+            confinement = prepare_fanout_filesystem_confinement(
+                worktree,
+                {"CLAUDE_CONFIG_DIR": str(state)},
+                (("/bin/sh", "-c", "exit 0"),),
+                owner="claude-code",
+            )
+
+            self.assertTrue(confinement.receipt["enforced"])
+            self.assertEqual(confinement.receipt["write_roots"], [str(worktree), str(state)])
+            self.assertEqual(confinement.receipt["write_literals"], [str(state / ".claude.json")])
+            self.assertNotIn(state, confinement.roots)
+            self.assertNotIn(state / ".claude.json", confinement.roots)
+            policy = confinement.command(("/bin/sh", "-c", "exit 0"))[2]
+            self.assertIn(f'(allow file-write* (literal "{state / ".claude.json"}"))', policy)
+            self.assertIn('(allow mach-lookup (global-name "com.apple.securityd.xpc"))', policy)
+            self.assertIn('(allow mach-lookup (global-name "com.apple.SecurityServer"))', policy)
+            self.assertEqual(confinement.receipt["probe"]["owner_state_write_exit_code"], 0)
+            self.assertEqual(confinement.receipt["probe"]["owner_state_write_exit_codes"], [0])
+            write_state = subprocess.run(
+                confinement.command(("/bin/sh", "-c", 'printf state > "$1"', "probe", str(state / "state"))),
+                cwd=worktree,
+                env=confinement.command_environment(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(write_state.returncode, 0, write_state.stderr)
+            self.assertTrue((state / "state").is_file())
+
+            escapes = {
+                "direct": ('printf direct > "$1"', (outside,)),
+                "child_process": ('/bin/sh -c \'printf child > "$1"\' child "$1"', (outside,)),
+                "rename_out": ('mv "$1" "$2"', (source, outside)),
+                "hardlink_out": ('ln "$1" "$2"', (source, outside)),
+                "symlink_out": ('printf symlink > "$1/file"', (symlink,)),
+                "unrelated_repo": ('printf unrelated > "$1/file"', (unrelated_repo,)),
+            }
+            for name, (script, arguments) in escapes.items():
+                with self.subTest(escape=name):
+                    completed = subprocess.run(
+                        confinement.command(("/bin/sh", "-c", script, name, *(str(path) for path in arguments))),
+                        cwd=worktree,
+                        env=confinement.command_environment(),
+                        text=True,
+                        capture_output=True,
+                        check=False,
+                    )
+                    self.assertNotEqual(completed.returncode, 0, completed.stderr)
+            self.assertFalse(outside.exists())
+            self.assertTrue(source.is_file())
+            self.assertFalse((linked_outside / "file").exists())
+            self.assertFalse((unrelated_repo / "file").exists())
+
+    def test_seatbelt_literal_replacement_does_not_grant_descendant_writes(self) -> None:
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary).resolve()
+            worktree = root / "worktree"
+            worktree.mkdir()
+            literal = root / "state-file"
+            literal.write_text("state", encoding="utf-8")
+            child = ChildContext(
+                worktree, worktree, worktree, worktree, worktree,
+                worktree / "request", worktree / "artifact", "literal-replacement",
+            )
+            literal.unlink()
+            literal.mkdir()
+            script = (
+                'printf child > "$1/child"; descendant=$?; '
+                'printf "descendant=%s\\n" "$descendant"; test "$descendant" -ne 0'
+            )
+            completed = subprocess.run(
+                sandbox_command(
+                    ("/bin/sh", "-c", script, "literal-replacement", str(literal)),
+                    "sandbox-exec",
+                    (worktree, Path("/bin"), *runtime_roots("sandbox-exec")),
+                    child,
+                    True,
+                    {},
+                    write_literals=(literal,),
+                ),
+                cwd=worktree,
+                env={},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(completed.stdout.strip(), "descendant=1")
+            self.assertTrue(literal.is_dir())
+            self.assertFalse((literal / "child").exists())
 
     def test_confined_command_can_exec_a_real_binary_without_widening_writes(self) -> None:
         with TemporaryDirectory() as temporary:


### PR DESCRIPTION
Repairs the regression shipped by #1358.

## Feature Report

### What Changed

- The dispatched owner state joins the unit worktree in the sandbox write set: directories **and** exact file literals, resolved per owner from its own environment variable or its documented default.
- Two named mach-lookup allowances, `com.apple.securityd.xpc` and `com.apple.SecurityServer`, so a confined CLI can reach the login keychain.
- The child environment pins the host own agent-dir variable to exactly the granted directory, and strips an ambient `SENPI_BRAND` from the omo spawn.
- The scratch `.gitignore` is compared before writing, so a repo that tracks that path is not dirtied.
- Receipt, action_gate and preflight wording name the widened write set and the credential IPC.

### Why This Exists

#1358 put the fanout dispatch lane under a macOS write fence, default-on wherever the probe succeeds. **It broke real dispatch.** Four legs on this host, same prompt, same owner, minutes apart:

| tree | outcome |
| --- | --- |
| #1358, confined | `failed`, exit 1, 3.409s, `not_logged_in`, no file |
| pre-#1358, no fence | `completed`, exit 0, 70.566s, `work/DONE.txt` created |
| #1358 again, confined | `failed`, exit 1, 3.368s, `not_logged_in`, no file |
| this branch, confined | `completed`, exit 0, 62.937s, `DONE.txt` = `ok` |

The account was never the problem. `auth_shaped / not_logged_in` was the fence, reported by a CLI that gave up in three seconds because it could not reach its own state, and the failure classifier had no way to tell the difference. A coding CLI writes constantly outside the worktree it edits -- measured on this host: `~/.codex` 17,437 files changed in a week, `~/.claude` 18,673, `~/.hermes` 105,552, with the newest codex writes being `logs_2.sqlite-wal` and `queue_1.sqlite-shm`. SQLite dies when it cannot write its WAL.

### User / Operator Impact

- `omh coding fanout dispatch` and `omh coding run` work again on macOS with confinement enforced, instead of failing in ~3s with a misleading auth message.
- The write fence still holds: a dispatched agent still cannot write into another repository, another owner state, `$HOME`, or anywhere else outside its unit worktree and its own state.
- Hosts with no backend, or a failed preflight, still degrade to today behaviour with a named reason.

### How It Works

**Owner state is a write root, deliberately not a read root.** `read_roots_are_safe` screens read roots and its `_SENSITIVE_PARTS` already refuses `.codex`, `.claude`, `.hermes`, `.omh` -- correctly, because a read root is data handed to a child. A write root is an execution allowance for the owner own tree, so it travels as its own parameter, and that reasoning is stated at the site.

**The file literal is `(literal ...)`, not `(subpath ...)`.** `~/.claude.json` sits in `$HOME` beside `~/.claude/`, so a subpath allowance never covered it. An intermediate revision used the subpath form; the reviewer demonstrated that would have been a real hole, and the red artifact records it.

**The mach-lookup pair is a restoration, not a new exposure.** The policy already carries `(allow file-read*)` and `(allow network*)`, and before #1358 the CLI ran with no restrictions at all. Each name was added only after a captured denial named it: file literal alone still failed in 1.18s, `+securityd.xpc` still failed in 1.19s with a captured `launchd denied lookup: name = com.apple.SecurityServer ... Sandbox restriction`, and only `+SecurityServer` reached `completed`.

**The pin makes the grant true by construction.** senpi `resolveAgentDir` walks ancestors for a `.senpi/agent`, so a worktree beneath one would silently redirect state outside the grant while the receipt still said `enforced`. The child environment now pins the host own agent-dir variable to exactly the granted directory. It fills absence only -- a user who exported the variable keeps their path -- and the grant is computed from the same environment two lines away, so they cannot diverge.

### Files And Contracts Touched

- `src/coding/fanout_confinement.py` -- owner-state table, write roots and literals, probe, receipt
- `src/coding/fanout_dispatch.py` -- child environment pin and brand strip
- `src/quality/cross_harness_adapter_sandbox.py` -- three defaulted parameters; adapter lane byte-identical
- `src/coding/action_gate.py` -- boundary statement wording
- `tests/test_fanout_confinement.py`, `tests/test_cross_harness_adapter_security.py` -- additive
- No new dependency, no network/LLM call, no generated artifact.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [x] Claude Code
- [ ] Hermes runtime or handoff
- [x] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `git diff --check`

### Observed Evidence

- Full suite on the shipping tree: **9364 tests, OK, 1 skipped**. `docs ulw-inventory --check` and `docs ulw-site --check` also exit 0.
- **Confined real dispatch, run by the lead on the shipping tree**: `omh coding run --owner claude-code` against a throwaway repo in a temp dir reached `completed`, exit 0, 62.937s, `work/DONE.txt` = `ok`, `enforced=true`, `write_roots=[unit worktree, ~/.claude]`, `write_literals=[~/.claude.json]`.
- **Probe hygiene, measured against a baseline taken before the run**: 0 `omh-confinement` markers in the live `~/.claude` before and after, and `~/.claude.json` still 78,566 bytes of valid JSON -- not truncated, not corrupted. The reviewer additionally constructed four failure paths (timeout via blocking FIFO, second-root write failure, OSError, preflight failure) and found the `finally` removes every marker in each.
- **Escape battery, re-run by the reviewer: 27/27 refused** -- write outside every root, child-process write outside, rename out, hardlink out, symlink out from both the worktree and the state root, unrelated second git repo, real `$HOME` canary, real `~/Library` canary, `/dev/zero`, the literal parent directory, and literal-replaced-by-directory descendant writes.
- RED was captured before every production change, including the reviewer own ancestor-`.senpi/agent` scenario exercised against the real senpi binary.
- **Three independent gate-review passes, one blocking.** The block was the omo-runtime mapping: the senpi profile read `OMO_CODING_AGENT_DIR`, but `@code-yeongyu/senpi/dist/core/brand.js` resolves `brandEnvNames` as `[<brand>, SENPI, PI]` and omh spawns senpi unbranded, so a user with `PI_CODING_AGENT_DIR` set would have been fenced out of the directory the binary actually uses. Also blocked: `OPENCODE_HOME` appears in no opencode artifact and `~/.opencode` does not exist, while `~/.local/share/opencode` does.

### Not Tested / Not Applicable

- **Linux is unexercised.** `bwrap` is not installed here (#1356). The Linux branch binds the state roots, but `--bind-try` cannot create a not-yet-existing file literal, so the literal half of the repair is macOS-effective only; that is commented at the site.
- **Windows has no backend at all** (#1357).
- **No codex dispatch**: codex is not installed on this host, so the codex mapping is unexercised end to end.
- The file literal and the two mach allowances are covered by unit tests rather than by the run own probe, which attests directories plus the outside refusal. The claim boundary says exactly that.

## Risk

The write set is wider than #1358 shipped, and that is the point -- it is still narrower than the unrestricted access every dispatch had before #1358. The residual risk is a mapping that does not match some owner real behaviour, which is precisely what bit the first two revisions of this PR; the pin converts the senpi case from observation to construction, and an unmapped owner widens nothing.

## Compatibility / Rollout

No flag, schema, or output contract changed. On macOS a dispatch that previously died with a spurious auth failure now runs.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- #1356 -- run the Linux `bwrap` path on a real Linux host, including whether the file literal needs a different shape there.
- #1357 -- a Windows backend, or a written finding that none is workable without a dependency.
- Reviewer note, not gated: if the `pi` on PATH were the senpi package own shim, that binary reads `SENPI_CODING_AGENT_DIR` first and defaults to `.senpi`, so a user exporting it while dispatching to that shim would diverge from the pi pin. Requires that shim plus that export; `pi` is absent here.
- A SIGKILL between the sandboxed probe write and its `finally` would leave one small marker per state root, and `subprocess.run` kills only the direct child so a blocked grandchild can outlive a timeout. Both are commented at the site.