### PR TITLE
feat(release): a cut ends with the machine synced, and a bare omh announces its Auto Update

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -145,6 +145,10 @@ Boundaries:
 - To bump by hand instead, run `uv run tools/package_manager/bump_version.py`
   (`--set X.Y.Z` for a minor or major, `--dry-run` to preview) and follow the
   Required Checks in [Release](RELEASE.md).
+- Publishing changes no installed machine. The tag and the registries move;
+  `omh --version`, the plugin manifest, and the Hermes TUI HUD footer keep
+  reporting the version each machine installed until it runs `omh update`.
+  [Release](RELEASE.md), "After the Cut", owns that step.
 
 ## Resume and rollback
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1040,6 +1040,15 @@ external agent named `choose`/`ask`:
 
 A quiet no-run line looks like
 `[omh] v1.0.6 | plugin:ready | target:single | coding-agent:not-selected`.
+
+That version is the **installed** version, never the newest published
+release: it is what `omh --version` prints, and for the TUI widget it is the
+version `omh install`/`omh update` recorded, because the widget runs the
+plugin-bundle reader without being able to import the `omh` package. A
+machine that has not run `omh update` since a release keeps showing the
+version it installed, and an already-open terminal keeps showing it until the
+TUI restarts. See [Release](RELEASE.md), "After the Cut".
+
 The plugin also exposes `omh_context` for a compact OMH mental model plus
 generic-tool checkpoint, `omh_memory` for a metadata-only comparison of Hermes
 memory against OMH's approved records, `omh_interact` for shell-free chat responses and
@@ -2232,9 +2241,29 @@ the same interval. `notify` never blocks or delays the launch either way.
 run as a real subprocess so its own re-entry sees a normal `omh update`
 argv), and by design that means the launch waits for that subprocess -- a
 command-package refresh can take minutes on the preview channel, the same
-wait `omh update` always has. A non-blocking lock keeps two simultaneous
-launches from auto-updating at once, and a failed or already-applied attempt
-is never retried before the next interval. Either mode spends at most one curl
+wait `omh update` always has. Because the launch is held for that whole
+wait, `auto` says what it is doing. It prints one line before it starts:
+
+```
+OMH Auto Update: 3f2a1c9 -> 9b7e21d (preview channel); running `omh update`.
+```
+
+and one when the update lands, naming the version now installed:
+
+```
+OMH Auto Update complete: omh 2.0.1 is installed.
+```
+
+That completion version is read back from the record `omh update` just
+rewrote, which is the same record the Hermes TUI HUD footer renders, so the
+line names the version the terminal that opens next will show. A failure
+still prints `omh: update-check auto-update failed` on stderr and nothing
+else changes. `off` and `notify` never print either line. A non-blocking lock
+keeps two simultaneous launches from auto-updating at once -- the launch that
+loses that race prints nothing, because it ran no update -- and a failed or
+already-applied attempt is never retried before the next interval.
+
+Either mode spends at most one curl
 subprocess per `interval_hours`, carrying two requests: the conditional,
 ETag-cached GET against the GitHub commits API that has always been there, and a
 repository-metadata read that names the current default branch. Each transfer is

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -535,6 +535,49 @@ packaged `omh` console script imports and runs from a source checkout. This
 check is local command importability only; it is not Hermes chat visibility,
 plugin load, executor dispatch, review, CI, merge, or delivery evidence.
 
+## After the Cut
+
+Tagging and publishing move the tag, the GitHub release, and the package
+registries. **They change no installed machine.** A machine keeps running the
+version it installed until it updates itself, so the release is not done when
+the tag exists; it is done when the machines that should run it report it.
+
+Every version an operator can see is the *installed* version, never the newest
+published tag:
+
+| Surface | What it reports |
+| --- | --- |
+| `omh --version` | the `omh` package on PATH |
+| `~/.hermes/plugins/omh/plugin.yaml` | the plugin bundle the last install/update wrote |
+| The Hermes TUI HUD footer (` v2.0.1`) | the version recorded by the last install/update, read by the plugin-bundle reader the widget spawns |
+
+The 2.0.1 cut is the worked example: the tag was pushed and npm `latest`
+moved, and the maintainer's own HUD kept showing `v2.0.0` for as long as the
+machine kept the 2.0.0 install. Nothing was broken; nothing had been updated.
+
+Sync each machine that should run the release:
+
+```sh
+omh update
+omh --version          # must print the released version
+omh doctor
+```
+
+Then restart the Hermes TUI and confirm the HUD footer shows the new version.
+The widget reads the installed plugin bundle, so a terminal that was already
+open keeps rendering the version it started with.
+
+Never hand-copy files into `~/.hermes/plugins/` or `~/.hermes/tui-widgets/` to
+close that gap. Hand-copied artifacts drift from the install manifests and
+make the next `omh update` refuse or demand `--force`.
+
+`omh release checklist` carries this as `machine_sync_after_cut`, a
+post-release follow-up rather than a pre-tag gate. Machines that opted into
+`omh update-check set --mode auto` sync themselves on the next bare `omh`
+launch and print an `OMH Auto Update` line while they do; every other machine
+syncs only when someone runs `omh update`. See
+[Installation](INSTALLATION.md), "Startup update check".
+
 ## Release Notes Must Include
 
 - Release version and channel.
@@ -551,6 +594,8 @@ plugin load, executor dispatch, review, CI, merge, or delivery evidence.
 - Plugin bundle status when `omh setup` changed.
 - GitHub Pages workflow status when public site copy changed.
 - Known manual Hermes checks that could not be automated.
+- Machine sync status after the cut: which machines ran `omh update` and what
+  version they now report, or that none has synced yet.
 - Any public claim that depends on wrapper evidence rather than Hermes-native
   capability evidence.
 

--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -407,7 +407,7 @@ def _run_startup_update_check(args: argparse.Namespace) -> None:
     except (OSError, ValueError, json.JSONDecodeError):
         return
     if result.get("should_auto_update"):
-        _run_auto_update(args, paths)
+        _run_auto_update(args, paths, result)
         return
     # Only a fresh probe prints a notice. Reusing the cache inside the same
     # interval would otherwise reprint the same "behind"/"inconclusive" line
@@ -426,7 +426,41 @@ def _run_startup_update_check(args: argparse.Namespace) -> None:
 _AUTO_UPDATE_SUBPROCESS_TIMEOUT_SECONDS = 600.0
 
 
-def _run_auto_update(args: argparse.Namespace, paths) -> None:
+def _auto_update_started_line(result: dict[str, object]) -> str:
+    """What `auto` says before it spends the launch on an update.
+
+    `notify` mode already prints why the launch is not current
+    (`maintenance/update_check.py:format_notice_line`); `auto` used to print
+    nothing at all and simply hold the terminal for however long `omh
+    update` took, which reads as a hung launch rather than as a running
+    update. Same sentence shape as the `notify` notice, so the two modes
+    read as one voice.
+    """
+    local = str(result.get("local_commit", ""))[:7] or "unknown"
+    remote = str(result.get("remote_commit", ""))[:7] or "unknown"
+    channel = str(result.get("channel", "")) or "unknown"
+    return f"OMH Auto Update: {local} -> {remote} ({channel} channel); running `omh update`."
+
+
+def _auto_update_complete_line(paths) -> str:
+    """What `auto` says once the update subprocess has succeeded.
+
+    The version comes from the record `omh update` just rewrote
+    (`commands/setup.py`), not from this process: this process is still
+    running the pre-update package, and its own `__version__` would report
+    the version the update just replaced. That record is also what the TUI
+    HUD renders (`plugin_bundle/omh/runtime_reader.py:_package_version`), so
+    the line names exactly the version the terminal is about to show.
+    """
+    from ..maintenance.update_check_state import read_runtime_state
+
+    version = str(read_runtime_state(paths).get("version", "") or "").strip()
+    if version:
+        return f"OMH Auto Update complete: omh {version} is installed."
+    return "OMH Auto Update complete."
+
+
+def _run_auto_update(args: argparse.Namespace, paths, result: dict[str, object]) -> None:
     """Auto mode: reuse `omh update`'s own code path, never a reimplementation.
 
     Spawns `omh update --no-interactive` as a real subprocess rather than
@@ -449,6 +483,11 @@ def _run_auto_update(args: argparse.Namespace, paths) -> None:
     non-forcing `ensure_tui_interface`/`ensure_omh_skin` path instead of the
     forcing `activate_*` one, so an existing explicit choice is preserved.
 
+    The attempt announces itself on stdout and says so again when it lands
+    (`_auto_update_started_line`, `_auto_update_complete_line`), because the
+    launch is held for the whole subprocess: an unannounced wait of minutes
+    is indistinguishable from a hung launch.
+
     A non-blocking lock keeps two simultaneous launches from auto-updating at
     once; losing the race is a silent skip, not a retry. A failed update is
     reported once (so the user is not left guessing) and never retried before
@@ -464,6 +503,9 @@ def _run_auto_update(args: argparse.Namespace, paths) -> None:
 
     try:
         with acquire_auto_update_lock(paths):
+            # Announced only after the lock is held: a launch that loses the
+            # race skips silently and must not claim an update it never ran.
+            print(_auto_update_started_line(result))
             # --omh-home/--hermes-home/--scope are TOP-LEVEL parser options
             # (defined before `add_subparsers`), so they must precede the
             # "update" subcommand token, not follow it.
@@ -484,6 +526,7 @@ def _run_auto_update(args: argparse.Namespace, paths) -> None:
             )
             if completed.returncode == 0:
                 refresh_cache_after_auto_update(paths)
+                print(_auto_update_complete_line(paths))
             else:
                 print(
                     f"omh: update-check auto-update failed (exit {completed.returncode})",

--- a/src/commands/release.py
+++ b/src/commands/release.py
@@ -389,7 +389,8 @@ def _print_release_checklist_summary(payload: dict[str, object]) -> None:
         print("")
         print("Optional follow-ups after evidence is attached:")
         for item in non_authority_items:
-            print(f"  - {item['id']} [{item['phase']}]")
+            marker = "profile-mutating" if item.get("mutates_profile") else "local"
+            print(f"  - {item['id']} [{item['phase']}; {marker}]")
             print(f"    {item['command']}")
     print("")
     print(f"Next: {payload['recommended_next_action']}")

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -1191,6 +1191,25 @@ def release_readiness_checklist(
             "This checklist does not create tags, GitHub releases, or production artifacts by itself.",
             True,
         ),
+        ReleaseChecklistItem(
+            "machine_sync_after_cut",
+            "Sync each machine to the published release and confirm the version it reports",
+            f"{omh_display} update && {omh_display} --version && {omh_display} doctor",
+            "post-release-sync",
+            False,
+            True,
+            (
+                f"The installed command reports {release_version}, doctor passes, and the Hermes TUI HUD footer shows "
+                f"v{release_version} after the terminal is restarted."
+            ),
+            (
+                "Tagging and publishing move the tag and the package registries only; no installed machine changes until it "
+                "updates itself. Every version an operator sees -- `omh --version`, the plugin manifest, and the TUI HUD "
+                "footer -- is the installed version, never the newest published tag. Never hand-copy files into "
+                "~/.hermes/plugins or ~/.hermes/tui-widgets to close the gap: that drifts from the install manifests and "
+                "makes the next update refuse."
+            ),
+        ),
     ]
     return {
         "schema_version": RELEASE_CHECKLIST_SCHEMA,

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -1215,7 +1215,22 @@ def format_omh_hud_line(payload: dict[str, Any], *, preset: str = "focused") -> 
 
 
 def _package_version(state: dict[str, Any], fallback: str) -> str:
-    value = str(state.get("version", "") or fallback or "").strip()
+    """The installed OMH version this HUD is describing.
+
+    A caller that can name the running package passes it (`surfaces/hud.py`
+    passes `omh.version.__version__`, the same string `omh --version`
+    prints), and that wins: it is the version of the code producing the
+    payload. The recorded `state.json` version is the fallback for the
+    reader the TUI widget spawns -- `tui_widgets/omh-status.mjs` runs
+    `python -I` with only `~/.hermes/plugins` on `sys.path`, so it imports
+    this module without being able to import `omh` at all, and the version
+    `omh install`/`omh update` recorded (`commands/setup.py`) is the only
+    installed version it can see. Both move when `omh update` runs. Reading
+    the record first made `omh hud` report a version older than `omh
+    --version` after any upgrade that refreshed the package without
+    rewriting the record.
+    """
+    value = str(fallback or "").strip() or str(state.get("version", "") or "").strip()
     if value:
         return value
     last_install = state.get("last_install", {})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4562,6 +4562,9 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertIn("profile-mutating", stdout)
         self.assertIn("Manual release-authority actions", stdout)
         self.assertIn("tag_and_publish [release-authority; release authority]", stdout)
+        self.assertIn("Optional follow-ups", stdout)
+        self.assertIn("machine_sync_after_cut [post-release-sync; profile-mutating]", stdout)
+        self.assertIn("/tmp/omh update && /tmp/omh --version && /tmp/omh doctor", stdout)
         self.assertIn("For machine-readable output", stdout)
         with self.assertRaises(json.JSONDecodeError):
             json.loads(stdout)

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -820,6 +820,42 @@ class HudCliTests(unittest.TestCase):
             self.assertNotIn("executor:", stdout)
             self.assertNotIn("handoff:", stdout)
 
+    def test_hud_version_is_the_installed_package_not_a_stale_record(self) -> None:
+        # The 2.0.1 cut: the tag moved and npm `latest` moved, and the HUD
+        # footer kept showing v2.0.0 because the machine had not run `omh
+        # update`. The HUD version is the INSTALLED version by design -- what
+        # this locks is which installed version it names. A caller that can
+        # import the running package (`surfaces/hud.py`) wins over the
+        # version `omh install`/`omh update` last recorded in state.json, so
+        # `omh hud` can never report a version older than `omh --version`.
+        # The reader the TUI widget spawns cannot import `omh` at all
+        # (`python -I` with only ~/.hermes/plugins on sys.path), so for it
+        # the recorded version is the whole answer -- and `omh update`
+        # rewrites that record.
+        from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            (omh_home / "runtime").mkdir(parents=True, exist_ok=True)
+            (omh_home / "runtime" / "state.json").write_text(
+                json.dumps({"schema_version": 1, "package": "oh-my-hermes", "version": "0.0.1"}),
+                encoding="utf-8",
+            )
+
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "hud", "--json"]
+            )
+
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertEqual(json.loads(stdout)["version"], omh_version)
+            self.assertNotEqual(omh_version, "0.0.1")
+
+            widget_payload = read_omh_hud(omh_home=str(omh_home), hermes_home=str(hermes_home))
+            self.assertEqual(widget_payload["version"], "0.0.1")
+
     def test_hud_shows_recorded_executor_preference_without_a_run(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -151,6 +151,24 @@ class ReleaseSmokeTests(unittest.TestCase):
         self.assertFalse(items["tag_and_publish"]["required"])
         self.assertIn('git tag -a v1.0.0 -m "Release v1.0.0"', items["tag_and_publish"]["command"])
         self.assertTrue(items["tag_and_publish"]["requires_release_authority"])
+        # A cut ends at the tag; a machine still runs whatever it installed.
+        # The 2.0.1 release moved the tag and npm `latest` while the
+        # maintainer's own HUD kept showing v2.0.0, because nothing had run
+        # `omh update` there. The checklist carries that as a post-release
+        # follow-up, never as a pre-tag gate.
+        self.assertIn("machine_sync_after_cut", items)
+        self.assertEqual(items["machine_sync_after_cut"]["phase"], "post-release-sync")
+        self.assertFalse(items["machine_sync_after_cut"]["required"])
+        self.assertTrue(items["machine_sync_after_cut"]["mutates_profile"])
+        self.assertFalse(items["machine_sync_after_cut"]["requires_release_authority"])
+        self.assertEqual(
+            items["machine_sync_after_cut"]["command"],
+            "/tmp/omh update && /tmp/omh --version && /tmp/omh doctor",
+        )
+        self.assertIn("1.0.0", items["machine_sync_after_cut"]["evidence_required"])
+        self.assertIn("HUD footer", items["machine_sync_after_cut"]["evidence_required"])
+        self.assertIn("no installed machine changes", items["machine_sync_after_cut"]["proof_boundary"])
+        self.assertIn("~/.hermes/plugins", items["machine_sync_after_cut"]["proof_boundary"])
         self.assertGreaterEqual(payload["required_item_count"], 18)
 
     def test_release_readiness_checklist_rejects_unsafe_versions_and_quotes_command_paths(self) -> None:

--- a/tests/test_update_check_command.py
+++ b/tests/test_update_check_command.py
@@ -264,6 +264,8 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
             output = buffer.getvalue()
             self.assertIn("OMH update available:", output)
             self.assertIn("omh update", output)
+            # `notify` reports; only `auto` updates, and only `auto` says so.
+            self.assertNotIn("Auto Update", output)
 
     def test_auto_mode_spawns_omh_update_no_interactive_as_a_real_subprocess(self) -> None:
         # Regression for the P1-b defect: `_run_auto_update` used to call
@@ -278,16 +280,25 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
             paths = _paths(root)
             write_update_check_policy(paths, mode="auto")
             paths.runtime_dir.mkdir(parents=True, exist_ok=True)
-            atomic_write_json(paths.runtime_state_path, {"release_source_commit": "a" * 40})
+            atomic_write_json(
+                paths.runtime_state_path,
+                {"release_source_commit": "a" * 40, "release_channel": "preview", "version": "9.9.8"},
+            )
             args = self._args(root)
             buffer = io.StringIO()
 
             def fake_run(argv, timeout=None):
                 # Simulate a successful `omh update` converging on the remote
-                # identity the auto-update was triggered by.
+                # identity the auto-update was triggered by, and recording the
+                # version it installed the way `commands/setup.py` does.
                 atomic_write_json(
                     paths.runtime_state_path,
-                    {"release_source_commit": "b" * 40, "last_update": {"status": "ok"}},
+                    {
+                        "release_source_commit": "b" * 40,
+                        "release_channel": "preview",
+                        "version": "9.9.9",
+                        "last_update": {"status": "ok"},
+                    },
                 )
                 return subprocess.CompletedProcess(argv, 0)
 
@@ -319,6 +330,16 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
             # same interval reads it as resolved, not still "behind".
             self.assertEqual(read_update_check_cache(paths)["outcome"], "up_to_date")
 
+            # The launch is held for the whole update, so it says what it is
+            # doing and what it landed on. The completion version is read
+            # back from the record the update just rewrote -- this process is
+            # still running the pre-update package -- and that same record is
+            # what the TUI HUD footer renders.
+            output = buffer.getvalue()
+            self.assertIn("OMH Auto Update: aaaaaaa -> bbbbbbb (preview channel)", output)
+            self.assertIn("OMH Auto Update complete: omh 9.9.9 is installed.", output)
+            self.assertNotIn("9.9.8", output)
+
     def test_auto_mode_reports_a_failed_subprocess_without_crashing_the_launch(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -341,6 +362,10 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
                 main_module._run_startup_update_check(args)
 
             self.assertIn("update-check auto-update failed", err_buffer.getvalue())
+            # The attempt is still announced -- the wait happened either way --
+            # but a failed update never claims to have completed.
+            self.assertIn("OMH Auto Update:", out_buffer.getvalue())
+            self.assertNotIn("Auto Update complete", out_buffer.getvalue())
             cache = read_update_check_cache(paths)
             # A failed attempt never claims convergence.
             self.assertNotEqual(cache.get("outcome"), "up_to_date")
@@ -359,6 +384,9 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
                     main_module._run_startup_update_check(args)
             state = read_json_object(paths.runtime_state_path) or {}
             self.assertNotIn("last_update", state)
+            # Silent skip means silent: the launch that loses the race must
+            # not announce an Auto Update it never ran.
+            self.assertEqual(buffer.getvalue(), "")
 
     def test_notify_prints_the_rewrite_line_even_when_no_update_qualifies(self) -> None:
         # Issue #1282: an unreachable cursor must surface the classification


### PR DESCRIPTION
## Feature Report

### What Changed

- **Post-cut machine sync is now part of the release procedure.** `docs/RELEASE.md` gains an "After the Cut" section, `omh release checklist` carries a `machine_sync_after_cut` follow-up item, and `docs/DISTRIBUTION.md` states the boundary: publishing a tag and moving npm `latest` changes no installed machine.
- **A bare `omh` launch announces its auto-update.** In `update_check.mode = auto`, the launch prints `OMH Auto Update: <local> -> <remote> (<channel> channel); running \`omh update\`.` before it starts and `OMH Auto Update complete: omh <version> is installed.` when it lands. `off` and `notify` print neither line; the failure line on stderr is unchanged; a launch that loses the lock race stays silent.
- **HUD version precedence fixed.** `_package_version` in the plugin bundle's runtime reader now lets an explicitly supplied running-package version win over the recorded `state.json` value, so `omh hud` and the menu bar can no longer report a version older than `omh --version`. The record stays the fallback for the TUI widget's reader, which cannot import `omh`.

### Why This Exists

The 2.0.1 cut moved the tag and npm `latest`, and the maintainer's own Hermes TUI kept showing v2.0.0. Nothing was broken: `omh --version` printed 2.0.0 and the installed plugin manifest said 2.0.0 because that machine had never run `omh update`. Every version an operator can see is the installed version, never the newest tag, and the release procedure said nothing about the difference or how to close it. Separately, auto mode held the launch for the whole `omh update` subprocess in silence, which reads as a hung launch.

### User / Operator Impact

- A maintainer finishing a release has a written, checklisted step: `omh update`, restart the TUI, confirm with `omh --version` and `omh doctor`. Hand-copying into `~/.hermes` remains prohibited.
- A user on `auto` sees why their launch is waiting and which version landed.

### How It Works

HUD version chain, traced: `omh-status.mjs` spawns `python -I` with only `~/.hermes/plugins` on `sys.path`, imports the installed bundle's `runtime_reader`, and renders `payload.version`. That is `_package_version(state, package_version)`; `state.json`'s `version` is written by the install/update apply in `commands/setup.py` from `omh.version.__version__`. So `omh update` alone refreshes it; no cache or baked widget string blocks it.

- `src/commands/main.py`: `_auto_update_started_line` / `_auto_update_complete_line`; the completion version is read from the record `omh update` just rewrote, because this process still runs the pre-update package.
- `src/maintenance/release.py` + `src/commands/release.py`: the checklist item and its index entry (37 items, required count unchanged).
- `src/plugin_bundle/omh/runtime_reader.py`: precedence flip with the rationale in the docstring.
- Tests: `tests/test_hud.py` (CLI payload equals `__version__` against a stale record; widget-path reader returns the record), `tests/test_update_check_command.py` (auto prints both lines, failure unchanged, off/notify print nothing new), `tests/test_release_smoke.py`, `tests/test_cli.py`.

### Files And Contracts Touched

`docs/RELEASE.md`, `docs/INSTALLATION.md` (Startup update check), `docs/DISTRIBUTION.md`, `src/commands/main.py`, `src/commands/release.py`, `src/maintenance/release.py`, `src/plugin_bundle/omh/runtime_reader.py`, four test modules.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] hermes-smoke with command smoke
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -m omh.cli release product-readiness --version 2.0.1 --json` (14/14 gates), `docs ulw-inventory --check`, `docs ulw-site --check`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: no live `omh update` was run on any machine

### Observed Evidence

- Touched and doc-reading modules (12 files, 686 tests) pass; `tests.test_cli tests.test_release_smoke tests.test_hud tests.test_update_check_command` rerun after rebase onto current main.
- Full suite in the worktree: 9365 tests, 28 failures/errors all in `tests/test_cross_harness_adapters.py` and `tests/test_cross_harness_adapter_security.py`, reproduced identically on the unmodified base commit (the adapter sandbox refuses the nested worktree path as an unsafe read root). Not caused here; CI runs from a normal checkout.

### Not Tested / Not Applicable

- The post-cut sync and the restarted-TUI HUD footer are documented and gated, not observed on a live machine.
- The Auto Update lines are covered by tests that fake the update subprocess, never by a real preview-channel auto-update.

## Risk

- Narrow. Two new stdout lines on one opt-in path; a precedence flip in one reader function with both halves locked by tests.

## Compatibility / Rollout

- No schema change. The checklist grows by one non-required follow-up item.
- The "update available" HUD hint was considered and rejected: the update-check cache compares against `origin/main` and is permanently inconclusive on stable and local channels, which is exactly the case the owner hit.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ6enDfqFG9ft8yCL2d5P5
