### PR TITLE
feat(runtime): cancelled is a first-class observed terminal state

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1621,6 +1621,46 @@ observed evidence, and keep review or verification gaps visible in
 verification, review, CI, merge-ready, and merged steps. Wrappers can render
 that card directly instead of inferring progress from prose.
 
+#### Observed terminal results
+
+An observed executor run ends in exactly one of four terminal results:
+`completed`, `blocked`, `failed`, or `cancelled`. They are four different
+claims, and OMH keeps them apart everywhere a result is recorded and everywhere
+one is read. `failed` says the work ran and did not work. `blocked` says
+something outside the work is in the way and the run may continue once it
+clears. `cancelled` says someone or something stopped the run before it reached
+an answer, so there is no verdict about the work at all and the next step is a
+decision about re-dispatching it. The vocabulary is shared by the run record
+(`RUN_STATUSES`), the delegation record (`DELEGATION_RESULTS`,
+`OBSERVED_RESULTS`), the wrapper record (`WRAPPER_COMPLETION_STATUSES`), the
+executor session (`EXECUTOR_SESSION_RESULTS`), and the work report
+(`REPORT_STATUSES`), and every command that records a result offers all four.
+
+`cancelled` is an OBSERVED result. Recording it needs the same evidence every
+other observed result needs: OMH records that a cancellation was observed --
+process termination, or an authoritative executor result -- never that one was
+requested, and never that OMH performed it. OMH terminates only the process
+groups its own fanout dispatcher spawned; process-control capability over any
+other executor is adapter- and host-specific and the shared contract records
+only the observed outcome. Cancelling a PREPARED wrapper plan before any
+executor ran is a different fact and stays where it is, on the wrapper session's
+own status.
+
+A cancellation satisfies no evidence gate. It stops the runtime claim ladder at
+`executor_dispatched`, so execution, verification, review, CI, merge-readiness,
+and merge are all blocked; the wrapper refuses to record verification over it;
+and the delegated-coding status answers `surface_executor_cancellation` rather
+than `surface_executor_blocker`, because a cancellation has no blocker to clear.
+
+The enum is additive and no schema version moved: every record written before
+`cancelled` existed still validates unchanged, and there is no migration. The
+compatibility direction that needs care is a newer record read by an older
+plugin bundle, since the bundle is installed and updated separately from the
+writer. The shipped reader decides "has this target ended" from the record's
+`observed` flag rather than by matching the result against a list it knows, so a
+result word added after that bundle shipped degrades to terminal-with-unknown-
+kind and never to "still running".
+
 `omh chat session status` also exposes `coding_briefing/v1` as a sibling to the
 compact status card. The briefing is the richer Hermes-facing report surface for
 delegated coding work: it combines persisted route/plan metadata, compact handoff

--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -2089,7 +2089,11 @@ def _executor_handoff(
             "evidence_required": "Record separate wrapper/runtime evidence before marking review observed.",
         },
         "report_contract": {
-            "allowed_statuses": ["completed", "blocked", "failed"],
+            # `cancelled` is offered so an executor that was stopped has a
+            # truthful status to report. Without it the only shapes on offer
+            # were `failed`, which blames the work, and `blocked`, which
+            # promises the work resumes when something clears.
+            "allowed_statuses": ["completed", "blocked", "cancelled", "failed"],
             "required_fields": [
                 "status",
                 "changed_files",
@@ -2295,7 +2299,7 @@ def _runtime_handoff(
             "record_with": (
                 "omh runtime observe --session <wrapper-session-id> --runtime-profile "
                 f"{profile} --event <runtime_start|worktree_creation|worker_dispatch|worker_result|verification|review|ci|merge_readiness|merge> "
-                "--status <observed|blocked|failed|not_observed> --summary <observed metadata>"
+                "--status <observed|blocked|cancelled|failed|not_observed> --summary <observed metadata>"
             ),
             "allowed_events": [
                 "runtime_start",

--- a/src/coding/executor_progress.py
+++ b/src/coding/executor_progress.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from ..local_store import atomic_write_json, ensure_dir, ensure_file, read_json_object, read_jsonl_objects, utc_now
 from ..paths import OmhPaths
+from ..runtime.records import OBSERVED_RESULTS as RUNTIME_OBSERVED_RESULTS
 from .context_safety import sanitize_user_facing_progress_text
 from .owner_progress_normalization import (
     NORMALIZED_PROGRESS_EVENT_TYPES,
@@ -47,6 +48,7 @@ TERMINAL_EVENT_TYPES = {
     "executor_completed",
     "executor_blocked",
     "executor_failed",
+    "executor_cancelled",
     "tests_failed",
     "tests_passed",
     "reported_change_not_observed",
@@ -54,11 +56,33 @@ TERMINAL_EVENT_TYPES = {
 # Observations that end a binding's life. Kept as its own name rather than
 # reusing TERMINAL_EVENT_TYPES: `tests_failed` and `tests_passed` are reportable
 # end states but the executor may still be working, so they must not close.
+#
+# `executor_cancelled` closes. A cancelled executor is not going to send
+# anything else, and a binding left open after one is the "still looks active
+# until it goes stale" reading a cancellation is supposed to replace: staleness
+# says nobody has heard from this in a while, which is a different and weaker
+# claim than "this stopped".
 CLOSING_EVENT_TYPES = {
     "executor_completed",
     "executor_blocked",
     "executor_failed",
+    "executor_cancelled",
     "reported_change_not_observed",
+}
+# What one closed binding means for the wait it was armed against. The wait
+# contract (`wait_strategy.WAIT_TERMINAL_STATES`) and this vocabulary are two
+# names for one ending, so the mapping is stated once here rather than being
+# re-derived by every caller that holds both.
+# The observed terminal results a run or wrapper session can hold, mirrored from
+# `runtime.records.OBSERVED_RESULTS` and imported rather than restated so a
+# fifth terminal result cannot appear there and leave a binding open here.
+_OBSERVED_TERMINAL_RESULTS = frozenset(RUNTIME_OBSERVED_RESULTS)
+_WAIT_OUTCOME_BY_CLOSING_EVENT = {
+    "executor_completed": "completed",
+    "executor_blocked": "failed",
+    "executor_failed": "failed",
+    "executor_cancelled": "cancelled",
+    "reported_change_not_observed": "failed",
 }
 # Where a progress summary came from. Only a summary this repo derived itself,
 # by parsing an executor stream it also hashed, can corroborate that executor's
@@ -538,6 +562,20 @@ _CHANGE_CLAIM_ACTIVITY = {"Codex applied a file change."}
 _CHANGE_CLAIM_EVENT_TYPES = {"diff_started"}
 _SUCCESS_PROCESS_STATUSES = {"completed", "complete", "done", "success", "succeeded", "exited_zero"}
 _FAILURE_PROCESS_STATUSES = {"failed", "failure", "error", "errored", "exited_nonzero"}
+# Process outcomes the HOST observed, not words an executor chose. Each one
+# names a stop that something outside the executor performed: the operator
+# interrupted the batch, a supervisor sent a signal, the dispatcher terminated
+# the unit group. This is the only corroboration a cancellation can have --
+# nothing an executor says about itself reaches `executor_cancelled` without one
+# of these, exactly as no executor reaches `executor_completed` on its own word.
+_CANCELLED_PROCESS_STATUSES = {
+    "cancelled",
+    "canceled",
+    "interrupted",
+    "killed",
+    "signal_terminated",
+    "terminated",
+}
 _BLOCKED_PROCESS_STATUSES = {"blocked", "blocker"}
 
 # Everything that can corroborate an owner's own end-state narration, and
@@ -553,6 +591,7 @@ _END_STATE_PROCESS_STATUSES = {
     *_SUCCESS_PROCESS_STATUSES,
     *_FAILURE_PROCESS_STATUSES,
     *_BLOCKED_PROCESS_STATUSES,
+    *_CANCELLED_PROCESS_STATUSES,
 }
 # Past tense only. "Codex is running tests." says a run started, which cannot
 # corroborate that one finished.
@@ -788,6 +827,14 @@ def infer_progress_event_type(signal: dict[str, Any]) -> str:
     # nothing about it needs corroborating.
     narrated = "" if self_reported_end_state else normalized_latest
     verdict = "" if self_reported_end_state and progress_status in _END_STATE_PROGRESS_STATUSES else progress_status
+    # Ahead of blocked and failed, because an observed cancellation explains
+    # both of the shapes they would otherwise claim. A group-terminated child
+    # exits non-zero, so a lane reading only the exit code files an operator's
+    # own stop as a model failure and sends the next reader looking for a defect
+    # that does not exist. Only the host's observed process outcome gets here:
+    # `narrated` is already blank whenever the word was the executor's alone.
+    if process_status in _CANCELLED_PROCESS_STATUSES or narrated == "executor_cancelled":
+        return "executor_cancelled"
     if narrated == "executor_blocked" or verdict == "blocked" or process_status in _BLOCKED_PROCESS_STATUSES:
         return "executor_blocked"
     if verdict == "failed_or_error_observed" or narrated == "tests_failed":
@@ -912,6 +959,19 @@ def summary_for_signal(signal: dict[str, Any], event_type: str) -> str:
     }:
         return _compact_text(_sanitize_progress_copy(visible) or _summary_for_event_type(event_type), 240)
     return _summary_for_event_type(event_type)
+
+
+def wait_outcome_for_progress_event(event_type: str) -> str:
+    """The `omh_execution_wait_strategy/v1` terminal state one closing event means.
+
+    Returns "" for an event that does not close a binding, so a caller can tell
+    "this progress event ends the wait" from "this one does not" without
+    restating `CLOSING_EVENT_TYPES`. The two contracts describe one ending from
+    two sides: a cancelled executor closes its progress binding here and closes
+    its wait as `cancelled` there, and they must not be able to disagree about
+    which of the two it was.
+    """
+    return _WAIT_OUTCOME_BY_CLOSING_EVENT.get(str(event_type), "")
 
 
 def observe_executor_progress(
@@ -1174,7 +1234,7 @@ def refresh_binding_freshness(
 ) -> dict[str, Any]:
     _require_valid("binding", validate_progress_binding(binding))
     updated = dict(binding)
-    if result_status in {"completed", "blocked", "failed"} or updated.get("state") == "closed":
+    if result_status in _OBSERVED_TERMINAL_RESULTS or updated.get("state") == "closed":
         updated["state"] = "closed"
         return updated
     reference = str(updated.get("last_observed_at") or updated.get("updated_at") or updated.get("created_at") or "")
@@ -1378,13 +1438,13 @@ def _terminal_result_status(paths: OmhPaths, binding: dict[str, Any]) -> str:
         delegation = read_json_object(paths.runtime_runs_dir / target_id / "delegation.json") or {}
         if bool(delegation.get("observed")):
             result = str(delegation.get("result", ""))
-            if result in {"completed", "blocked", "failed"}:
+            if result in _OBSERVED_TERMINAL_RESULTS:
                 return result
     if target_type == "wrapper_session":
         record = read_json_object(paths.runtime_wrapper_sessions_dir / target_id / "executor_session.json") or {}
         if bool(record.get("result_observed")):
             result = str(record.get("result", ""))
-            if result in {"completed", "blocked", "failed"}:
+            if result in _OBSERVED_TERMINAL_RESULTS:
                 return result
     return ""
 

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -145,6 +145,41 @@ FANOUT_DISPATCH_SCHEMA_VERSION = "fanout_dispatch_summary/v1"
 # launcher uses the same 10s window before re-raising on itself.
 UNIT_TERMINATE_GRACE_SECONDS = 10.0
 
+# Unit statuses for a batch that was stopped. Four words, because the four
+# facts an operator has to act on differently used to arrive as one
+# (`interrupted`) or as `failed`:
+#
+#   cancelled                       -- this unit's process was running and the
+#                                      dispatcher terminated its group. It may
+#                                      have left a dirty worktree, so a resume
+#                                      still asks the replay-safety question.
+#   cancelled_outcome_unknown       -- the unit was in flight and its worker did
+#                                      not come back within the terminate grace.
+#                                      Whether it wrote anything is not known,
+#                                      and saying so is the honest answer.
+#   not_started_cancelled           -- the unit never spawned. Nothing exists to
+#                                      preserve, so a resume re-attempts it.
+#   blocked_by_cancelled_dependency -- the unit was admissible only behind a
+#                                      unit that was cancelled. It is not a
+#                                      failure of this unit and not the same as
+#                                      being blocked behind one that failed.
+#
+# OMH records these; it does not claim it can cancel every external executor.
+# The dispatcher can only terminate the process groups it spawned itself, and
+# these words describe what it OBSERVED of that termination.
+UNIT_STATUS_CANCELLED = "cancelled"
+UNIT_STATUS_CANCELLED_OUTCOME_UNKNOWN = "cancelled_outcome_unknown"
+UNIT_STATUS_NOT_STARTED_CANCELLED = "not_started_cancelled"
+UNIT_STATUS_BLOCKED_BY_CANCELLED_DEPENDENCY = "blocked_by_cancelled_dependency"
+CANCELLED_UNIT_STATUSES = frozenset(
+    {
+        UNIT_STATUS_CANCELLED,
+        UNIT_STATUS_CANCELLED_OUTCOME_UNKNOWN,
+        UNIT_STATUS_NOT_STARTED_CANCELLED,
+        UNIT_STATUS_BLOCKED_BY_CANCELLED_DEPENDENCY,
+    }
+)
+
 # Live unit process groups, registered by the signal-safe default runner so
 # an interrupt terminates them instead of orphaning them to pid 1. OMO
 # shipped exactly this incident: a launcher blocked in spawnSync died on
@@ -1928,7 +1963,7 @@ def dispatch_fanout(
         # pool, or parked on the owner gate while the batch died — must not
         # start a fresh agent CLI nobody will ever collect.
         if _INTERRUPT_FLAG.is_set():
-            return _skipped(unit, "interrupted")
+            return _skipped(unit, UNIT_STATUS_NOT_STARTED_CANCELLED)
         gate = owner_gates.get(str(unit.get("owner") or "choose"))
         if gate is None:
             if health_events is not None:
@@ -1936,7 +1971,7 @@ def dispatch_fanout(
             return _dispatch_unit(paths, unit, **kwargs)
         with gate:
             if _INTERRUPT_FLAG.is_set():
-                return _skipped(unit, "interrupted")
+                return _skipped(unit, UNIT_STATUS_NOT_STARTED_CANCELLED)
             if health_events is not None:
                 health_events.started(str(unit["unit_id"]))
             return _dispatch_unit(paths, unit, **kwargs)
@@ -2051,26 +2086,37 @@ def dispatch_fanout(
                 results[unit_id] = result
                 if admission is not None:
                     admission.observe(unit_id, result)
-            except (
-                FuturesCancelledError,
-                FuturesTimeoutError,
-                KeyboardInterrupt,
-                SystemExit,
-            ):
-                results[unit_id] = _skipped(units[unit_id], "interrupted")
+            except (FuturesCancelledError, KeyboardInterrupt, SystemExit):
+                # `shutdown(cancel_futures=True)` cancels only futures the pool
+                # never started, so a cancelled future is a unit that never
+                # spawned: there is nothing on disk to preserve.
+                results[unit_id] = _skipped(units[unit_id], UNIT_STATUS_NOT_STARTED_CANCELLED)
+            except FuturesTimeoutError:
+                # It was in flight and did not come back inside the terminate
+                # grace. Whether it wrote anything is genuinely unknown, and a
+                # resume has to ask rather than assume either way.
+                results[unit_id] = _skipped(units[unit_id], UNIT_STATUS_CANCELLED_OUTCOME_UNKNOWN)
             if unit_id in pending:
                 pending.remove(unit_id)
         for unit_id in list(pending):
             if unit_id not in results:
-                results[unit_id] = _skipped(units[unit_id], "interrupted")
+                results[unit_id] = _skipped(units[unit_id], UNIT_STATUS_NOT_STARTED_CANCELLED)
             pending.remove(unit_id)
-        # A group-terminated unit exits with a negative signal code and would
-        # otherwise read as a genuine model failure in the merged summary;
-        # the flag keeps a re-dispatch decision from blaming the model.
+        # A group-terminated unit exits with a negative signal code. Reported as
+        # `failed` it reads as a genuine model failure in the merged summary and
+        # sends the next reader hunting a defect that does not exist, so the
+        # observed termination is recorded as the terminal state it was. The
+        # failure classification goes with it: a stop is not a crash, and a
+        # cancelled unit's `failure_kind` would otherwise steer the recovery
+        # interview toward a fault nobody observed.
         for entry in results.values():
             exit_code = entry.get("exit_code")
             if isinstance(exit_code, int) and exit_code < 0:
                 entry["interrupted"] = True
+                entry["status"] = UNIT_STATUS_CANCELLED
+                entry.pop("failure_kind", None)
+                entry.pop("limit_shaped", None)
+                entry.pop("limit_pattern", None)
     finally:
         # Idempotent after the success/interrupt shutdowns; without it, a
         # worker exception re-raised by future.result() leaks live pool
@@ -2244,9 +2290,14 @@ def dispatch_fanout(
         summary["resume"] = {**resume_plan, "counts": resume_counts(resume_plan["decisions"])}
     if interrupted_by is not None:
         # A cut-short batch says so; units that never started carry the
-        # `interrupted` status rather than silently vanishing from the
+        # `not_started_cancelled` status rather than silently vanishing from the
         # rollup as if they were never planned.
         summary["interrupted"] = True
+        # Which units ended in which cancellation state, so the summary answers
+        # "what happened to each of them" without a reader re-deriving it from
+        # per-unit rows. Present only on a cancelled batch: an ordinary dispatch
+        # has nothing to say here and should not carry an empty section.
+        summary["cancellation"] = _cancellation_rollup(summary_units)
     if not dry_run and fanout_id:
         from .fanout_artifacts import fanout_dispatch_summary_path, fanout_run_journal_path
 
@@ -2659,6 +2710,36 @@ def _with_carried_recovery(
     return carried
 
 
+def _cancellation_rollup(units: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Which units this cancelled batch stopped, never started, or lost track of.
+
+    Metadata only: unit ids and the closed status words above, never output,
+    prompts, or signal detail. `operator_initiated_cancel` is deliberately
+    false-by-construction wording rather than a field: OMH RECORDS an observed
+    cancellation, and the only cancellation it performs is of the process groups
+    its own dispatcher spawned.
+    """
+    by_status: dict[str, list[str]] = {status: [] for status in sorted(CANCELLED_UNIT_STATUSES)}
+    for entry in units:
+        if not isinstance(entry, Mapping):
+            continue
+        status = str(entry.get("status", ""))
+        if status in by_status:
+            by_status[status].append(str(entry.get("unit_id", "")))
+    return {
+        "cancelled": by_status[UNIT_STATUS_CANCELLED],
+        "outcome_unknown": by_status[UNIT_STATUS_CANCELLED_OUTCOME_UNKNOWN],
+        "never_started": by_status[UNIT_STATUS_NOT_STARTED_CANCELLED],
+        "blocked_by_cancelled_dependency": by_status[UNIT_STATUS_BLOCKED_BY_CANCELLED_DEPENDENCY],
+        "claim_boundary": (
+            "A cancellation rollup records the terminal state each unit reached when this dispatch was "
+            "stopped. OMH terminates only the process groups its own dispatcher spawned; it is not a "
+            "claim that any external executor was cancelled, and it is not execution, verification, "
+            "review, CI, merge-readiness, or merge evidence."
+        ),
+    }
+
+
 def _recovery_available(units: Sequence[Mapping[str, Any]]) -> list[str]:
     return [
         str(entry.get("unit_id"))
@@ -2933,9 +3014,19 @@ def _close_fanout_progress_binding(
     try:
         telemetry = parse_unit_telemetry(owner, stdout_text)
         cost_usd = telemetry.get("cost_usd")
+        # A dispatcher-terminated unit closes its binding as cancelled, not as
+        # failed. `_INTERRUPT_FLAG` is the host's own observation that it sent
+        # the signal, which is the corroboration the progress lane requires
+        # before it will accept a cancellation at all.
+        if exit_code == 0:
+            observed_process_status = "completed"
+        elif _INTERRUPT_FLAG.is_set():
+            observed_process_status = "cancelled"
+        else:
+            observed_process_status = "failed"
         signal = build_safe_progress_signal(
             executor_profile=str(binding.get("executor_profile", "")),
-            process_status="completed" if exit_code == 0 else "failed",
+            process_status=observed_process_status,
             routed_model=routed_model,
             routed_reasoning_effort=routed_effort,
             explicit_summary=title,
@@ -4536,6 +4627,12 @@ def _dependency_failed(result: dict[str, Any] | None) -> bool:
         "capability_snapshot_invalid",
         "failed",
         "blocked_by_dependency",
+        # A cancelled dependency produced nothing a dependent can build on. It
+        # is admitted as a prerequisite by neither this predicate's opposite
+        # (`_dependency_satisfied`, which requires an observed exit-0) nor by
+        # any other path, and naming it here is what lets the dependent say
+        # WHICH unit it is waiting on rather than blocking on nothing.
+        *CANCELLED_UNIT_STATUSES,
         "executor_not_ready",
         "unsupported_for_local_dispatch",
         "worktree_failed",
@@ -4550,8 +4647,20 @@ def _dependency_failed(result: dict[str, Any] | None) -> bool:
 
 
 def _blocked(unit: Mapping[str, Any], results: Mapping[str, dict[str, Any]]) -> dict[str, Any]:
-    entry = _skipped(unit, "blocked_by_dependency")
     deps = [str(dep) for dep in unit.get("depends_on", []) or []]
+    cancelled_deps = [
+        dep
+        for dep in deps
+        if str((results.get(dep) or {}).get("status", "")) in CANCELLED_UNIT_STATUSES
+    ]
+    # A dependent held behind a cancelled unit is not held behind a defect. The
+    # two read the same in a rollup that has only `blocked_by_dependency`, and
+    # they call for different next steps: one waits on a fix, the other waits on
+    # a decision to re-dispatch.
+    entry = _skipped(
+        unit,
+        UNIT_STATUS_BLOCKED_BY_CANCELLED_DEPENDENCY if cancelled_deps else "blocked_by_dependency",
+    )
     failed = [dep for dep in deps if _dependency_failed(results.get(dep))]
     # A dependency stuck in a non-terminal verdict (for example
     # model_choice_required) is neither satisfied nor failed; the entry must

--- a/src/coding/fanout_journal.py
+++ b/src/coding/fanout_journal.py
@@ -91,6 +91,13 @@ TERMINAL_FAILED = "failed"
 TERMINAL_DECLINED = "declined"
 TERMINAL_SKIPPED_BY_DEPENDENCY = "skipped_by_dependency"
 TERMINAL_NOT_ATTEMPTED = "not_attempted"
+# A unit whose process was running when the dispatch was stopped, or that was in
+# flight and never reported back. Kept apart from `failed` because a resume acts
+# on it differently: nothing about the unit's own work is known to be wrong, so
+# the question is whether to run it again, not what to fix. It still goes
+# through the replay-safety gate -- a killed unit can leave a dirty worktree
+# exactly as a crashed one can.
+TERMINAL_CANCELLED = "cancelled"
 
 # The journal's own name for a decline in `failure_class`, kept apart from
 # every class `fanout_retry` owns: a decline was never classified by the
@@ -115,6 +122,10 @@ RESUME_HOLD_DECLINED = "hold_declined_conclusive"
 # name so the resume record says the unit is being re-attempted because someone
 # asked for exactly that, not because a failure happened to be replay-safe.
 RESUME_RERUN_AWAITING_RETRY = "rerun_awaiting_retry"
+# The prior run was stopped while this unit was running. It is re-dispatched
+# under its own action name so a resume record says the unit is being attempted
+# again because someone stopped it, not because it failed replay-safely.
+RESUME_RERUN_CANCELLED = "rerun_cancelled"
 
 RESUME_HOLD_ACTIONS = frozenset(
     {RESUME_HOLD_SUCCEEDED, RESUME_HOLD_REPLAY_UNSAFE, RESUME_HOLD_BLOCKED_DEPENDENCY, RESUME_HOLD_DECLINED}
@@ -125,6 +136,7 @@ RESUME_RERUN_ACTIONS = frozenset(
         RESUME_RERUN_NOT_ATTEMPTED,
         RESUME_UNSKIP_DEPENDENT,
         RESUME_RERUN_AWAITING_RETRY,
+        RESUME_RERUN_CANCELLED,
     }
 )
 
@@ -143,6 +155,10 @@ _NEVER_SPAWNED_STATUSES = frozenset(
     {
         "not_selected",
         "interrupted",
+        # The dispatcher's own word for a unit a cancelled batch never spawned.
+        # `interrupted` stays a member so a journal written before the
+        # cancellation states existed still resumes the way it always did.
+        "not_started_cancelled",
         "model_choice_required",
         "spawn_ceiling_reached",
         "review_dispatch_budget_exhausted",
@@ -436,6 +452,22 @@ def _unit_resume_decision(
             reason=f"never attempted in the prior run (status {row.get('status') or 'unknown'})",
             row=row,
         )
+    if prior_state == TERMINAL_CANCELLED:
+        # After the replay-safety and blocker gates above, which apply to a
+        # cancelled unit exactly as they apply to a failed one: a unit killed
+        # mid-write is held with its side effect named, not re-dispatched over
+        # the work it left behind.
+        return _decision(
+            unit_id,
+            prior_state=prior_state,
+            action=RESUME_RERUN_CANCELLED,
+            reason=(
+                f"the prior run was stopped while this unit was in flight (status "
+                f"{row.get('status') or 'unknown'}) with no observed side effect, so re-dispatching "
+                "it destroys nothing"
+            ),
+            row=row,
+        )
     return _decision(
         unit_id,
         prior_state=prior_state,
@@ -486,8 +518,10 @@ def _carried_forward(entry: Mapping[str, Any]) -> dict[str, Any] | None:
 def _terminal_state(entry: Mapping[str, Any]) -> str:
     if entry.get("status") in _SUCCEEDED_STATUSES or bool(entry.get("process_succeeded")):
         return TERMINAL_SUCCEEDED
-    if entry.get("status") == "blocked_by_dependency":
+    if entry.get("status") in {"blocked_by_dependency", "blocked_by_cancelled_dependency"}:
         return TERMINAL_SKIPPED_BY_DEPENDENCY
+    if entry.get("status") in {"cancelled", "cancelled_outcome_unknown"}:
+        return TERMINAL_CANCELLED
     if "exit_code" not in entry and entry.get("status") in _NEVER_SPAWNED_STATUSES:
         return TERMINAL_NOT_ATTEMPTED
     if _unit_result_declined(entry):
@@ -528,6 +562,8 @@ def _failure_classification(entry: Mapping[str, Any], *, state: str = "") -> dic
     re-matching here would be guessing. Only a failure the retry ladder never
     saw falls back to the exit-code-only classification.
 
+    A cancelled unit skips both as well, with an empty class: nothing failed.
+
     A declined unit skips both: its class is the journal's own
     `FAILURE_CLASS_DECLINED_CONCLUSIVE`, never `fanout_retry`'s
     `terminal_failure`, because the retry ladder never asked "is this
@@ -537,6 +573,11 @@ def _failure_classification(entry: Mapping[str, Any], *, state: str = "") -> dic
     """
     if state == TERMINAL_DECLINED:
         return {"failure_class": FAILURE_CLASS_DECLINED_CONCLUSIVE, "failure_label": ""}
+    if state == TERMINAL_CANCELLED:
+        # A cancelled unit observed no failure. Classifying its signal exit code
+        # would attribute a fault to work that was never allowed to reach a
+        # verdict, and the recovery interview reads this field.
+        return {"failure_class": "", "failure_label": ""}
     retry = entry.get("retry")
     if isinstance(retry, Mapping):
         decisions = retry.get("decisions")

--- a/src/coding/hermes_harness.py
+++ b/src/coding/hermes_harness.py
@@ -196,7 +196,10 @@ def validate_hermes_coding_harness(harness: Any) -> list[str]:
         errors.append("hermes_coding_harness schema_version is invalid")
     if harness.get("selected_owner") != "hermes":
         errors.append("hermes_coding_harness selected_owner must be hermes")
-    if harness.get("status") not in {"prepared_not_observed", "in_progress", "blocked", "completed", "failed"}:
+    # `cancelled` is a member because `_harness_status` already returns it. A
+    # status the builder can produce and the validator rejects is a harness that
+    # fails to validate the moment a run is cancelled.
+    if harness.get("status") not in {"prepared_not_observed", "in_progress", "blocked", "cancelled", "completed", "failed"}:
         errors.append("hermes_coding_harness status is invalid")
     if harness.get("start_mode") not in {"solo", "durable_goal", "team", "swarm"}:
         errors.append("hermes_coding_harness start_mode is invalid")
@@ -604,7 +607,7 @@ def _runtime_requirements() -> list[dict[str, str]]:
             "event_type": event,
             "record_schema": "runtime_observation/v1",
             "record_with": "omh runtime observe --session <wrapper-session-id> --runtime-profile hermes --event "
-            f"{event} --status <observed|blocked|failed|not_observed> --summary <observed metadata>",
+            f"{event} --status <observed|blocked|cancelled|failed|not_observed> --summary <observed metadata>",
         }
         for event in HERMES_CODING_TEAM_STATUS_LADDER
     ]

--- a/src/coding/owner_progress_normalization.py
+++ b/src/coding/owner_progress_normalization.py
@@ -142,6 +142,13 @@ NORMALIZED_PROGRESS_EVENT_TYPES: Final[tuple[str, ...]] = (
     "executor_completed",
     "executor_blocked",
     "executor_failed",
+    # An observed cancellation. It sits beside the other three end-state words
+    # rather than folding into `executor_failed`, because "this ran and did not
+    # work" and "someone stopped this" call for different recovery. The lane
+    # (`executor_progress.infer_progress_event_type`) is what decides whether a
+    # word this table translates is CORROBORATED; a run whose process was never
+    # observed to stop cannot reach this event by narration alone.
+    "executor_cancelled",
     "reported_change_not_observed",
     "progress_observed",
     UNMAPPED_NORMALIZED_EVENT,
@@ -178,6 +185,7 @@ _TIER_BY_NORMALIZED_EVENT: Final[dict[str, str]] = {
     "executor_completed": "result_claimed",
     "executor_blocked": "result_claimed",
     "executor_failed": "result_claimed",
+    "executor_cancelled": "result_claimed",
     "tests_passed": "verified",
     "tests_failed": "verified",
 }
@@ -301,6 +309,9 @@ _SOURCE_EVENT_EVIDENCE_TIERS: Final[dict[str, str]] = {
     "executor_completed": "result_claimed",
     "executor_blocked": "result_claimed",
     "executor_failed": "result_claimed",
+    "executor_cancelled": "result_claimed",
+    "run_cancelled": "result_claimed",
+    "workflow_cancelled": "result_claimed",
     "workflow_completed": "result_claimed",
     "failure_discovered": "result_claimed",
     "blocker_encountered": "result_claimed",
@@ -343,12 +354,20 @@ _SHARED_DIALECT: Final[dict[str, str]] = {
     "executor_completed": "executor_completed",
     "executor_blocked": "executor_blocked",
     "executor_failed": "executor_failed",
+    "executor_cancelled": "executor_cancelled",
     "reported_change_not_observed": "reported_change_not_observed",
     "progress_observed": "progress_observed",
     # Workflow vocabulary.
     "workflow_started": UNMAPPED_NORMALIZED_EVENT,
     "dispatch_to_executor": "executor_dispatched",
     "workflow_completed": "executor_completed",
+    # Two owner spellings of the same end state. They translate here; whether
+    # the lane ACCEPTS the translation still depends on corroboration, so a
+    # host that narrates a cancellation it did not observe gets the same
+    # `self_reported_end_state_not_corroborated` answer any other end-state
+    # word gets.
+    "run_cancelled": "executor_cancelled",
+    "workflow_cancelled": "executor_cancelled",
     "status_update": "progress_observed",
     "bug_discovered": "progress_observed",
     "failure_discovered": "executor_failed",

--- a/src/commands/chat.py
+++ b/src/commands/chat.py
@@ -23,6 +23,7 @@ from ..runtime.artifacts import create_run, summarize_delegated_coding_status, w
 from ..targets import TARGET_METADATA_KEYS, build_target_change_notice, inspect_target_observation, record_target_observation
 from ..wrapper.contract import INTERACTION_MODES, RENDER_PROFILES, build_chat_interaction_payload, build_chat_status_interaction
 from ..wrapper.executor_sessions import (
+    EXECUTOR_SESSION_OBSERVED_RESULTS,
     ExecutorSessionError,
     attach_executor_session,
     open_executor_session,
@@ -1358,7 +1359,7 @@ def _add_chat_commands(sub) -> None:
 
     session_record_executor = session_sub.add_parser("record-executor")
     session_record_executor.add_argument("session_id")
-    session_record_executor.add_argument("--result", choices=("completed", "blocked", "failed"), required=True)
+    session_record_executor.add_argument("--result", choices=EXECUTOR_SESSION_OBSERVED_RESULTS, required=True)
     session_record_executor.add_argument("--evidence-ref", action="append")
     session_record_executor.add_argument("--summary", default="")
     session_record_executor.add_argument("--codex-log-jsonl", default=None, help="Observed Codex JSONL/process output to summarize; raw events are not echoed.")

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -47,6 +47,7 @@ from ..plugin_bundle.omh.hermes_delegation import effective_mixture_category_cha
 from ..routing.intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
 from ..routing.localization import normalized_phrase, routing_tokens
 from ..runtime.artifacts import append_journal_observation, create_prepared_coding_delegation_run, write_coding_delegation
+from ..runtime.records import OBSERVED_RESULTS, WRAPPER_COMPLETION_STATUSES
 from ..system.paths import OmhPaths
 from ..workflows.blocked_work_records import mint_blocked_work_record
 from ..workflows.role_context_packs import validate_accepted_role_context, write_role_context_pack
@@ -3398,14 +3399,14 @@ def _add_coding_commands(sub) -> None:
 
     lifecycle_result = lifecycle_sub.add_parser("result")
     lifecycle_result.add_argument("--run", dest="run_id", required=True)
-    lifecycle_result.add_argument("--result", choices=("completed", "blocked", "failed"), required=True)
+    lifecycle_result.add_argument("--result", choices=OBSERVED_RESULTS, required=True)
     lifecycle_result.add_argument("--participants", default="codex")
     lifecycle_result.add_argument("--evidence-ref", action="append")
     lifecycle_result.set_defaults(func=cmd_coding_lifecycle_result)
 
     lifecycle_verify = lifecycle_sub.add_parser("verify")
     lifecycle_verify.add_argument("--run", dest="run_id", required=True)
-    lifecycle_verify.add_argument("--completion-status", choices=("completed", "blocked", "failed", "unknown"), default="completed")
+    lifecycle_verify.add_argument("--completion-status", choices=tuple(v for v in WRAPPER_COMPLETION_STATUSES if v != "started"), default="completed")
     lifecycle_verify.add_argument("--gap", action="append")
     lifecycle_verify.set_defaults(func=cmd_coding_lifecycle_verify)
 

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -54,6 +54,7 @@ from ..runtime.artifacts import (
     RUN_STATUSES,
     RUNTIME_OBSERVABLE_EVENTS,
     RUNTIME_OBSERVATION_STATUSES,
+    WRAPPER_COMPLETION_STATUSES,
     create_run,
     export_runtime,
     list_runs,
@@ -1364,7 +1365,7 @@ def _add_runtime_commands(sub) -> None:
     runtime_wrapper.add_argument("--prompt-dispatched", action="store_true")
     runtime_wrapper.add_argument("--response-observed", action="store_true")
     runtime_wrapper.add_argument("--verification-observed", action="store_true")
-    runtime_wrapper.add_argument("--completion-status", choices=("started", "completed", "blocked", "failed", "unknown"), default="unknown")
+    runtime_wrapper.add_argument("--completion-status", choices=WRAPPER_COMPLETION_STATUSES, default="unknown")
     runtime_wrapper.add_argument("--gap", action="append")
     runtime_wrapper.add_argument("--message", default="")
     runtime_wrapper.set_defaults(func=cmd_runtime_wrapper)

--- a/src/evidence/labels.py
+++ b/src/evidence/labels.py
@@ -182,6 +182,7 @@ _PHASE_BY_NEXT_ACTION: Final[dict[str, str]] = {
     "accept_or_revise_plan": PHASE_PLAN,
     "wait_for_executor_evidence": PHASE_CODE,
     "report_completion_with_evidence": PHASE_CODE,
+    "surface_executor_cancellation": PHASE_CODE,
 }
 
 

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -3073,6 +3073,7 @@ def first_use_status_smoke_plan(
                     "attach_executor_session",
                     "record_executor_completed",
                     "record_executor_blocked",
+                    "record_executor_cancelled",
                     "record_executor_failed",
                     "ask_hermes_verify",
                 ],

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -91,10 +91,18 @@ EXECUTOR_PROGRESS_EVENT_TYPES = {
     "executor_completed",
     "executor_blocked",
     "executor_failed",
+    "executor_cancelled",
     "reported_change_not_observed",
     "progress_observed",
     "unmapped_source_event",
 }
+# Hand-copied from `omh.workflows.observation_journal` (the non-`observed`
+# members of `OBSERVATION_STATUSES`) and `omh.runtime.records`
+# (`OBSERVED_RESULTS` minus `completed`); the bundle cannot import from src.
+# These are the statuses that END a target. `cancelled` belongs to both because
+# a run someone stopped is over: leaving it out is what made a cancelled run
+# read as one that had merely not got there yet.
+TERMINAL_JOURNAL_STATUSES = {"blocked", "failed", "cancelled"}
 EXECUTOR_PROGRESS_PROFILES = {"codex", "claude_code", "hermes_local", "omo_runtime"}
 EXECUTOR_PROGRESS_BINDING_STATES = {"active", "stale", "expired", "closed"}
 # Hand-copied from `omh.workflows.external_effect_receipts` and
@@ -576,7 +584,7 @@ def _receipt_backed_effect_kinds(receipts: list[dict[str, Any]], run_id: str) ->
 
 def _demote_observation_status(status: str, backed: set[str]) -> str:
     """Walk an observation status down to the highest rung it can still claim."""
-    if status in {"blocked", "failed", "cancelled"}:
+    if status in TERMINAL_JOURNAL_STATUSES:
         return status
     try:
         index = OBSERVATION_STATUS_ORDER.index(status)
@@ -657,7 +665,7 @@ def _journal_projection_for_run(
         if event.get("plan_status"):
             projection["plan_status"] = str(event.get("plan_status", ""))
         if status != "observed":
-            if status in {"blocked", "failed"}:
+            if status in TERMINAL_JOURNAL_STATUSES:
                 projection["observation_status"] = status
             continue
         if name == "prepared_handoff_created":
@@ -714,7 +722,7 @@ def _apply_lifecycle_to_run_summary(summary: dict[str, Any], lifecycle: dict[str
 
 def _later_status(current: str, candidate: str) -> str:
     order = list(OBSERVATION_STATUS_ORDER)
-    if current in {"blocked", "failed", "cancelled"}:
+    if current in TERMINAL_JOURNAL_STATUSES:
         return current
     try:
         return candidate if order.index(candidate) >= order.index(current) else current
@@ -734,8 +742,9 @@ def _ordered_activity_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     def observed(row: dict[str, Any]) -> str:
         return str(row.get("observed_at", ""))
 
-    running = [row for row in rows if str(row.get("state", "running")) not in {"blocked", "failed", "done"}]
-    blocked = [row for row in rows if str(row.get("state", "")) in {"blocked", "failed"}]
+    settled_states = {"blocked", "failed", "cancelled"}
+    running = [row for row in rows if str(row.get("state", "running")) not in settled_states | {"done"}]
+    blocked = [row for row in rows if str(row.get("state", "")) in settled_states]
     done = [row for row in rows if str(row.get("state", "")) == "done"]
     blocked.sort(key=observed, reverse=True)
     done.sort(key=observed, reverse=True)
@@ -1537,11 +1546,14 @@ def _hud_subagent_summary(status: dict[str, Any]) -> dict[str, Any]:
     progress_rows = status.get("latest_progress_events", [])
     progress = progress_rows if isinstance(progress_rows, list) else []
     blocked = 0
+    cancelled = 0
     for row in active:
         event = row.get("latest_event", {}) if isinstance(row, dict) else {}
         event_type = str(event.get("event_type", "")) if isinstance(event, dict) else ""
         event_status = str(event.get("status", "")) if isinstance(event, dict) else ""
-        if event_type in {"executor_blocked", "executor_failed"} or event_status in {"blocked", "failed"}:
+        if _hud_row_state(event_type, event_status) == "cancelled":
+            cancelled += 1
+        elif event_type in {"executor_blocked", "executor_failed"} or event_status in {"blocked", "failed"}:
             blocked += 1
     completed = sum(
         1
@@ -1567,12 +1579,7 @@ def _hud_subagent_summary(status: dict[str, Any]) -> dict[str, Any]:
         event = event if isinstance(event, dict) else {}
         event_type = str(event.get("event_type", ""))
         event_status = str(event.get("status", ""))
-        state = (
-            "blocked"
-            if event_type in {"executor_blocked", "executor_failed"}
-            or event_status in {"blocked", "failed"}
-            else "running"
-        )
+        state = _hud_row_state(event_type, event_status)
         projected = {
             "state": state,
             "task_id": _hud_text(row.get("target_id", ""), limit=80)[:8],
@@ -1628,14 +1635,34 @@ def _hud_subagent_summary(status: dict[str, Any]) -> dict[str, Any]:
         "hidden_rows": hidden_rows,
         "status": "observed" if active or stale or progress else "idle",
         "active": len(active),
-        "running": max(0, len(active) - blocked),
+        "running": max(0, len(active) - blocked - cancelled),
         "blocked": blocked,
+        # Counted apart from `blocked` because the two ask for different things:
+        # a blocked executor is waiting on something a reader may be able to
+        # clear, and a cancelled one is over and will only run again if someone
+        # re-dispatches it.
+        "cancelled": cancelled,
         "completed": completed,
         "stale": len(stale),
         "latest_action": latest_action,
         "rows": subagent_rows,
         "maestro_rows": maestro_rows,
     }
+
+
+def _hud_row_state(event_type: str, event_status: str) -> str:
+    """The display state one executor row is in: cancelled, blocked, or running.
+
+    Cancellation is tested first. A cancelled executor whose event also carries
+    a failed process status would otherwise render as blocked, which is the
+    conflation #808 AC2 rules out and which sends a reader looking for a blocker
+    to clear on work that someone deliberately stopped.
+    """
+    if event_type == "executor_cancelled" or event_status == "cancelled":
+        return "cancelled"
+    if event_type in {"executor_blocked", "executor_failed"} or event_status in {"blocked", "failed"}:
+        return "blocked"
+    return "running"
 
 
 def _hud_executor_role(row: dict[str, Any]) -> str:
@@ -2419,6 +2446,17 @@ def _projected_binding_state(runtime_dir: Path, binding: dict[str, Any]) -> str:
 
 
 def _target_has_terminal_result(runtime_dir: Path, target_type: str, target_id: str) -> bool:
+    """Whether the run or wrapper session behind a binding has already ended.
+
+    Asks whether the record is OBSERVED and carries any result, rather than
+    matching the result against a list of the ones this bundle happens to know.
+    A bundle is copied onto a machine and updated separately from the writer, so
+    it will meet result words added after it shipped; matching a list made every
+    such word read as "not terminal", which projects a target that stopped as
+    one still running. Unobserved results (`not_observed`, `not_available`)
+    cannot reach an observed record, so the observed flag is the whole test, and
+    a result this bundle cannot name degrades to terminal-with-unknown-kind.
+    """
     if (
         not target_id
         or target_id in {".", ".."}
@@ -2429,10 +2467,10 @@ def _target_has_terminal_result(runtime_dir: Path, target_type: str, target_id: 
         return False
     if target_type == "run":
         delegation = _read_json(runtime_dir / "runs" / target_id / "delegation.json")
-        return bool(delegation.get("observed")) and str(delegation.get("result", "")) in {"completed", "blocked", "failed"}
+        return bool(delegation.get("observed")) and bool(str(delegation.get("result", "")).strip())
     if target_type == "wrapper_session":
         record = _read_json(runtime_dir / "wrapper_sessions" / target_id / "executor_session.json")
-        return bool(record.get("result_observed")) and str(record.get("result", "")) in {"completed", "blocked", "failed"}
+        return bool(record.get("result_observed")) and bool(str(record.get("result", "")).strip())
     return False
 
 

--- a/src/quality/harness_quality.py
+++ b/src/quality/harness_quality.py
@@ -20,7 +20,13 @@ HARNESS_QUALITY_KEYS = (
     "overclaim_guards",
 )
 HARNESS_PROGRESS_SCHEMA_VERSION = "harness_progress/v1"
-HARNESS_PROGRESS_STATES = ("pending", "complete", "blocked", "not_required")
+# `cancelled` is a member so a stopped step cannot be reported as `blocked`.
+# The two ask for different things -- a blocked step is waiting on something,
+# a cancelled one is over -- and it is not `complete` or `not_required` either,
+# so it counts as unfinished in `build_harness_progress` exactly as `blocked`
+# does. `_progress_state` folds anything outside this tuple to `pending`, which
+# is why a state has to be admitted here before a step can report it.
+HARNESS_PROGRESS_STATES = ("pending", "complete", "blocked", "cancelled", "not_required")
 
 
 def build_harness_quality_contract(
@@ -77,7 +83,7 @@ def build_harness_progress(contract: dict[str, object], step_states: dict[str, s
         for step in ladder_steps
     ]
     completed = sum(1 for step in steps if step["state"] in {"complete", "not_required"})
-    next_step = next((str(step["id"]) for step in steps if step["state"] in {"blocked", "pending"}), "")
+    next_step = next((str(step["id"]) for step in steps if step["state"] in {"blocked", "cancelled", "pending"}), "")
     return {
         "schema_version": HARNESS_PROGRESS_SCHEMA_VERSION,
         "harness": contract.get("harness", "unknown"),

--- a/src/routing/action_copy.py
+++ b/src/routing/action_copy.py
@@ -138,6 +138,7 @@ NEXT_ACTION_LABELS: dict[str, str] = {
     "show_context_brief": "showing the OMH context brief",
     "show_agent_ops_review": "showing agent-ops status",
     "show_coding_handoff_status": "showing coding-agent progress",
+    "surface_executor_cancellation": "surfacing the cancelled coding-agent run",
     "show_prompt_handoff": "showing the prompt handoff",
     "show_rejected_decision_recall": "showing scoped rejected-decision context",
     "show_run_efficiency_report": "showing the supplied local run efficiency report",

--- a/src/runtime/artifacts.py
+++ b/src/runtime/artifacts.py
@@ -613,7 +613,12 @@ def _legacy_lifecycle_projection(shown: dict[str, Any]) -> dict[str, Any]:
         "merge_observed": bool(merge.get("merged", False)),
         "blocked": delegation.get("result") == "blocked" or wrapper.get("completion_status") == "blocked",
         "failed": delegation.get("result") == "failed" or wrapper.get("completion_status") == "failed",
-        "cancelled": False,
+        # Read from the record like its two neighbours, rather than being
+        # hard-coded false. While it was a constant the journal projection was
+        # the only surface that could ever report a cancellation, so a
+        # cancellation recorded through the run or wrapper record alone
+        # projected as neither cancelled nor anything else.
+        "cancelled": delegation.get("result") == "cancelled" or wrapper.get("completion_status") == "cancelled",
         "observation_status": observation_status,
         "journal_event_count": 0,
         "latest_event_id": "",
@@ -859,10 +864,10 @@ def _compact_executor_progress_report(report: dict[str, Any]) -> dict[str, Any]:
 
 def _executor_progress_show_state(target_dir: Path, binding: dict[str, Any]) -> str:
     delegation = read_json_object(target_dir / "delegation.json") or {}
-    if bool(delegation.get("observed")) and str(delegation.get("result", "")) in {"completed", "blocked", "failed"}:
+    if bool(delegation.get("observed")) and str(delegation.get("result", "")) in OBSERVED_RESULTS:
         return "closed"
     executor_session = read_json_object(target_dir / "executor_session.json") or {}
-    if bool(executor_session.get("result_observed")) and str(executor_session.get("result", "")) in {"completed", "blocked", "failed"}:
+    if bool(executor_session.get("result_observed")) and str(executor_session.get("result", "")) in OBSERVED_RESULTS:
         return "closed"
     return str(binding.get("state", ""))
 
@@ -1371,6 +1376,8 @@ def _delegated_harness_progress(
 def _executor_progress_state(observed: bool, status: str) -> str:
     if not observed:
         return "pending"
+    if status == "cancelled":
+        return "cancelled"
     if status in {"blocked", "failed"}:
         return "blocked"
     return "complete"
@@ -1806,6 +1813,11 @@ def _delegated_status_next_action(
         return "dispatch_to_executor"
     if not execution_observed:
         return "wait_for_executor_evidence"
+    # Ahead of the blocker branch, and its own action. "Surface the blocker"
+    # tells a reader to go clear something; a cancelled run has nothing to
+    # clear and needs a decision about re-dispatch instead.
+    if execution_status == "cancelled":
+        return "surface_executor_cancellation"
     if execution_status in {"blocked", "failed"}:
         return "surface_executor_blocker"
     if not verification_observed:
@@ -1859,6 +1871,11 @@ def _delegated_status_summary(
         return f"A {executor_target} coding handoff is prepared, but wrapper dispatch is not observed yet."
     if not execution_observed:
         return f"A {executor_target} coding handoff was dispatched, but executor completion is not observed yet."
+    if execution_status == "cancelled":
+        return (
+            f"The {executor_target} executor run was cancelled before it reported a result; "
+            "re-dispatch or resume it before claiming any outcome."
+        )
     if execution_status in {"blocked", "failed"}:
         return f"The {executor_target} executor reported {execution_status}; do not claim completion."
     if not verification_observed:

--- a/src/runtime/claims.py
+++ b/src/runtime/claims.py
@@ -59,7 +59,7 @@ RUNTIME_CLAIM_LABELS: Final = {
 RUNTIME_CLAIM_BLOCK_REASONS: Final = {
     Claim.HANDOFF_PREPARED: "prepared coding handoff metadata is not available",
     Claim.EXECUTOR_DISPATCHED: "wrapper dispatch evidence is not observed",
-    Claim.EXECUTION_OBSERVED: "executor result evidence is not observed",
+    Claim.EXECUTION_OBSERVED: "executor result evidence is not observed, or the run was cancelled before it reached one",
     Claim.VERIFICATION_OBSERVED: "verification evidence is not observed",
     Claim.REVIEW_OBSERVED: (
         "review evidence is not observed, or no external effect receipt from runtime_review_record "
@@ -118,7 +118,17 @@ def _claim_allowed(claim: Claim, status: Mapping[str, JsonValue]) -> bool:
         case Claim.EXECUTOR_DISPATCHED:
             return _bool_value(_mapping_value(status, "wrapper"), "prompt_dispatched")
         case Claim.EXECUTION_OBSERVED:
-            return _bool_value(_mapping_value(status, "execution"), "observed")
+            execution = _mapping_value(status, "execution")
+            # This rung's own block reason names what it stands for: "executor
+            # result evidence is observed". A cancelled run has none -- it was
+            # stopped before it reached one -- so it stops here, and every rung
+            # above it (verification, review, CI, merge-readiness, merge) is
+            # blocked by the ladder's break rather than by a separate check.
+            # Blocked and failed results are NOT excluded: each of those IS the
+            # executor's answer about the work, however unwelcome.
+            if _string_value(execution, "status") == "cancelled":
+                return False
+            return _bool_value(execution, "observed")
         case Claim.VERIFICATION_OBSERVED:
             return _bool_value(_mapping_value(status, "verification"), "observed")
         case Claim.REVIEW_OBSERVED:

--- a/src/runtime/records.py
+++ b/src/runtime/records.py
@@ -100,16 +100,40 @@ from ..workflows.workspace_bindings import (
 
 
 SCHEMA_VERSION = 1
-RUN_STATUSES = ("started", "prepared", "completed", "blocked", "failed", "unknown")
+# Compatibility strategy for `cancelled`, which appears in five tuples below.
+#
+# It is an ADDITIVE enum member and nothing else changes: `SCHEMA_VERSION` is
+# not bumped, no field is added, renamed, or given a new meaning, and no
+# existing value's meaning moves. Every record written before `cancelled`
+# existed still validates byte-for-byte against these validators, because
+# validation is membership in a tuple that only grew. There is no migration and
+# no rewrite of stored records -- a record that never said `cancelled` still
+# does not.
+#
+# The direction that DOES need care is a newer record read by an older bundle,
+# which is a real shape here because `plugin_bundle/omh/runtime_reader.py` is
+# copied onto a machine and updated separately from the writer. An older reader
+# that hard-codes the three terminal results sees `cancelled` as a value it does
+# not know. The requirement on that reader is that an unknown result on an
+# `observed` record degrades to "terminal, kind unknown" and never to "still
+# active" -- a stopped run that reads as running is the exact failure this whole
+# state exists to end. The shipped reader does that by asking whether the record
+# is observed rather than by matching the result against a list.
+RUN_STATUSES = ("started", "prepared", "completed", "blocked", "failed", "cancelled", "unknown")
 PRIVACY_MODES = ("metadata_only",)
 RUN_ARTIFACT_KINDS = ("workflow_run", "prepared_coding_delegation")
 RUN_PHASES = ("runtime", "prepared", "unknown")
 RUN_OBSERVATION_STATUSES = ("unknown", "observed", "not_observed", "prepared_not_observed")
-DELEGATION_RESULTS = ("completed", "blocked", "failed", "not_available", "not_observed")
-OBSERVED_RESULTS = ("completed", "blocked", "failed")
+DELEGATION_RESULTS = ("completed", "blocked", "failed", "cancelled", "not_available", "not_observed")
+# `cancelled` is an OBSERVED result, not an unobserved one. Recording it still
+# requires the same `observed=True` evidence every other terminal result
+# requires: OMH records that a cancellation was observed (process termination or
+# an authoritative executor result), never that one was requested. A request to
+# cancel is not a terminal result and has no member here.
+OBSERVED_RESULTS = ("completed", "blocked", "failed", "cancelled")
 UNOBSERVED_RESULTS = ("not_available", "not_observed")
 EVENT_LEVELS = ("debug", "info", "warning", "error")
-WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "unknown")
+WRAPPER_COMPLETION_STATUSES = ("started", "completed", "blocked", "failed", "cancelled", "unknown")
 REVIEW_STATUSES = ("not_required", "pending", "passed", "failed", "blocked", "not_observed")
 CI_STATUSES = ("not_required", "pending", "passed", "failed", "blocked", "not_observed")
 CI_CHECK_STATUSES = ("passed", "failed", "blocked", "pending", "not_required")
@@ -719,7 +743,7 @@ def build_event_record(event: dict[str, Any]) -> dict[str, Any]:
 
 def validate_delegation_result(observed: bool, result: str) -> None:
     if observed and result not in OBSERVED_RESULTS:
-        raise ValueError("observed delegation requires result completed, blocked, or failed")
+        raise ValueError("observed delegation requires result completed, blocked, failed, or cancelled")
     if not observed and result not in UNOBSERVED_RESULTS:
         raise ValueError("unobserved delegation requires result not_available or not_observed")
 
@@ -2363,7 +2387,11 @@ def validate_runtime_observation_record(observation: dict[str, Any]) -> list[str
     else:
         _require(observation.get("observed") is True, errors, "runtime_observation observed status requires observed=true")
         has_evidence = bool(observation.get("evidence_refs")) or bool(str(observation.get("summary", "")).strip())
-        _require(has_evidence, errors, "runtime_observation observed/blocked/failed status requires summary or evidence_refs")
+        _require(
+            has_evidence,
+            errors,
+            "runtime_observation observed/blocked/cancelled/failed status requires summary or evidence_refs",
+        )
     if observation.get("event_type") in {"worktree_creation"} and observation.get("status") == "observed":
         _require(bool(str(observation.get("worktree_ref", "")).strip()), errors, "runtime_observation worktree_creation requires worktree_ref")
     if observation.get("event_type") in {"worker_dispatch", "worker_result"} and observation.get("status") == "observed":

--- a/src/runtime/run_health.py
+++ b/src/runtime/run_health.py
@@ -150,6 +150,11 @@ _PHASE_BY_NORMALIZED_EVENT: Final[dict[str, str]] = {
     "executor_completed": "completion",
     "executor_blocked": "completion",
     "executor_failed": "completion",
+    # A cancellation ends the run at the same rung the other three end it. It
+    # is deliberately absent from `_FAILURE_CLASS_BY_NORMALIZED_EVENT`: a run
+    # someone stopped observed no failure, and reporting one would attribute a
+    # defect to work that was never allowed to reach a verdict.
+    "executor_cancelled": "completion",
 }
 
 # Only phases that a LATER phase can close get a duration. `verification_outcome`

--- a/src/wrapper/briefing.py
+++ b/src/wrapper/briefing.py
@@ -10,6 +10,7 @@ from ..coding.executor_capabilities import (
 from ..coding.executor_capability_snapshots import validate_executor_capability_snapshot
 from ..coding.executor_local_workflow import validate_executor_local_workflow
 from ..coding.handoff_input_manifest import input_manifest_summary
+from ..runtime.records import OBSERVED_RESULTS
 
 CODING_BRIEFING_SCHEMA_VERSION = "coding_briefing/v1"
 
@@ -336,7 +337,7 @@ def _progress_steps(
     isolation_status = _object(executor_status.get("workspace_isolation"))
     dispatch_observed = _bool_path(runtime_status, "execution", "observed") or str(executor_status.get("dispatch")) == "observed"
     result = str(executor_status.get("result") or _object(runtime_status.get("execution")).get("status") or "not_observed")
-    result_observed = result in {"completed", "blocked", "failed"}
+    result_observed = result in OBSERVED_RESULTS
     verification_observed = bool(_object(runtime_status.get("verification")).get("observed")) or str(executor_status.get("verification")) in {
         "observed",
         "satisfied",

--- a/src/wrapper/continuity_state.py
+++ b/src/wrapper/continuity_state.py
@@ -8,6 +8,7 @@ StateValue: TypeAlias = (
 )
 JourneyState: TypeAlias = Literal[
     "executor_blocked",
+    "executor_cancelled",
     "executor_failed",
     "execution_observed",
     "invalid_runtime_evidence",
@@ -31,6 +32,7 @@ def journey_state(
     if execution.get("observed") is True:
         observed_states: dict[str, JourneyState] = {
             "blocked": "executor_blocked",
+            "cancelled": "executor_cancelled",
             "failed": "executor_failed",
             "completed": "execution_observed",
         }
@@ -86,6 +88,7 @@ def resume_status_from_evidence(evidence: Mapping[str, StateValue]) -> ResumeSta
         "not_observed",
         "completed",
         "blocked",
+        "cancelled",
         "failed",
     }:
         return "blocked"
@@ -110,6 +113,11 @@ def resume_status_from_evidence(evidence: Mapping[str, StateValue]) -> ResumeSta
             return "conversation_safe"
         case (
             "executor_blocked"
+            # A cancelled run is not conversation-safe and not reattachable:
+            # nothing is still running to reattach to, and no result was
+            # reached to continue from. It needs a re-dispatch decision, which
+            # is what `blocked` means on this axis.
+            | "executor_cancelled"
             | "executor_failed"
             | "runtime_recovery_blocked"
             | "invalid_runtime_evidence"

--- a/src/wrapper/contract.py
+++ b/src/wrapper/contract.py
@@ -153,6 +153,7 @@ VISIBLE_ACTIONS = (
     "show_coding_handoff_status",
     "record_executor_completed",
     "record_executor_blocked",
+    "record_executor_cancelled",
     "record_executor_failed",
     "ask_hermes_verify",
     "show_quickstart",
@@ -673,6 +674,12 @@ _STATUS_COPY = {
         "The executor reported a blocker.",
         "I will surface the blocker instead of claiming completion.",
         "Blocked executor work is not complete.",
+    ),
+    "surface_executor_cancellation": (
+        "blocker",
+        "The executor run was cancelled.",
+        "I will report the cancellation and what re-dispatching it would need, instead of claiming any outcome.",
+        "Cancelled executor work is not complete, not failed, and not blocked on anything clearable.",
     ),
     "record_review_evidence": (
         "status",
@@ -10313,6 +10320,7 @@ def _phase_for_next_action(next_action: str) -> str:
         "show_runtime_handoff": "runtime_handoff_prepared",
         "wait_for_executor_evidence": "dispatched",
         "surface_executor_blocker": "blocked",
+        "surface_executor_cancellation": "cancelled",
         "surface_review_blocker": "blocked",
         "surface_ci_blocker": "blocked",
         "surface_merge_blocker": "blocked",
@@ -10327,6 +10335,8 @@ def _phase_for_next_action(next_action: str) -> str:
 
 
 def _status_card_severity(next_action: str) -> str:
+    if next_action == "surface_executor_cancellation":
+        return "cancelled"
     if next_action.startswith("surface_"):
         return "blocked"
     if next_action in {"report_merge_ready", "report_merged", "report_completion_with_evidence"}:

--- a/src/wrapper/executor_sessions.py
+++ b/src/wrapper/executor_sessions.py
@@ -53,8 +53,16 @@ EXECUTOR_SESSION_SCHEMA_VERSION = "executor_session/v1"
 EXECUTOR_SESSION_STATUS_SCHEMA_VERSION = "executor_session_status/v1"
 EXECUTOR_LAUNCH_SCHEMA_VERSION = "executor_launch/v1"
 EXECUTOR_SESSION_RECORD_TYPE = "executor_session"
-EXECUTOR_SESSION_STATUSES = ("not_started", "prepared", "running", "completed", "blocked", "failed")
-EXECUTOR_SESSION_RESULTS = ("not_observed", "completed", "blocked", "failed")
+# Additive: `cancelled` joins both tuples and nothing else moves, so every
+# executor-session record written before it existed still validates unchanged.
+# The wrapper's own `session["status"] == "cancelled"` is a different fact and
+# stays where it is -- that one cancels a PREPARED PLAN before any executor ran,
+# and `record_executor_session_result` still refuses to file a result on such a
+# session. This one is an observed executor cancellation, which can only exist
+# after a dispatch was observed.
+EXECUTOR_SESSION_STATUSES = ("not_started", "prepared", "running", "completed", "blocked", "cancelled", "failed")
+EXECUTOR_SESSION_RESULTS = ("not_observed", "completed", "blocked", "cancelled", "failed")
+EXECUTOR_SESSION_OBSERVED_RESULTS = ("completed", "blocked", "cancelled", "failed")
 EXECUTOR_SESSION_VERIFICATION_STATUSES = ("not_requested", "requested", "observed")
 EXECUTOR_SESSION_ACTION_IDS = (
     "prepare_worktree",
@@ -63,6 +71,7 @@ EXECUTOR_SESSION_ACTION_IDS = (
     "refresh_executor_status",
     "record_executor_completed",
     "record_executor_blocked",
+    "record_executor_cancelled",
     "record_executor_failed",
     "ask_hermes_verify",
 )
@@ -103,7 +112,7 @@ class _ExecutorSessionObservationAdapter:
                 }
             )
         result = str(status.get("result", "not_observed"))
-        if result in {"completed", "blocked", "failed"}:
+        if result in EXECUTOR_SESSION_OBSERVED_RESULTS:
             observations.append(
                 {
                     "event": "result",
@@ -394,6 +403,13 @@ def build_executor_session_actions(
             payload={**base_payload, "backend_action": "record-executor", "result": "blocked", "disabled_reason": status_blocker},
         ),
         _action(
+            "record_executor_cancelled",
+            "Record cancelled",
+            "secondary",
+            enabled=not status_blocker and bool(attached or dispatch_observed) and result_status == "not_observed",
+            payload={**base_payload, "backend_action": "record-executor", "result": "cancelled", "disabled_reason": status_blocker},
+        ),
+        _action(
             "record_executor_failed",
             "Record failed",
             "secondary",
@@ -570,8 +586,8 @@ def record_executor_session_result(
     summary: str = "",
     codex_progress_summary: dict[str, object] | None = None,
 ) -> dict[str, object]:
-    if result not in {"completed", "blocked", "failed"}:
-        raise ExecutorSessionError("executor result must be completed, blocked, or failed")
+    if result not in EXECUTOR_SESSION_OBSERVED_RESULTS:
+        raise ExecutorSessionError("executor result must be completed, blocked, cancelled, or failed")
     session = _existing_session(paths, session_id)
     require_not_terminal(
         session,
@@ -1205,6 +1221,7 @@ def _progress_event_for_result(result: str) -> str:
         "completed": "executor_completed",
         "blocked": "executor_blocked",
         "failed": "executor_failed",
+        "cancelled": "executor_cancelled",
     }.get(result, "progress_observed")
 
 
@@ -1321,7 +1338,7 @@ def _verification_status(record: dict[str, Any], linked_status: dict[str, Any], 
 
 
 def _agent_state(record: dict[str, Any], dispatch_observed: bool, result_status: str) -> str:
-    if result_status in {"completed", "blocked", "failed"}:
+    if result_status in EXECUTOR_SESSION_OBSERVED_RESULTS:
         return result_status
     if dispatch_observed or bool(record.get("attached", False)):
         return "running"
@@ -1782,6 +1799,8 @@ def _executor_action_label(executor_status: dict[str, object], action_id: str) -
 
 
 def _executor_status_card_severity(result: str, verification: str) -> str:
+    if result == "cancelled":
+        return "cancelled"
     if result in {"blocked", "failed"}:
         return "blocked"
     if result == "completed" and verification == "observed":
@@ -1796,6 +1815,10 @@ def _card_step(step_id: str, label: str, state: str, detail: str) -> dict[str, o
 
 
 def _result_step_state(result: str) -> str:
+    # `cancelled` is its own card state, not a shade of `blocked`: the card is
+    # exactly where #808 AC2 requires the four to stay apart.
+    if result == "cancelled":
+        return "cancelled"
     if result in {"blocked", "failed"}:
         return "blocked"
     if result == "completed":

--- a/src/wrapper/lifecycle.py
+++ b/src/wrapper/lifecycle.py
@@ -139,7 +139,7 @@ def record_codex_result(
     if str(status.get("next_action")) != "wait_for_executor_evidence":
         raise CodingLifecycleError(f"cannot record Codex result while next_action is {status.get('next_action')}")
     if result not in OBSERVED_RESULTS:
-        raise CodingLifecycleError("Codex result must be completed, blocked, or failed")
+        raise CodingLifecycleError("executor result must be completed, blocked, failed, or cancelled")
     delegation = write_delegation(
         run_dir,
         {
@@ -176,8 +176,10 @@ def record_codex_verification(
     execution = status.get("execution", {})
     if not isinstance(execution, dict) or not execution.get("observed"):
         raise CodingLifecycleError("cannot record verification before executor evidence is observed")
-    if execution.get("status") in {"blocked", "failed"}:
-        raise CodingLifecycleError("cannot record successful verification for blocked or failed executor result")
+    if execution.get("status") in {"blocked", "cancelled", "failed"}:
+        raise CodingLifecycleError(
+            "cannot record successful verification for a blocked, cancelled, or failed executor result"
+        )
     unobserved_gaps = list(gaps or [])
     verification_observed = completion_status == "completed" and not unobserved_gaps
     wrapper = write_wrapper_contract(
@@ -320,6 +322,7 @@ def _progress_event_for_result(result: str) -> str:
         "completed": "executor_completed",
         "blocked": "executor_blocked",
         "failed": "executor_failed",
+        "cancelled": "executor_cancelled",
     }.get(result, "progress_observed")
 
 
@@ -338,6 +341,7 @@ def _lifecycle_status(next_action: str) -> str:
         "dispatch_to_executor": "prepared",
         "wait_for_executor_evidence": "dispatched",
         "surface_executor_blocker": "blocked",
+        "surface_executor_cancellation": "cancelled",
         "surface_review_blocker": "blocked",
         "surface_ci_blocker": "blocked",
         "surface_merge_blocker": "blocked",
@@ -359,6 +363,7 @@ def _blocking_reason(next_action: str) -> str:
         "dispatch_to_executor": "executor/runtime dispatch is not observed",
         "wait_for_executor_evidence": "executor evidence is not observed",
         "surface_executor_blocker": "executor reported blocked or failed",
+        "surface_executor_cancellation": "executor run was cancelled and must be re-dispatched or resumed before any outcome is claimed",
         "surface_review_blocker": "review failed or blocked completion",
         "surface_ci_blocker": "CI failed or blocked completion",
         "surface_merge_blocker": "merge is blocked",

--- a/src/wrapper/mission_control.py
+++ b/src/wrapper/mission_control.py
@@ -11,6 +11,7 @@ from ..coding.routing_observation import (
     validate_routing_observation,
 )
 from ..paths import OmhPaths
+from ..runtime.records import OBSERVED_RESULTS
 from .continuity_state import journey_state as _journey_state
 from .sessions import build_wrapper_session_status, read_wrapper_session
 
@@ -106,7 +107,7 @@ def _routing_observation(
         **runtime_observation,
         **executor_progress,
         **latest_event,
-        "status": (result if result in {"completed", "blocked", "failed"} else None)
+        "status": (result if result in OBSERVED_RESULTS else None)
         or latest_event.get("status")
         or runtime_observation.get("status")
         or ("running" if executor_status.get("dispatch") == "observed" else None),
@@ -177,6 +178,11 @@ def _recovery(journey_state: str, conformance: dict[str, object]) -> dict[str, o
             return {"status": "running_observed", "resume_safe": False, "next_action": next_action}
         case "runtime_running_observed":
             return {"status": "running_observed", "resume_safe": False, "next_action": next_action}
+        case "executor_cancelled":
+            # Its own recovery status. `recovery_blocked` reads as "something is
+            # in the way", and the answer to a cancellation is a decision about
+            # re-dispatching, not a blocker to clear.
+            return {"status": "cancelled_observed", "resume_safe": False, "next_action": next_action}
         case "executor_blocked" | "executor_failed" | "runtime_recovery_blocked" | "invalid_runtime_evidence":
             return {"status": "recovery_blocked", "resume_safe": False, "next_action": next_action}
         case "handoff_prepared":

--- a/tests/test_cancelled_terminal_state.py
+++ b/tests/test_cancelled_terminal_state.py
@@ -1,0 +1,463 @@
+"""`cancelled` as a first-class observed terminal state (issue #1360).
+
+The four terminal states have to stay apart everywhere they are recorded and
+everywhere they are read. These tests hold that line from both ends: a
+cancellation can be RECORDED without being relabelled, and once recorded it
+never reads as active, stale, blocked, failed, or completed, and never satisfies
+an evidence gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.coding.executor_progress import (  # noqa: E402
+    CLOSING_EVENT_TYPES,
+    PROGRESS_EVENT_TYPES,
+    TERMINAL_EVENT_TYPES,
+    build_progress_binding,
+    build_safe_progress_signal,
+    infer_progress_event_type,
+    observe_executor_progress,
+    read_progress_binding,
+    wait_outcome_for_progress_event,
+    write_progress_binding,
+)
+from omh.coding.wait_strategy import (  # noqa: E402
+    WAIT_TERMINAL_STATES,
+    arm_wait_binding,
+    build_execution_wait_strategy,
+    consume_wait_completion,
+)
+from omh.coding_lifecycle import (  # noqa: E402
+    CodingLifecycleError,
+    record_codex_dispatch,
+    record_codex_result,
+    record_codex_verification,
+    report_codex_delegation_lifecycle,
+    start_codex_delegation_lifecycle,
+)
+from omh.executors import EXECUTOR_PROFILES  # noqa: E402
+from omh.paths import resolve_paths  # noqa: E402
+from omh.plugin_bundle.omh.runtime_reader import _hud_subagent_summary  # noqa: E402
+from omh.runtime.artifacts import (  # noqa: E402
+    export_runtime,
+    show_run,
+    summarize_delegated_coding_status,
+)
+from omh.runtime.claims import Claim, allowed_runtime_claims  # noqa: E402
+from omh.runtime.records import (  # noqa: E402
+    DELEGATION_RESULTS,
+    OBSERVED_RESULTS,
+    RUN_STATUSES,
+    UNOBSERVED_RESULTS,
+    WRAPPER_COMPLETION_STATUSES,
+    build_delegation_record,
+    build_run_record,
+    build_wrapper_record,
+    validate_delegation_record,
+    validate_delegation_result,
+    validate_run_record,
+    validate_wrapper_record,
+)
+from omh.wrapper.continuity_state import journey_state, resume_status_from_evidence  # noqa: E402
+from omh.wrapper.contract import STATUS_CARD_STEP_STATES  # noqa: E402
+from omh.wrapper.executor_sessions import build_executor_session_status_card  # noqa: E402
+from omh.wrapper.executor_sessions import (  # noqa: E402
+    EXECUTOR_SESSION_OBSERVED_RESULTS,
+    EXECUTOR_SESSION_RESULTS,
+    EXECUTOR_SESSION_STATUSES,
+    ExecutorSessionError,
+    open_executor_session,
+    record_executor_session_result,
+)
+from omh.wrapper_sessions import (  # noqa: E402
+    create_or_resume_wrapper_session,
+    prepare_wrapper_session_handoff,
+    record_plan_decision,
+    select_wrapper_session_executor,
+)
+
+from omh.commands.main import build_parser  # noqa: E402
+
+
+def _paths(tmp: str):
+    return resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+
+
+class CancelledVocabularyTests(unittest.TestCase):
+    def test_cancelled_is_a_member_of_every_terminal_vocabulary(self) -> None:
+        self.assertIn("cancelled", RUN_STATUSES)
+        self.assertIn("cancelled", DELEGATION_RESULTS)
+        self.assertIn("cancelled", OBSERVED_RESULTS)
+        self.assertIn("cancelled", WRAPPER_COMPLETION_STATUSES)
+        self.assertIn("cancelled", EXECUTOR_SESSION_STATUSES)
+        self.assertIn("cancelled", EXECUTOR_SESSION_RESULTS)
+        self.assertIn("cancelled", EXECUTOR_SESSION_OBSERVED_RESULTS)
+
+    def test_cancellation_is_observed_never_merely_requested(self) -> None:
+        """It sits with the observed results, so recording it needs the same evidence."""
+        self.assertNotIn("cancelled", UNOBSERVED_RESULTS)
+        with self.assertRaises(ValueError):
+            validate_delegation_result(False, "cancelled")
+        validate_delegation_result(True, "cancelled")
+
+    def test_a_cancelled_run_and_wrapper_record_build_and_validate(self) -> None:
+        run = build_run_record({"status": "cancelled", "skill": "x", "harness": "y"}, "run-1")
+        self.assertEqual(validate_run_record(run), [])
+        wrapper = build_wrapper_record({"completion_status": "cancelled"})
+        self.assertEqual(validate_wrapper_record(wrapper), [])
+        delegation = build_delegation_record(
+            {"requested": True, "observed": True, "result": "cancelled", "evidence_refs": ["host:sigterm"]}
+        )
+        self.assertEqual(validate_delegation_record(delegation), [])
+
+    def test_records_written_before_cancelled_existed_still_validate(self) -> None:
+        """The change is additive: no stored record's meaning or shape moved."""
+        for result in ("completed", "blocked", "failed"):
+            with self.subTest(result=result):
+                legacy = build_delegation_record({"requested": True, "observed": True, "result": result})
+                self.assertEqual(validate_delegation_record(legacy), [])
+        for status in ("started", "completed", "blocked", "failed", "unknown"):
+            with self.subTest(status=status):
+                self.assertEqual(validate_wrapper_record(build_wrapper_record({"completion_status": status})), [])
+
+    def test_a_forged_cancellation_is_refused_the_way_every_unobserved_claim_is(self) -> None:
+        with self.assertRaises(ValueError):
+            build_delegation_record({"requested": True, "observed": False, "result": "cancelled"})
+
+
+class CancelledLifecycleTests(unittest.TestCase):
+    def _cancelled_run(self, paths) -> str:
+        started = start_codex_delegation_lifecycle(paths, "diagnose installation health")
+        run_id = started["run"]["run_id"]
+        record_codex_dispatch(paths, run_id)
+        record_codex_result(paths, run_id, result="cancelled", evidence_refs=["host:sigterm"])
+        return run_id
+
+    def test_a_cancelled_result_records_without_being_relabelled(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            run_id = self._cancelled_run(paths)
+
+            delegation = json.loads((paths.runtime_runs_dir / run_id / "delegation.json").read_text())
+            self.assertEqual(delegation["result"], "cancelled")
+            self.assertTrue(delegation["observed"])
+
+    def test_the_status_surfaces_cancellation_apart_from_a_blocker(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            run_id = self._cancelled_run(paths)
+
+            status = summarize_delegated_coding_status(paths, run_id)
+            self.assertEqual(status["next_action"], "surface_executor_cancellation")
+            self.assertEqual(status["execution"]["status"], "cancelled")
+            self.assertIn("was cancelled", status["safe_summary"])
+            self.assertNotIn("blocked", status["safe_summary"])
+
+            reported = report_codex_delegation_lifecycle(paths, run_id)
+            self.assertEqual(reported["lifecycle_status"], "cancelled")
+            self.assertFalse(reported["can_report_completion"])
+            self.assertIn("re-dispatched or resumed", reported["blocking_reason"])
+
+    def test_a_cancelled_run_cannot_record_verification(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            run_id = self._cancelled_run(paths)
+
+            with self.assertRaises(CodingLifecycleError):
+                record_codex_verification(paths, run_id)
+
+    def test_the_lifecycle_projection_says_cancelled_and_nothing_else(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            run_id = self._cancelled_run(paths)
+
+            lifecycle = show_run(paths, run_id)["lifecycle"]
+            self.assertTrue(lifecycle["cancelled"])
+            self.assertFalse(lifecycle["blocked"])
+            self.assertFalse(lifecycle["failed"])
+            self.assertFalse(lifecycle["verification_observed"])
+            self.assertFalse(lifecycle["merge_observed"])
+
+    def test_cancellation_satisfies_no_evidence_gate_above_dispatch(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            run_id = self._cancelled_run(paths)
+
+            allowed = allowed_runtime_claims(summarize_delegated_coding_status(paths, run_id), validation_failed=False)
+            self.assertIn(Claim.EXECUTOR_DISPATCHED, allowed)
+            for claim in (
+                Claim.EXECUTION_OBSERVED,
+                Claim.VERIFICATION_OBSERVED,
+                Claim.REVIEW_OBSERVED,
+                Claim.CI_OBSERVED,
+                Claim.MERGE_READY,
+                Claim.MERGED,
+            ):
+                with self.subTest(claim=claim.value):
+                    self.assertNotIn(claim, allowed)
+
+    def test_a_blocked_result_still_reaches_the_execution_rung(self) -> None:
+        """The negative above is about cancellation, not a new rule for every non-success."""
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            started = start_codex_delegation_lifecycle(paths, "diagnose installation health")
+            run_id = started["run"]["run_id"]
+            record_codex_dispatch(paths, run_id)
+            record_codex_result(paths, run_id, result="blocked", evidence_refs=["codex-log"])
+
+            allowed = allowed_runtime_claims(summarize_delegated_coding_status(paths, run_id), validation_failed=False)
+            self.assertIn(Claim.EXECUTION_OBSERVED, allowed)
+
+
+class CancelledProgressEventTests(unittest.TestCase):
+    def _binding(self, paths) -> dict:
+        binding = build_progress_binding(
+            target_type="run",
+            target_id="20260101T000000-run",
+            executor_profile="codex",
+        )
+        return write_progress_binding(paths, binding)
+
+    def test_executor_cancelled_is_terminal_and_closing(self) -> None:
+        self.assertIn("executor_cancelled", PROGRESS_EVENT_TYPES)
+        self.assertIn("executor_cancelled", TERMINAL_EVENT_TYPES)
+        self.assertIn("executor_cancelled", CLOSING_EVENT_TYPES)
+
+    def test_the_wait_contract_and_the_progress_contract_agree(self) -> None:
+        outcome = wait_outcome_for_progress_event("executor_cancelled")
+        self.assertEqual(outcome, "cancelled")
+        self.assertIn(outcome, WAIT_TERMINAL_STATES)
+        strategy = build_execution_wait_strategy(
+            work_kind="executor_dispatch",
+            expected_duration_class="long",
+            handle_kind="process",
+            handle_ref="job-1",
+            condition="the dispatched unit reports a terminal result",
+            host_capabilities=("background_completion_notification",),
+            deadline_seconds=60,
+            cancellation_path="terminate the dispatched unit process group",
+        )
+        closed = consume_wait_completion(arm_wait_binding(strategy), outcome=outcome)
+        self.assertEqual(closed["binding_state"], "cancelled")
+        self.assertNotIn("unmapped_source_outcome", closed)
+
+    def test_a_host_observed_termination_infers_cancellation_not_failure(self) -> None:
+        for process_status in ("cancelled", "terminated", "interrupted", "signal_terminated", "killed"):
+            with self.subTest(process_status=process_status):
+                signal = build_safe_progress_signal(executor_profile="codex", process_status=process_status)
+                self.assertEqual(infer_progress_event_type(signal), "executor_cancelled")
+
+    def test_an_executor_narrating_its_own_cancellation_is_not_believed(self) -> None:
+        """A cancellation the host did not observe is narration, and narration ends nothing."""
+        signal = build_safe_progress_signal(
+            executor_profile="codex",
+            profile_progress_summary={"status": "", "latest_progress_event_type": "executor_cancelled"},
+        )
+        self.assertNotEqual(infer_progress_event_type(signal), "executor_cancelled")
+
+    def test_the_event_closes_the_binding_so_it_is_never_stale_afterwards(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            binding = self._binding(paths)
+            signal = build_safe_progress_signal(executor_profile="codex", process_status="cancelled")
+
+            observation = observe_executor_progress(paths, binding, signal)
+
+            self.assertEqual(observation["event"]["event_type"], "executor_cancelled")
+            self.assertEqual(observation["binding"]["state"], "closed")
+            stored = read_progress_binding(paths, "run", "20260101T000000-run")
+            self.assertEqual(stored["state"], "closed")
+
+
+class CancelledWrapperSessionTests(unittest.TestCase):
+    """Recording a cancellation through the wrapper session, for every executor profile."""
+
+    def _session(self, paths, profile: str) -> str:
+        started = create_or_resume_wrapper_session(paths, "risky refactor", source="discord")
+        session_id = str(started["session"]["session_id"])
+        record_plan_decision(paths, session_id, "accept")
+        select_wrapper_session_executor(paths, session_id, profile)
+        prepare_wrapper_session_handoff(paths, session_id, "risky refactor")
+        open_executor_session(
+            paths,
+            session_id,
+            observed=True,
+            external_session_ref="thread-1",
+            evidence_refs=["discord-button"],
+        )
+        return session_id
+
+    def test_every_supported_executor_profile_can_record_a_cancellation(self) -> None:
+        for profile in EXECUTOR_PROFILES:
+            with self.subTest(profile=profile), TemporaryDirectory() as tmp:
+                paths = _paths(tmp)
+                session_id = self._session(paths, profile)
+
+                recorded = record_executor_session_result(
+                    paths, session_id, result="cancelled", evidence_refs=["host:sigterm"]
+                )
+
+                status = recorded["status"]
+                self.assertEqual(status["result"], "cancelled")
+                self.assertEqual(status["coding_agent"], f"cancelled({profile})")
+                self.assertEqual(status["verification"], "not_requested")
+                self.assertEqual(recorded["executor_session"]["status"], "cancelled")
+
+    def test_the_cancellation_closes_the_progress_binding_and_names_its_own_event(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            session_id = self._session(paths, "codex")
+
+            recorded = record_executor_session_result(
+                paths, session_id, result="cancelled", evidence_refs=["host:sigterm"]
+            )
+
+            progress = recorded["status"]["executor_progress"]
+            self.assertEqual(progress["state"], "closed")
+            self.assertEqual(progress["latest_event"]["event_type"], "executor_cancelled")
+
+    def test_the_status_card_shows_cancelled_apart_from_blocked_and_failed(self) -> None:
+        card = build_executor_session_status_card({"result": "cancelled", "verification": "not_requested"})
+        result_step = next(step for step in card["steps"] if step["id"] == "result")
+
+        self.assertEqual(result_step["state"], "cancelled")
+        self.assertIn(result_step["state"], STATUS_CARD_STEP_STATES)
+        self.assertEqual(card["severity"], "cancelled")
+
+        blocked = build_executor_session_status_card({"result": "blocked", "verification": "not_requested"})
+        self.assertEqual(
+            next(step for step in blocked["steps"] if step["id"] == "result")["state"], "blocked"
+        )
+
+    def test_an_unsupported_result_word_is_still_refused(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            session_id = self._session(paths, "codex")
+
+            with self.assertRaises(ExecutorSessionError):
+                record_executor_session_result(paths, session_id, result="cancel_requested")
+
+
+class CancelledCliSurfaceTests(unittest.TestCase):
+    """The recorded vocabulary and the offered vocabulary are the same vocabulary.
+
+    An integration that can only submit `failed` or `blocked` for a cancelled
+    run has to relabel it, which is the coercion this whole change removes.
+    """
+
+    def _choices(self, path: tuple[str, ...], option: str) -> tuple[str, ...]:
+        parser = build_parser()
+        for name in path:
+            actions = [
+                action
+                for action in parser._actions  # noqa: SLF001 - argparse has no public subparser lookup
+                if isinstance(action, argparse._SubParsersAction)  # noqa: SLF001
+            ]
+            parser = next(sub for action in actions for key, sub in action.choices.items() if key == name)
+        target = next(action for action in parser._actions if option in action.option_strings)  # noqa: SLF001
+        return tuple(target.choices or ())
+
+    def test_the_result_recording_commands_offer_cancelled(self) -> None:
+        for path, option in (
+            (("coding", "lifecycle", "result"), "--result"),
+            (("coding", "lifecycle", "verify"), "--completion-status"),
+            (("chat", "session", "record-executor"), "--result"),
+            (("runtime", "wrapper"), "--completion-status"),
+            (("runtime", "delegate"), "--result"),
+            (("runtime", "record"), "--status"),
+        ):
+            with self.subTest(command=" ".join(path)):
+                self.assertIn("cancelled", self._choices(path, option))
+
+
+class CancelledHudProjectionTests(unittest.TestCase):
+    def test_a_cancelled_executor_row_is_neither_running_nor_blocked(self) -> None:
+        summary = _hud_subagent_summary(
+            {
+                "active_executors": [
+                    {
+                        "target_id": "run-a",
+                        "target_type": "run",
+                        "executor_profile": "codex",
+                        "latest_event": {"event_type": "executor_cancelled", "status": "cancelled", "summary": "s"},
+                    },
+                    {
+                        "target_id": "run-b",
+                        "target_type": "run",
+                        "executor_profile": "codex",
+                        "latest_event": {"event_type": "executor_blocked", "status": "blocked", "summary": "s"},
+                    },
+                ],
+                "stale_executors": [],
+                "latest_progress_events": [],
+            }
+        )
+
+        self.assertEqual(summary["cancelled"], 1)
+        self.assertEqual(summary["blocked"], 1)
+        self.assertEqual(summary["running"], 0)
+        states = {row["task_id"]: row["state"] for row in summary["rows"]}
+        self.assertEqual(sorted(states.values()), ["blocked", "cancelled"])
+
+
+class CancelledExportTests(unittest.TestCase):
+    def test_a_redacted_export_carries_the_cancellation_as_allowlisted_metadata(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            started = start_codex_delegation_lifecycle(paths, "diagnose installation health")
+            run_id = started["run"]["run_id"]
+            record_codex_dispatch(paths, run_id)
+            record_codex_result(paths, run_id, result="cancelled", evidence_refs=["host:sigterm"])
+
+            payload = export_runtime(paths, redacted=True, run_id=run_id)
+            text = json.dumps(payload)
+
+            self.assertIn("cancelled", text)
+            delegation = payload["runs"][0]["delegation"]
+            self.assertEqual(delegation["result"], "cancelled")
+            self.assertEqual(
+                sorted(delegation),
+                [
+                    "evidence_refs",
+                    "message",
+                    "observed",
+                    "participants",
+                    "requested",
+                    "result",
+                    "schema_version",
+                    "updated_at",
+                ],
+            )
+            for forbidden in ("stdout", "stderr", "transcript", "raw_logs", "prompt_body"):
+                with self.subTest(forbidden=forbidden):
+                    self.assertNotIn(f'"{forbidden}"', text)
+
+
+class CancelledContinuityTests(unittest.TestCase):
+    def test_the_journey_state_names_cancellation_instead_of_invalid_evidence(self) -> None:
+        state = journey_state({"execution": {"observed": True, "status": "cancelled"}}, {}, {})
+        self.assertEqual(state, "executor_cancelled")
+
+    def test_a_cancelled_session_is_not_resumable_as_a_conversation(self) -> None:
+        status = resume_status_from_evidence(
+            {
+                "runtime_status": {"execution": {"observed": True, "status": "cancelled"}},
+                "runtime_observation": {},
+                "executor_status": {"result": "cancelled"},
+                "session_status": "handoff_prepared",
+            }
+        )
+        self.assertEqual(status, "blocked")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fanout_cancellation_states.py
+++ b/tests/test_fanout_cancellation_states.py
@@ -1,0 +1,253 @@
+"""Fanout cancellation: four states, not one word and not `failed` (issue #1360).
+
+A stopped batch used to answer with `interrupted` for everything it had not
+finished and `failed` for the unit it had killed. Those are four different facts
+an operator acts on differently, and this module holds them apart: the unit that
+was running, the one nobody heard back from, the ones that never spawned, and
+the ones held behind a cancelled dependency.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from omh.coding.fanout import build_fanout_contract
+from omh.coding.fanout_artifacts import write_fanout_contract
+from omh.coding.fanout_dispatch import (
+    CANCELLED_UNIT_STATUSES,
+    UNIT_STATUS_BLOCKED_BY_CANCELLED_DEPENDENCY,
+    UNIT_STATUS_CANCELLED,
+    UNIT_STATUS_CANCELLED_OUTCOME_UNKNOWN,
+    UNIT_STATUS_NOT_STARTED_CANCELLED,
+    _blocked,
+    _cancellation_rollup,
+    _dependency_failed,
+    _dependency_satisfied,
+    dispatch_fanout,
+)
+from omh.coding.fanout_journal import (
+    RESUME_HOLD_REPLAY_UNSAFE,
+    RESUME_RERUN_CANCELLED,
+    RESUME_RERUN_NOT_ATTEMPTED,
+    RESUME_UNSKIP_DEPENDENT,
+    TERMINAL_CANCELLED,
+    TERMINAL_NOT_ATTEMPTED,
+    TERMINAL_SKIPPED_BY_DEPENDENCY,
+    plan_fanout_resume,
+    build_fanout_run_journal,
+    journal_unit_entry,
+)
+from omh.system.paths import OmhPaths
+
+
+_GOAL = "cancellation drill"
+_UNITS = [
+    {"unit_id": "one", "title": "One", "owner": "codex", "file_scope": ["src/one/"]},
+    {"unit_id": "two", "title": "Two", "owner": "codex", "file_scope": ["src/two/"]},
+]
+
+
+def _paths(tmp: str) -> OmhPaths:
+    root = Path(tmp)
+    return OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+
+
+def _make_repo(root: Path) -> tuple[Path, str]:
+    repo = root / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "seed.txt"], cwd=str(repo), check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init"],
+        cwd=str(repo),
+        check=True,
+    )
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
+    ).stdout.strip()
+    return repo, sha
+
+
+def _ready(paths, profile, **kwargs):
+    return {"status": "ready", "profile": profile}
+
+
+class CancelledDependencyTests(unittest.TestCase):
+    def test_a_cancelled_dependency_is_never_a_satisfied_prerequisite(self) -> None:
+        for status in sorted(CANCELLED_UNIT_STATUSES):
+            with self.subTest(status=status):
+                self.assertFalse(_dependency_satisfied({"status": status}))
+                self.assertTrue(_dependency_failed({"status": status}))
+
+    def test_a_dependent_of_a_cancelled_unit_says_so_in_its_own_status(self) -> None:
+        unit = {"unit_id": "two", "depends_on": ["one"]}
+        entry = _blocked(unit, {"one": {"status": UNIT_STATUS_CANCELLED}})
+
+        self.assertEqual(entry["status"], UNIT_STATUS_BLOCKED_BY_CANCELLED_DEPENDENCY)
+        self.assertEqual(entry["blocked_on"], ["one"])
+        self.assertFalse(entry["integration_ready"])
+
+    def test_a_dependent_of_a_failed_unit_keeps_the_ordinary_blocked_status(self) -> None:
+        """The new status is about cancellation only; a failure still reads as one."""
+        entry = _blocked({"unit_id": "two", "depends_on": ["one"]}, {"one": {"status": "failed"}})
+
+        self.assertEqual(entry["status"], "blocked_by_dependency")
+
+
+class CancellationRollupTests(unittest.TestCase):
+    def test_the_rollup_sorts_every_unit_into_exactly_one_bucket(self) -> None:
+        rollup = _cancellation_rollup(
+            [
+                {"unit_id": "a", "status": UNIT_STATUS_CANCELLED},
+                {"unit_id": "b", "status": UNIT_STATUS_CANCELLED_OUTCOME_UNKNOWN},
+                {"unit_id": "c", "status": UNIT_STATUS_NOT_STARTED_CANCELLED},
+                {"unit_id": "d", "status": UNIT_STATUS_BLOCKED_BY_CANCELLED_DEPENDENCY},
+                {"unit_id": "e", "status": "completed"},
+            ]
+        )
+
+        self.assertEqual(rollup["cancelled"], ["a"])
+        self.assertEqual(rollup["outcome_unknown"], ["b"])
+        self.assertEqual(rollup["never_started"], ["c"])
+        self.assertEqual(rollup["blocked_by_cancelled_dependency"], ["d"])
+
+    def test_the_rollup_is_metadata_only(self) -> None:
+        rollup = _cancellation_rollup([{"unit_id": "a", "status": UNIT_STATUS_CANCELLED, "output_tail": "secret"}])
+
+        self.assertEqual(
+            sorted(rollup),
+            ["blocked_by_cancelled_dependency", "cancelled", "claim_boundary", "never_started", "outcome_unknown"],
+        )
+        self.assertNotIn("secret", str(rollup))
+        self.assertIn("not execution, verification", rollup["claim_boundary"])
+
+
+class CancelledJournalTests(unittest.TestCase):
+    def test_a_terminated_unit_journals_as_cancelled_with_no_failure_class(self) -> None:
+        row = journal_unit_entry(
+            {"unit_id": "a", "owner": "codex", "status": UNIT_STATUS_CANCELLED, "exit_code": -15}
+        )
+
+        self.assertEqual(row["terminal_state"], TERMINAL_CANCELLED)
+        self.assertEqual(row["failure_class"], "")
+        self.assertEqual(row["failure_label"], "")
+
+    def test_the_other_three_cancellation_states_journal_distinctly(self) -> None:
+        cases = {
+            UNIT_STATUS_CANCELLED_OUTCOME_UNKNOWN: TERMINAL_CANCELLED,
+            UNIT_STATUS_NOT_STARTED_CANCELLED: TERMINAL_NOT_ATTEMPTED,
+            UNIT_STATUS_BLOCKED_BY_CANCELLED_DEPENDENCY: TERMINAL_SKIPPED_BY_DEPENDENCY,
+        }
+        for status, expected in cases.items():
+            with self.subTest(status=status):
+                row = journal_unit_entry({"unit_id": "a", "owner": "codex", "status": status})
+                self.assertEqual(row["terminal_state"], expected)
+
+    def test_resume_is_deterministic_across_the_cancellation_states(self) -> None:
+        summary = {
+            "fanout_id": "f1",
+            "merge_order": ["a", "b", "c"],
+            "units": [
+                # A probe that measured a clean worktree is what makes a
+                # terminated unit re-dispatchable; without one it is held below.
+                {
+                    "unit_id": "a",
+                    "owner": "codex",
+                    "status": UNIT_STATUS_CANCELLED,
+                    "exit_code": -15,
+                    "recovery": {"outcome": "no_changes"},
+                },
+                {"unit_id": "b", "owner": "codex", "status": UNIT_STATUS_NOT_STARTED_CANCELLED},
+                {
+                    "unit_id": "c",
+                    "owner": "codex",
+                    "status": UNIT_STATUS_BLOCKED_BY_CANCELLED_DEPENDENCY,
+                    "blocked_on": ["a"],
+                },
+            ],
+        }
+        journal = build_fanout_run_journal(summary)
+        order = ["a", "b", "c"]
+        depends_on = {"a": [], "b": [], "c": ["a"]}
+
+        plan = plan_fanout_resume(journal, order=order, depends_on=depends_on)
+        actions = {str(row["unit_id"]): str(row["action"]) for row in plan["decisions"]}
+
+        self.assertEqual(actions["a"], RESUME_RERUN_CANCELLED)
+        self.assertEqual(actions["b"], RESUME_RERUN_NOT_ATTEMPTED)
+        self.assertEqual(actions["c"], RESUME_UNSKIP_DEPENDENT)
+        # Re-planning the same journal gives the same answer.
+        self.assertEqual(
+            plan["decisions"],
+            plan_fanout_resume(journal, order=order, depends_on=depends_on)["decisions"],
+        )
+
+    def test_a_terminated_unit_whose_worktree_nobody_measured_is_held(self) -> None:
+        """Fail-closed, exactly as for a failure: a resume never rebuilds over unmeasured work.
+
+        An interrupted batch skips the recovery probe entirely, so this is the
+        state a real cancelled unit is in, and holding it is the answer.
+        """
+        summary = {
+            "fanout_id": "f1",
+            "merge_order": ["a"],
+            "units": [{"unit_id": "a", "owner": "codex", "status": UNIT_STATUS_CANCELLED, "exit_code": -15}],
+        }
+        journal = build_fanout_run_journal(summary)
+
+        plan = plan_fanout_resume(journal, order=["a"], depends_on={"a": []})
+
+        self.assertEqual(str(plan["decisions"][0]["action"]), RESUME_HOLD_REPLAY_UNSAFE)
+        self.assertEqual(str(plan["decisions"][0]["prior_state"]), TERMINAL_CANCELLED)
+
+
+class InterruptedRunningUnitTests(unittest.TestCase):
+    def setUp(self) -> None:
+        from omh.coding.fanout_dispatch import _INTERRUPT_FLAG
+
+        _INTERRUPT_FLAG.clear()
+
+    def test_a_signal_killed_unit_records_cancelled_rather_than_a_model_failure(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            root = Path(tmp)
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+            spawned: list[str] = []
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                spawned.append(argv[0])
+                if len(spawned) == 1:
+                    # The group terminator's signature: a negative exit code.
+                    return subprocess.CompletedProcess(list(argv), -15, "", "")
+                raise KeyboardInterrupt
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                concurrency=1,
+                runner=runner,
+                readiness=_ready,
+            )
+
+            statuses = {entry["unit_id"]: entry["status"] for entry in summary["units"]}
+            self.assertEqual(statuses["one"], UNIT_STATUS_CANCELLED)
+            killed = next(entry for entry in summary["units"] if entry["unit_id"] == "one")
+            self.assertTrue(killed["interrupted"])
+            self.assertNotIn("failure_kind", killed)
+            self.assertFalse(killed["process_succeeded"])
+            self.assertFalse(killed["integration_ready"])
+            self.assertEqual(summary["cancellation"]["cancelled"], ["one"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fanout_signal_safety.py
+++ b/tests/test_fanout_signal_safety.py
@@ -268,7 +268,16 @@ class InterruptedDispatchTests(unittest.TestCase):
             # Both units surface in the rollup — nothing silently vanishes as
             # if it were never planned.
             self.assertEqual(set(statuses), {"one", "two"})
-            self.assertIn("interrupted", set(statuses.values()))
+            # A unit a cancelled batch never spawned says exactly that. It is
+            # not `failed` (nothing ran) and not the older undifferentiated
+            # `interrupted` (which said nothing about whether a process had
+            # started), so a resume knows there is nothing to preserve.
+            self.assertEqual(set(statuses.values()), {"not_started_cancelled"})
+            rollup = summary["cancellation"]
+            self.assertEqual(sorted(rollup["never_started"]), ["one", "two"])
+            self.assertEqual(rollup["cancelled"], [])
+            self.assertEqual(rollup["outcome_unknown"], [])
+            self.assertEqual(rollup["blocked_by_cancelled_dependency"], [])
 
     def test_system_exit_re_raises_after_the_summary_is_written(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_owner_progress_normalization.py
+++ b/tests/test_owner_progress_normalization.py
@@ -157,8 +157,8 @@ class NormalizationRecordShapeTests(unittest.TestCase):
     def test_the_normalized_vocabulary_is_the_shipped_one_plus_the_unmapped_value(self) -> None:
         self.assertEqual(PROGRESS_EVENT_TYPES, NORMALIZED_PROGRESS_EVENT_TYPES)
         self.assertEqual(NORMALIZED_PROGRESS_EVENT_TYPES[-1], UNMAPPED_NORMALIZED_EVENT)
-        self.assertEqual(len(NORMALIZED_PROGRESS_EVENT_TYPES), 13)
-        self.assertEqual(len(set(NORMALIZED_PROGRESS_EVENT_TYPES)), 13)
+        self.assertEqual(len(NORMALIZED_PROGRESS_EVENT_TYPES), 14)
+        self.assertEqual(len(set(NORMALIZED_PROGRESS_EVENT_TYPES)), 14)
 
     def test_the_unmapped_value_never_ends_a_binding(self) -> None:
         """An unrecognized word settles nothing, so it must not close or exempt."""


### PR DESCRIPTION
## Feature Report

Resolves #1360.

### What Changed

- `cancelled` is a first-class observed terminal result. It joins `RUN_STATUSES`, `DELEGATION_RESULTS`, `OBSERVED_RESULTS`, `WRAPPER_COMPLETION_STATUSES` (`src/runtime/records.py`), the executor-session statuses and results (`src/wrapper/executor_sessions.py`), and the harness progress ladder (`src/quality/harness_quality.py`). The work-report and runtime-observation vocabularies already carried it.
- New `executor_cancelled` progress event (`src/coding/executor_progress.py`). It is terminal and closing: the binding closes immediately, so a cancelled target is never later shown as active or stale. Only a host-observed process outcome (interrupted, killed, signal-terminated, terminated) corroborates it; an executor's own narration never reaches it, the same rule that governs every other end-state word. One shared table maps it onto the `cancelled` terminal state of the wait contract from #1366 so the two cannot disagree.
- Projections keep cancellation apart from completed, blocked, and failed: the legacy lifecycle projection reads `cancelled` from the record instead of hard-coding false; the delegated status answers `surface_executor_cancellation` (a re-dispatch decision) rather than a blocker to clear; the HUD counts and renders a cancelled row separately; the status card, mission control, continuity journey state, briefing, and run health each gained their own cancelled answer.
- No evidence gate is satisfied by cancellation. The runtime claim ladder stops at `executor_dispatched`, so execution, verification, review, CI, merge-readiness, and merge are all blocked; the wrapper refuses to record verification over a cancelled result. A negative test confirms a `blocked` result still reaches the execution rung, so this is a rule about cancellation only.
- CLI and wrapper actions (`omh chat`, `omh runtime`, `omh coding`) accept `cancelled` so integrations never file a stopped run as failed or blocked. Forged or unobserved cancellation is refused by the existing observed-evidence validation.
- Fanout dispatch distinguishes four facts an operator acts on differently:

| Status | Meaning | Journal terminal state | Resume |
| --- | --- | --- | --- |
| `cancelled` | process running, group terminated | `cancelled` | rerun if measured clean, else held with side effect named |
| `cancelled_outcome_unknown` | in flight, no return inside terminate grace | `cancelled` | same |
| `not_started_cancelled` | never spawned | `not_attempted` | rerun |
| `blocked_by_cancelled_dependency` | held behind a cancelled unit | `skipped_by_dependency` | unskip |

  A cancelled dependency is never a satisfied prerequisite. A terminated unit carries no failure classification. The dispatch summary gains a metadata-only `cancellation` rollup with a claim boundary.

### Why This Exists

An observed executor cancellation had nowhere to go. A user stop, host cancellation, or killed fanout unit had to be filed as a failure of the work, as a blocker that would clear, or left looking active until stale. Each sends the next reader somewhere useless: hunting a defect that does not exist, waiting for a condition that will never change, or watching a row that will never move. Closed issue #808 already required user-facing status to distinguish the four.

### User / Operator Impact

- One truthful `cancelled` state across runtime records, wrapper sessions, progress events, HUD/status projections, fanout summaries, and redacted exports, with a recovery action that makes retry/resume explicit.
- Cancelling a prepared plan before execution stays workflow state; only an observed termination becomes `cancelled`.

### How It Works

- **Compatibility**: additive enum only. No schema version bump, no migration, no field added or renamed. A test builds and validates every pre-existing result and completion status unchanged. The direction that needed care is a newer record read by an older plugin bundle (installed and updated separately): that reader now decides "has this target ended" from the record's `observed` flag rather than matching against a list it knows, so an unknown terminal word degrades to terminal-with-unknown-kind, never to "still running". Documented in `docs/ARCHITECTURE.md`.
- **Fanout interruption**: the existing interrupt path already reaps every live unit group through the dispatcher's own process-tree code; no new process-control layer. Operator-initiated cancel is recorded from the observed exit, not initiated by this change.
- **A latent bug fixed on the way**: `hermes_harness._harness_status` could already return `cancelled` but its own validator rejected the value, so the harness failed validation the moment a run was cancelled.
- `EXECUTOR_SESSION_OBSERVED_RESULTS` replaces three hand-written three-member sets, and `executor_progress` imports `OBSERVED_RESULTS` instead of restating it, so a fifth terminal result cannot appear in one place and leave a binding open elsewhere.

### Files And Contracts Touched

29 files. Contracts: `src/runtime/{records,claims,artifacts,run_health}.py`, `src/coding/{executor_progress,coding_delegation,fanout_dispatch,fanout_journal,hermes_harness,owner_progress_normalization}.py`, `src/wrapper/{executor_sessions,lifecycle,contract,continuity_state,mission_control,briefing}.py`, `src/plugin_bundle/omh/runtime_reader.py`, `src/commands/{chat,coding,runtime}.py`, `src/quality/harness_quality.py`, `src/evidence/labels.py`, `src/routing/action_copy.py`, `src/maintenance/release.py`, `docs/ARCHITECTURE.md`. Tests: `tests/test_cancelled_terminal_state.py` (new), `tests/test_fanout_cancellation_states.py` (new), `tests/test_fanout_signal_safety.py`, `tests/test_owner_progress_normalization.py` (event-type count moved by one).

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate` (77 harnesses / 124 skills)
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] hermes-smoke with command smoke
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `docs ulw-inventory --check`, `docs ulw-site --check`, `release drift` (no drift, 18 checks)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: no live executor was cancelled

### Observed Evidence

- `tests.test_cancelled_terminal_state tests.test_fanout_cancellation_states tests.test_fanout_signal_safety tests.test_owner_progress_normalization tests.test_execution_wait_strategy tests.test_hud tests.test_release_smoke tests.test_cli`: 634 tests OK, rerun after rebase onto current main.
- Full suite in the worktree: 9591 tests, 28 pre-existing sandbox failures confined to `tests/test_cross_harness_adapters.py` and `tests/test_cross_harness_adapter_security.py`, confirmed identical on a stash of the base (the adapter sandbox refuses the nested worktree path). CI runs from a normal checkout.

### Not Tested / Not Applicable

- No live executor was cancelled. Cancellation paths are exercised through injected runners and constructed records, never against a real agent CLI.
- The plugin bundle's degradation on an unknown terminal result is tested against the shipped reader in-process, not against an older installed bundle.

## Risk

- Broad scope: five vocabularies, one new progress event, and projections across runtime, wrapper, HUD, fanout, and exports. Mitigated by the additive-only compatibility rule and by importing one shared vocabulary instead of restating it.
- OMH records an observed cancellation; it never claims it can terminate an external executor. Process control stays adapter- and host-specific.

## Compatibility / Rollout

- Old records validate byte-identically. Plugin bundle copies pick up the reader change through `omh update`; until then an older reader degrades a `cancelled` record to terminal-with-unknown-kind.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- A live cancellation of a fanout unit and of a Hermes-child dispatch, to turn the observed-cancellation paths from fixture-proven into observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ6enDfqFG9ft8yCL2d5P5
