### PR TITLE
feat(coding): record delegation continuity as an OMH goal-ledger obligation, never in the product tree

### DIFF
--- a/src/coding/coding_delegation.py
+++ b/src/coding/coding_delegation.py
@@ -76,6 +76,7 @@ from .context_safety import (
 from ..harness_quality import with_wrapper_actions
 from ..quality.specialist_work import build_specialist_work_quality_contract
 from ..quality.verification_tiering import sensitive_path_escalation
+from ..system.paths import CONTINUITY_FORBIDDEN_TARGETS
 from ..system.security_posture import STRICT_POSTURE, resolve_security_posture
 from ..ingress import CHAT_SOURCES, extract_message_text, extract_source_metadata
 from ..isolation import build_isolation_plan
@@ -103,6 +104,7 @@ from ..skills.catalog_types import omh_skill_display_name
 
 
 SCHEMA_VERSION = "coding_delegation/v1"
+DELEGATION_CONTINUITY_SCHEMA_VERSION = "omh_delegation_continuity/v1"
 DELEGATION_ACTIONS = ("delegate", "clarify", "fallback")
 DELEGATION_POLICY_SCHEMA_VERSION = "coding_delegation_policy/v1"
 INLINE_CODING_POLICY_STATEMENT = (
@@ -877,6 +879,7 @@ def _build_coding_delegation_payload_native(
     _attach_specialist_work_quality(payload, specialist_work_quality)
     _attach_role_context_pack(payload)
     _attach_task_authority_envelope(payload, authority_envelope)
+    _attach_delegation_continuity(payload, authority_envelope, message=message)
     _attach_governance_and_family(payload, governance, family_template, quality_harness)
     payload["harness_quality"] = _public_harness_quality(
         harness,
@@ -1135,6 +1138,80 @@ def _attach_governance_and_family(
             handoff["product_family_template"] = family_template
         if quality_harness:
             handoff["product_quality_harness"] = quality_harness
+
+
+def _delegation_continuity_goal_slug(message: str, obligation: str) -> str:
+    """A deterministic, offline goal-ledger slug for this obligation.
+
+    Derived from the obligation and the message so the same delegation always
+    proposes the same goal id -- the command layer creates the ledger under it,
+    or links an existing one, without minting a divergent id. No clock and no
+    secrets, so the prepared block stays byte-identical across builds. The
+    12-hex digest exposes no recoverable request text.
+    """
+    digest = hashlib.sha256(f"{obligation}\x00{message}".encode("utf-8")).hexdigest()[:12]
+    return f"coding-{obligation}-{digest}"
+
+
+def _attach_delegation_continuity(
+    payload: dict[str, object],
+    authority_envelope: Mapping[str, object],
+    *,
+    message: str,
+) -> None:
+    """Prepare (never write) the delegation-continuity block for a merge/deploy obligation.
+
+    The outstanding obligation is OMH-owned durable state. This builder only
+    prepares the metadata that names where the command layer must record it -- a
+    goal ledger in the OMH state root -- and never writes anything itself, so the
+    core stays offline. The obligation is read back from Goal 1's already-computed
+    `post_completion_directive` on the authority envelope; it is never recomputed
+    here. The key is omitted entirely when the user gave no explicit merge/deploy
+    directive (a denied run carries none), so every non-merge payload stays
+    byte-identical.
+
+    A delegated subtask completing is not the parent obligation completing:
+    `subtask_is_not_goal` states that, and the durable record's required
+    criterion keeps the goal open until the merge/deploy is observed. Continuity
+    lives only in the OMH goal ledger; `write_location_policy` forbids the
+    product-repo runtime-evidence dirs a prior agent hand-wrote markdown into.
+    """
+    directive = authority_envelope.get("post_completion_directive")
+    if not isinstance(directive, Mapping):
+        return
+    obligation = str(directive.get("action", "")).strip()
+    if obligation not in ("merge", "deploy"):
+        return
+    slug = _delegation_continuity_goal_slug(message, obligation)
+    payload["delegation_continuity"] = {
+        "schema_version": DELEGATION_CONTINUITY_SCHEMA_VERSION,
+        "obligation": obligation,
+        # A directive only rides a non-denied envelope, so the obligation is an
+        # active (open) goal here; a blocked ledger reads as "hold", set later by
+        # the command layer when it records a blocker.
+        "overall_outcome_state": "open",
+        "subtask_is_not_goal": True,
+        "durable_record": {
+            "kind": "goal_ledger",
+            # `<omh_home>` is a placeholder the offline builder cannot resolve;
+            # the command layer resolves the real state root via
+            # `continuity_write_target` before it writes.
+            "goal_ledger_path": f"<omh_home>/goals/{slug}/goal.json",
+            "goal_id": slug,
+            "required_criterion": (
+                f"{obligation} observed (external-effect {obligation} receipt)"
+            ),
+        },
+        "write_location_policy": {
+            "state_root": "<omh_home>",
+            "handoff_family": "goals",
+            "forbidden_targets": list(CONTINUITY_FORBIDDEN_TARGETS),
+            "note": (
+                "OMH delegation continuity lives in the OMH state root only. "
+                "Never write continuity into a product repo's runtime-evidence dirs."
+            ),
+        },
+    }
 
 
 def _attach_task_authority_envelope(payload: dict[str, object], envelope: dict[str, object]) -> None:

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -48,8 +48,14 @@ from ..routing.intent import META_OR_FEEDBACK_INTENTS, classify_workflow_intent
 from ..routing.localization import normalized_phrase, routing_tokens
 from ..runtime.artifacts import append_journal_observation, create_prepared_coding_delegation_run, write_coding_delegation
 from ..runtime.records import OBSERVED_RESULTS, WRAPPER_COMPLETION_STATUSES
-from ..system.paths import OmhPaths
+from ..system.paths import OmhPaths, continuity_write_target
 from ..workflows.blocked_work_records import mint_blocked_work_record
+from ..workflows.goal_ledger import (
+    create_goal_ledger,
+    goal_ledger_path,
+    merge_obligation_criterion,
+    record_goal_checkpoint,
+)
 from ..workflows.role_context_packs import validate_accepted_role_context, write_role_context_pack
 from ..wrapper.lifecycle import (
     CodingLifecycleError,
@@ -250,6 +256,13 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
         # to outlive the turn was the one that left nothing behind. The store is
         # runtime-wide precisely so it can hold a decision that has no run.
         payload["blocked_work_record"] = _record_coding_decision(paths, payload)
+        # An explicit merge/deploy obligation is OMH-owned durable state: record
+        # it in the OMH goal ledger here, beside the blocked-work decision and on
+        # the same unconditional path, so the obligation outlives the turn even
+        # when no run is created. A delegated subtask completing is not this
+        # obligation completing; the required merge criterion keeps the goal open
+        # until the merge/deploy is observed.
+        payload["delegation_continuity_record"] = _record_delegation_continuity(paths, payload)
         runtime_skip_reason = ""
         if args.record:
             runtime_skip_reason = _coding_delegate_record_readiness_skip_reason(
@@ -315,6 +328,11 @@ def cmd_coding_delegate(args: argparse.Namespace) -> int:
                     },
                 )
             payload["runtime"] = {"run": run, "coding_delegation": record}
+            # The delegated run is a linked subtask of the obligation, never the
+            # obligation itself: record it as an in_progress checkpoint so the
+            # goal can be reconciled against it after resume without upgrading a
+            # subtask's completion into the parent goal's.
+            _link_delegation_continuity_run(paths, payload, str(run["run_id"]))
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         raise OmhError(str(exc)) from exc
     _print_json(payload)
@@ -347,6 +365,95 @@ def _record_coding_decision(paths: OmhPaths, payload: dict[str, object]) -> dict
         safety_profile_revision=str(decision.get("safety_profile_revision", "")),
         class_shape=[str(label) for label in decision.get("class_shape", []) or []],
     )
+
+
+def _record_delegation_continuity(paths: OmhPaths, payload: dict[str, object]) -> dict[str, object]:
+    """Persist an outstanding merge/deploy obligation as an OMH goal ledger.
+
+    The builder prepares the `delegation_continuity` block (obligation, prepared
+    goal slug, the OMH-state-root write policy); the durable write lives here, in
+    the command layer, so the builder stays offline. This mirrors
+    `_record_coding_decision`: it never fails the command over a store error, and
+    it re-derives the ledger's location from `continuity_write_target(paths)` so
+    it can only ever write under the OMH goals directory -- never into a product
+    repo's `.omo`/`.omx`/`.document-harness` runtime-evidence dirs.
+
+    The goal is created active with a REQUIRED merge/deploy criterion carrying no
+    evidence, so it stays open until the merge/deploy is observed. An existing
+    ledger under the prepared slug is linked, not overwritten, so a re-delegated
+    obligation keeps its in-progress history.
+    """
+    block = payload.get("delegation_continuity")
+    if not isinstance(block, dict):
+        return {"recorded": False, "reason": "no_delegation_continuity"}
+    obligation = str(block.get("obligation", "")).strip()
+    if not obligation:
+        return {"recorded": False, "reason": "no_obligation"}
+    durable = block.get("durable_record")
+    goal_id = str(durable.get("goal_id", "")).strip() if isinstance(durable, dict) else ""
+    if not goal_id:
+        return {"recorded": False, "reason": "no_goal_id"}
+    target = continuity_write_target(paths)
+    try:
+        path = goal_ledger_path(paths, goal_id)
+        if path.exists():
+            return {
+                "recorded": True,
+                "created": False,
+                "linked": True,
+                "goal_id": goal_id,
+                "goal_ledger_path": str(path),
+                "state_root": target["state_root"],
+            }
+        create_goal_ledger(
+            paths,
+            f"coding-delegation:{obligation}:{goal_id}",
+            [merge_obligation_criterion(obligation)],
+            goal_id=goal_id,
+            source="coding_delegation",
+            objective_summary=(
+                f"Outstanding {obligation} obligation from a coding delegation; a delegated "
+                "subtask completing is not this obligation being met."
+            ),
+        )
+    except (OSError, ValueError) as exc:
+        return {"recorded": False, "reason": "goal_ledger_write_failed", "error": str(exc)}
+    return {
+        "recorded": True,
+        "created": True,
+        "linked": False,
+        "goal_id": goal_id,
+        "goal_ledger_path": str(goal_ledger_path(paths, goal_id)),
+        "state_root": target["state_root"],
+    }
+
+
+def _link_delegation_continuity_run(paths: OmhPaths, payload: dict[str, object], run_id: str) -> None:
+    """Link the delegated run to the obligation goal as an in_progress checkpoint.
+
+    The checkpoint references no acceptance criterion and carries no evidence, so
+    linking a subtask never satisfies the required merge/deploy criterion: the
+    goal stays open until the merge/deploy is observed. Never fails the command
+    over a store error, mirroring the decision and continuity records above.
+    """
+    record = payload.get("delegation_continuity_record")
+    if not isinstance(record, dict) or not record.get("recorded"):
+        return
+    goal_id = str(record.get("goal_id", "")).strip()
+    if not goal_id or not run_id:
+        return
+    block = payload.get("delegation_continuity")
+    obligation = str(block.get("obligation", "")).strip() if isinstance(block, dict) else "merge"
+    try:
+        record_goal_checkpoint(
+            paths,
+            goal_id,
+            f"Delegated coding run linked to the outstanding {obligation} obligation.",
+            status="in_progress",
+            linked_runtime_run_id=run_id,
+        )
+    except (OSError, ValueError):
+        return
 
 
 def _coding_delegate_runtime_skip_reason(payload: dict[str, object]) -> str:

--- a/src/plugin_bundle/omh/awareness.py
+++ b/src/plugin_bundle/omh/awareness.py
@@ -1195,7 +1195,7 @@ WORKFLOW_CONTEXT_CARDS = (
             "ultraqa",
         ),
         "user_examples": ("Turn this issue into a PR-ready plan", "Is the Codex run done yet?"),
-        "first_response_shape": "State the selected coding owner or choice point, prepare the handoff/status, and keep dispatch, result, review, CI, and merge evidence separate; when the user explicitly authorized merge or deploy, carry that forward as a prepared post-verification step rather than downgrading it to 'no merge', still gated on observed receipt evidence.",
+        "first_response_shape": "State the selected coding owner or choice point, prepare the handoff/status, and keep dispatch, result, review, CI, and merge evidence separate; when the user explicitly authorized merge or deploy, carry that forward as a prepared post-verification step rather than downgrading it to 'no merge', still gated on observed receipt evidence. Record cross-delegation continuity and the outstanding merge/deploy obligation in the goal ledger under .omh/goals; a delegated subtask completing is not the parent goal completing, and never write continuity into the product repo's .omo/.omx runtime-evidence dirs.",
         "not_evidence_until_observed": ("dispatch", "implementation", "review", "CI", "merge"),
     },
 )
@@ -6089,6 +6089,10 @@ def awareness_primer_payload() -> dict[str, object]:
             {
                 "cue": "coding, risky changes, executor status, review, CI, or merge state",
                 "route": "ultrawork, coding handoff, code-review, or agent-ops-review with observed evidence boundaries",
+            },
+            {
+                "cue": "delegated coding continuity, an outstanding merge/deploy obligation, or where to record it",
+                "route": "record the obligation in the goal ledger under .omh/goals, never in the product repo's .omo/.omx runtime-evidence dirs; a delegated subtask completing is not the parent goal completing",
             },
             {
                 "cue": "workflow trace, skill improvement, regression corpus, or why-routing questions",

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -430,6 +430,32 @@ class OmhPaths:
         return self.omh_home / "team-profile-packs"
 
 
+# Product-repo runtime-evidence directories that OMH delegation continuity must
+# never be written into. `.omo`/`.omx` are other oh-my products' runtime trees
+# and `.document-harness` is a product's own evidence dir; continuity is
+# OMH-owned durable state and belongs in the OMH state root's goal ledger, never
+# hand-written into a product repo. `continuity_write_target` resolves the only
+# allowed destination so a writer can never construct one of these instead.
+CONTINUITY_FORBIDDEN_TARGETS: tuple[str, ...] = (".omo", ".omx", ".document-harness")
+
+
+def continuity_write_target(paths: OmhPaths) -> dict[str, object]:
+    """The one allowed destination for OMH delegation-continuity state.
+
+    Returns the OMH state root, the goals directory continuity lives under, and
+    the forbidden product-repo runtime-evidence targets. A continuity writer
+    resolves its path from `goals_dir` here and can never assemble a
+    `.omo`/`.omx`/`.document-harness` path, because this is the only target it
+    is handed.
+    """
+    return {
+        "state_root": str(paths.omh_home),
+        "handoff_family": "goals",
+        "goals_dir": str(paths.goals_dir),
+        "forbidden_targets": list(CONTINUITY_FORBIDDEN_TARGETS),
+    }
+
+
 def expand_path(value: str | Path) -> Path:
     return Path(os.path.expandvars(str(value))).expanduser().resolve()
 

--- a/src/workflows/goal_ledger.py
+++ b/src/workflows/goal_ledger.py
@@ -57,6 +57,36 @@ STORAGE_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
 RUNTIME_COMPLETION_ACTIONS = {"report_completion_with_evidence", "report_merge_ready", "report_merged"}
 
 
+MERGE_OBLIGATION_ACTIONS = ("merge", "deploy")
+MERGE_OBLIGATION_CRITERION_IDS = {"merge": "AC-MERGE", "deploy": "AC-DEPLOY"}
+
+
+def merge_obligation_criterion(obligation: str, ref: str = "") -> dict[str, Any]:
+    """A REQUIRED acceptance criterion for a post-verification merge/deploy.
+
+    The obligation is met only when the merge (or deploy) is *observed* through
+    an external-effect receipt -- a delegated subtask completing is not the
+    parent obligation being met. The criterion is required and carries no
+    evidence, so a fresh ledger stays not-ready until a checkpoint satisfies it
+    with observed evidence; the goal ledger's completion-integrity classifier
+    then refuses a hand-satisfying entry that names no observed command or
+    receipt (placeholder, self-referential, or prepared-not-observed evidence),
+    which is the reuse that keeps "merged" a claim rather than a proof.
+    """
+    if obligation not in MERGE_OBLIGATION_ACTIONS:
+        raise ValueError(f"merge obligation must be one of {MERGE_OBLIGATION_ACTIONS}")
+    target = re.sub(r"\s+", " ", str(ref)).strip()
+    scope = f" {target}" if target else ""
+    return {
+        "id": MERGE_OBLIGATION_CRITERION_IDS[obligation],
+        "summary": (
+            f"{obligation}{scope} observed via an external-effect {obligation} receipt "
+            "(a delegated subtask completing is not this obligation being met)"
+        ),
+        "required": True,
+    }
+
+
 def _slugify(value: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
     return (slug or "goal")[:48].strip("-") or "goal"

--- a/tests/test_coding_delegation.py
+++ b/tests/test_coding_delegation.py
@@ -499,5 +499,60 @@ class HermesNativeModelBindingTests(unittest.TestCase):
         self.assertEqual(binding["next_action"], "configure_hermes_native_alias")
 
 
+class DelegationContinuityBlockTests(unittest.TestCase):
+    """The `delegation_continuity` block appears only under a merge/deploy directive.
+
+    Goal 2 rides on Goal 1's `post_completion_directive`: when the user asked to
+    merge or deploy, the payload carries an OMH-owned continuity block naming the
+    goal-ledger record and the OMH-state-root write policy; otherwise the key is
+    omitted entirely so a plain coding delegation stays byte-identical.
+    """
+
+    _MESSAGE = "fix the broken login flow in src/auth.py and add a regression test"
+
+    def test_a_merge_directive_attaches_the_continuity_block(self) -> None:
+        payload = build_coding_delegation_payload(
+            f"{self._MESSAGE} then merge it", executor_target="codex"
+        )
+        block = payload["delegation_continuity"]
+        self.assertEqual(block["schema_version"], "omh_delegation_continuity/v1")
+        self.assertEqual(block["obligation"], "merge")
+        self.assertEqual(block["overall_outcome_state"], "open")
+        self.assertIs(block["subtask_is_not_goal"], True)
+        self.assertEqual(block["durable_record"]["kind"], "goal_ledger")
+        self.assertTrue(block["durable_record"]["goal_id"])
+        self.assertIn(".omo", block["write_location_policy"]["forbidden_targets"])
+        self.assertIn(".omx", block["write_location_policy"]["forbidden_targets"])
+
+    def test_a_deploy_directive_attaches_a_deploy_obligation(self) -> None:
+        payload = build_coding_delegation_payload(
+            f"{self._MESSAGE} then deploy it", executor_target="codex"
+        )
+        self.assertEqual(payload["delegation_continuity"]["obligation"], "deploy")
+
+    def test_a_plain_coding_delegation_omits_the_block(self) -> None:
+        payload = build_coding_delegation_payload(self._MESSAGE, executor_target="codex")
+        self.assertNotIn("delegation_continuity", payload)
+
+    def test_the_seam_coexists_with_goal_1_directive(self) -> None:
+        # Goal 1's post_completion_directive (on the handoff envelope) and Goal
+        # 2's delegation_continuity (top-level) must both be present, neither
+        # overwriting the other.
+        payload = build_coding_delegation_payload(
+            f"{self._MESSAGE} then merge it", executor_target="codex"
+        )
+        self.assertEqual(payload["delegation_continuity"]["obligation"], "merge")
+        for key in ("executor_handoff", "runtime_handoff", "prompt_handoff"):
+            handoff = payload.get(key)
+            if isinstance(handoff, dict):
+                envelope = handoff["task_authority_envelope"]
+                self.assertEqual(
+                    envelope["post_completion_directive"]["action"], "merge"
+                )
+                break
+        else:  # pragma: no cover - a dispatchable codex handoff always exists here
+            self.fail("no handoff carried the authority envelope")
+
+
 if __name__ == "__main__":  # pragma: no cover - unittest entry point
     unittest.main()

--- a/tests/test_delegation_continuity.py
+++ b/tests/test_delegation_continuity.py
@@ -1,0 +1,227 @@
+"""Cross-delegation continuity is OMH-owned durable state, never product-tree markdown.
+
+When OMH delegates coding work toward a stated merge/deploy goal, the outstanding
+obligation is recorded as a goal ledger in the OMH state root -- not hand-written
+into a product repo's `.omo`/`.omx`/`.document-harness` runtime-evidence dirs. A
+delegated subtask completing (a review, say) is not the parent goal completing:
+the goal stays OPEN until the merge/deploy is observed through an external-effect
+receipt, or until explicit cancellation, and it is reconcilable from the
+persisted ledger alone after a resume or compaction.
+
+These tests cover the seam with Goal 1 (the merge directive it preserves is what
+raises this block), the OMH-state-root write target, the command-layer ledger
+creation and run linkage, the subtask-not-goal gate, cancellation, offline
+reconciliation, and the awareness guardrail text.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.coding_delegation import build_coding_delegation_payload  # noqa: E402
+from omh.commands.coding import (  # noqa: E402
+    _link_delegation_continuity_run,
+    _record_delegation_continuity,
+)
+from omh.goal_ledger import (  # noqa: E402
+    MERGE_OBLIGATION_CRITERION_IDS,
+    build_goal_completion_gate,
+    build_goal_continuation,
+    cancel_goal_ledger,
+    read_goal_ledger,
+    record_goal_checkpoint,
+)
+from omh.paths import (  # noqa: E402
+    CONTINUITY_FORBIDDEN_TARGETS,
+    OmhPaths,
+    continuity_write_target,
+    resolve_paths,
+)
+from omh.plugin_bundle.omh.awareness import (  # noqa: E402
+    awareness_primer_payload,
+    workflow_context_cards,
+)
+
+_MESSAGE = "fix the broken login flow in src/auth.py and add a regression test"
+
+
+def _merge_payload() -> dict[str, object]:
+    return build_coding_delegation_payload(f"{_MESSAGE} then merge it", executor_target="codex")
+
+
+class WriteTargetTests(unittest.TestCase):
+    """The one allowed destination resolves under the OMH goals dir, never a product tree."""
+
+    def test_user_scope_target_is_under_omh_home_goals(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            target = continuity_write_target(paths)
+            goals_dir = Path(target["goals_dir"])
+            self.assertEqual(goals_dir, paths.omh_home / "goals")
+            self.assertEqual(goals_dir.parent, Path(target["state_root"]))
+
+    def test_project_scope_target_is_under_the_repo_omh_home(self) -> None:
+        # A `<repo>/.omh` state root -- exactly the shape `--scope project`
+        # resolves to -- still puts continuity under its own goals dir.
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            paths = OmhPaths(omh_home=repo / ".omh", hermes_home=repo / ".hermes")
+            target = continuity_write_target(paths)
+            self.assertEqual(Path(target["goals_dir"]), repo / ".omh" / "goals")
+
+    def test_the_target_never_names_a_product_runtime_evidence_dir(self) -> None:
+        for home in ("~/.omh", "/some/repo/.omh"):
+            with self.subTest(home=home):
+                paths = OmhPaths(omh_home=Path(home), hermes_home=Path(home).parent / ".hermes")
+                target = continuity_write_target(paths)
+                for forbidden in CONTINUITY_FORBIDDEN_TARGETS:
+                    self.assertNotIn(forbidden, target["goals_dir"])
+                self.assertEqual(target["forbidden_targets"], list(CONTINUITY_FORBIDDEN_TARGETS))
+
+
+class LedgerCreationTests(unittest.TestCase):
+    def test_persisting_a_merge_delegation_creates_a_required_pending_criterion(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            payload = _merge_payload()
+            record = _record_delegation_continuity(paths, payload)
+            self.assertTrue(record["recorded"])
+            self.assertTrue(record["created"])
+            goal = read_goal_ledger(paths, record["goal_id"])
+            self.assertEqual(goal["status"], "active")
+            self.assertEqual(Path(record["goal_ledger_path"]).parent.parent, paths.goals_dir)
+            (criterion,) = goal["acceptance_criteria"]
+            self.assertEqual(criterion["id"], MERGE_OBLIGATION_CRITERION_IDS["merge"])
+            self.assertIs(criterion["required"], True)
+            self.assertEqual(criterion["status"], "pending")
+            self.assertEqual(criterion["evidence_refs"], [])
+
+    def test_a_plain_delegation_records_nothing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            payload = build_coding_delegation_payload(_MESSAGE, executor_target="codex")
+            record = _record_delegation_continuity(paths, payload)
+            self.assertFalse(record["recorded"])
+            self.assertFalse(paths.goals_dir.exists())
+
+    def test_re_delegation_links_the_existing_ledger_without_overwriting(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            payload = _merge_payload()
+            first = _record_delegation_continuity(paths, payload)
+            record_goal_checkpoint(paths, first["goal_id"], "made progress", status="in_progress")
+            second = _record_delegation_continuity(paths, payload)
+            self.assertEqual(second["goal_id"], first["goal_id"])
+            self.assertFalse(second["created"])
+            self.assertTrue(second["linked"])
+            # The in-progress checkpoint survived: the re-delegation did not
+            # recreate (and reset) the ledger.
+            goal = read_goal_ledger(paths, first["goal_id"])
+            self.assertTrue(any(c["summary"] == "made progress" for c in goal["checkpoints"]))
+
+    def test_a_linked_run_is_an_in_progress_checkpoint_not_a_completion(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            payload = _merge_payload()
+            record = _record_delegation_continuity(paths, payload)
+            payload["delegation_continuity_record"] = record
+            _link_delegation_continuity_run(paths, payload, "run-abc")
+            goal = read_goal_ledger(paths, record["goal_id"])
+            self.assertIn("run-abc", goal["linked_runtime_runs"])
+            (checkpoint,) = goal["checkpoints"]
+            self.assertEqual(checkpoint["status"], "in_progress")
+            self.assertEqual(checkpoint["criteria_refs"], [])
+            # The obligation is still open: linking a subtask satisfied no criterion.
+            gate = build_goal_completion_gate(paths, record["goal_id"])
+            self.assertFalse(gate["ready"])
+
+
+class SubtaskIsNotGoalTests(unittest.TestCase):
+    def test_a_completed_review_subtask_leaves_the_merge_obligation_open(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _record_delegation_continuity(paths, _merge_payload())
+            goal_id = record["goal_id"]
+            # The delegated review run is observed complete, with observed-class
+            # evidence -- yet it references no acceptance criterion, so it is a
+            # subtask, not the goal.
+            record_goal_checkpoint(
+                paths,
+                goal_id,
+                "delegated review run completed",
+                status="done",
+                evidence_refs=["observed: review passed run-abc"],
+            )
+            gate = build_goal_completion_gate(paths, goal_id)
+            self.assertFalse(gate["ready"])
+            self.assertEqual(
+                [c["id"] for c in gate["missing_required_criteria"]],
+                [MERGE_OBLIGATION_CRITERION_IDS["merge"]],
+            )
+
+
+class CancellationTests(unittest.TestCase):
+    def test_explicit_cancellation_is_terminal_and_refuses_later_checkpoints(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            record = _record_delegation_continuity(paths, _merge_payload())
+            goal_id = record["goal_id"]
+            cancelled = cancel_goal_ledger(paths, goal_id, reason="user cancelled the merge")
+            self.assertEqual(cancelled["status"], "cancelled")
+            with self.assertRaises(ValueError):
+                record_goal_checkpoint(paths, goal_id, "too late", status="in_progress")
+
+
+class ReconciliationTests(unittest.TestCase):
+    def test_the_obligation_is_reconcilable_from_the_persisted_ledger_alone(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            goal_id = _record_delegation_continuity(paths, _merge_payload())["goal_id"]
+            # Rebuild from disk with no live process in hand: this is the
+            # after-resume/compaction path.
+            reread = resolve_paths(paths.omh_home, paths.hermes_home)
+            continuation = build_goal_continuation(reread, goal_id)
+            self.assertEqual(continuation["goal_status"], "active")
+            self.assertEqual(continuation["next_action"], "record_checkpoint")
+            missing = continuation["status_card"]["missing_criteria"]
+            self.assertEqual(
+                [c["id"] for c in missing], [MERGE_OBLIGATION_CRITERION_IDS["merge"]]
+            )
+
+
+class AwarenessGuardrailTests(unittest.TestCase):
+    def _coding_handoff_card(self) -> dict[str, object]:
+        for card in workflow_context_cards():
+            if card.get("id") == "coding_handoff":
+                return card
+        self.fail("coding_handoff card not found")
+
+    def test_the_card_carries_both_goal_1_and_goal_2_clauses(self) -> None:
+        shape = str(self._coding_handoff_card()["first_response_shape"])
+        # Goal 1's preserved-merge clause.
+        self.assertIn("post-verification", shape)
+        self.assertIn("no merge", shape)
+        # Goal 2's write-location clause.
+        self.assertIn(".omh/goals", shape)
+        self.assertIn(".omo", shape)
+        self.assertIn(".omx", shape)
+        self.assertIn("subtask completing is not the parent goal completing", shape)
+
+    def test_a_write_location_rail_line_is_present(self) -> None:
+        cues = awareness_primer_payload()["workflow_cues"]
+        rails = [
+            cue
+            for cue in cues
+            if ".omh/goals" in str(cue.get("route", "")) and ".omo" in str(cue.get("route", ""))
+        ]
+        self.assertTrue(rails, "no delegation-continuity write-location rail cue found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_goal_ledger.py
+++ b/tests/test_goal_ledger.py
@@ -9,6 +9,8 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.goal_ledger import (
+    MERGE_OBLIGATION_CRITERION_IDS,
+    merge_obligation_criterion,
     GOAL_COMPLETION_GATE_SCHEMA,
     GOAL_CONTINUATION_SCHEMA,
     GOAL_FAILURE_REASON_CODES,
@@ -810,6 +812,87 @@ class GoalLedgerDuplicateItemIdValidationTests(unittest.TestCase):
             stored = read_goal_ledger(paths, "goal-duplicate")
             self.assertEqual([item["quality_gate_id"] for item in stored["quality_gates"]], ["turn-1", "turn-2"])
             self.assertEqual(validate_goal_ledger(stored), {"ok": True, "errors": []})
+
+
+class MergeObligationCriterionTests(unittest.TestCase):
+    def test_the_constructor_builds_a_required_merge_criterion(self) -> None:
+        criterion = merge_obligation_criterion("merge", ref="#647")
+        self.assertEqual(criterion["id"], MERGE_OBLIGATION_CRITERION_IDS["merge"])
+        self.assertIs(criterion["required"], True)
+        self.assertIn("receipt", criterion["summary"])
+        self.assertIn("#647", criterion["summary"])
+
+    def test_deploy_is_a_distinct_criterion_id(self) -> None:
+        self.assertEqual(
+            merge_obligation_criterion("deploy")["id"], MERGE_OBLIGATION_CRITERION_IDS["deploy"]
+        )
+
+    def test_an_unsupported_obligation_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            merge_obligation_criterion("rebase")
+
+    def test_a_fresh_merge_obligation_ledger_stays_not_ready(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths,
+                "coding-delegation:merge:goal-obl",
+                [merge_obligation_criterion("merge")],
+                goal_id="goal-obl",
+                source="coding_delegation",
+            )
+            gate = build_goal_completion_gate(paths, "goal-obl")
+            self.assertFalse(gate["ready"])
+            self.assertEqual(
+                [c["id"] for c in gate["missing_required_criteria"]],
+                [MERGE_OBLIGATION_CRITERION_IDS["merge"]],
+            )
+
+    def test_hand_satisfying_without_a_receipt_stays_not_ready(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths,
+                "coding-delegation:merge:goal-hand",
+                [merge_obligation_criterion("merge")],
+                goal_id="goal-hand",
+                source="coding_delegation",
+            )
+            # A placeholder evidence value trips the existing completion-integrity
+            # refusal, so "merged" cannot check out without an observed receipt.
+            record_goal_checkpoint(
+                paths,
+                "goal-hand",
+                "recorded merge",
+                criteria_refs=[MERGE_OBLIGATION_CRITERION_IDS["merge"]],
+                evidence_refs=["pending"],
+                status="done",
+            )
+            gate = build_goal_completion_gate(paths, "goal-hand")
+            self.assertFalse(gate["ready"])
+            self.assertTrue(gate["integrity_refusals"])
+
+    def test_an_observed_receipt_ref_satisfies_the_obligation(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            create_goal_ledger(
+                paths,
+                "coding-delegation:merge:goal-recv",
+                [merge_obligation_criterion("merge", ref="#647")],
+                goal_id="goal-recv",
+                source="coding_delegation",
+            )
+            record_goal_checkpoint(
+                paths,
+                "goal-recv",
+                "merge observed via receipt",
+                criteria_refs=[MERGE_OBLIGATION_CRITERION_IDS["merge"]],
+                evidence_refs=["observed: merge receipt merge:run-1 external_ref pr-647"],
+                status="done",
+            )
+            gate = build_goal_completion_gate(paths, "goal-recv")
+            self.assertTrue(gate["ready"])
+            self.assertEqual(gate["integrity_refusals"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

Stacked on #1368 (base `claude/preserve-merge-directive`). Review/merge #1368 first; this PR's base retargets to `main` once #1368 lands.

### What Changed

- When OMH delegates coding work toward a stated goal that carries an explicit merge/deploy directive, the outstanding obligation is now recorded as **OMH-owned durable state** in the OMH state root (`omh_home/goals/<goal_id>/goal.json`) via the existing goal ledger — never hand-written into a product repo's runtime-evidence dirs (`.omo/`, `.omx/`, `.document-harness/`).
- A delegated subtask completing (e.g. a review) is **not** the parent goal completing: the goal stays OPEN until a merge is observed (a required criterion that needs an external-effect merge receipt) or the ledger is explicitly cancelled, and it is reconcilable after resume/compaction/child exit through the ledger's existing offline gates.

### Why This Exists

Observed defect: while delegating a "merge #647, no deploy" goal, the agent hand-wrote a cross-delegation continuity handoff into the product repo's `.omo/handoffs/` — the wrong location (a product runtime-evidence namespace) — and had to improvise markdown to remember that the merge obligation stays open, because a delegated review completing looked like the goal completing. Root cause: the coding-delegation lane and the goal-ledger obligation layer were unconnected; the delegation path opened no durable obligation record and pointed the agent at nowhere in OMH state, so it fell back to writing files wherever it was.

Rejected alternative: inventing a new `outstanding_obligation` store. That reinvents the goal ledger's status model, completion gate, cancellation, reconciliation, and coordination-board integration, and creates two obligation stores to reconcile. The ledger already is a durable, schema-versioned, resume-reconcilable OPEN/cancelled record, so this reuses it.

### User / Operator Impact

- A multi-subtask coding goal (like "merge this when done") now has a first-class durable home: the obligation survives compaction, child-process exit, and resume, and the parent reconciles "outstanding merge obligation still OPEN" from OMH state instead of a product-tree scratch file.
- No behavior change for a delegation without an explicit merge/deploy directive: the `delegation_continuity` key is omitted and those payloads are byte-identical.

### How It Works

- `src/coding/coding_delegation.py`: `_attach_delegation_continuity(payload, authority_envelope, message=...)` attaches a metadata-only `omh_delegation_continuity/v1` block right after the authority envelope. It reads the obligation back from Goal 1's `task_authority_envelope["post_completion_directive"]["action"]` — recomputes nothing. The block carries `obligation`, `overall_outcome_state="open"`, `subtask_is_not_goal=true`, a `durable_record` (kind `goal_ledger`, a deterministic prepared slug `coding-<obligation>-<sha12>`, and an `<omh_home>` placeholder path), and a `write_location_policy` forbidding `.omo`/`.omx`/`.document-harness`. Builder stays pure/offline — no write.
- `src/commands/coding.py`: the durable write lives here (beside the blocked-work decision). `_record_delegation_continuity` creates the ledger with `merge_obligation_criterion(obligation)` (REQUIRED, pending, no evidence) or links an existing ledger under the prepared slug without overwrite; `_link_delegation_continuity_run` records the delegated run as an `in_progress` checkpoint.
- `src/workflows/goal_ledger.py`: `merge_obligation_criterion(...)` + `MERGE_OBLIGATION_CRITERION_IDS`. The required criterion needs a merge external-effect receipt as evidence, so the goal stays `active` until merge is actually observed (anchoring Goal 1's receipt gate to the obligation).
- `src/system/paths.py`: `continuity_write_target(paths)` returns the goals dir + `CONTINUITY_FORBIDDEN_TARGETS`, so a writer can never assemble a `.omo`/`.omx` path. Uses the real resolver `resolve_paths()` → `omh_home` only; no `OMH_STATE_DIR`/`.omc-workspace` handling (those are OMC global-layer conventions absent from this repo).
- `src/plugin_bundle/omh/awareness.py`: the `coding_handoff` card gains a second sentence (record continuity + the outstanding obligation in the goal ledger under `.omh/goals`, subtask ≠ goal, never write into the product repo's `.omo`/`.omx`), plus a separate write-location workflow-cue rail. Worded to avoid the command-shaped `omh ` token that leaks into chat cards.

### Files And Contracts Touched

`src/coding/coding_delegation.py`, `src/commands/coding.py`, `src/workflows/goal_ledger.py`, `src/system/paths.py`, `src/plugin_bundle/omh/awareness.py`, `tests/test_delegation_continuity.py` (new), `tests/test_coding_delegation.py`, `tests/test_goal_ledger.py`.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [x] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] hermes-smoke with command smoke
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `docs ulw-inventory --check`, `docs ulw-site --check`, `release drift` (no drift, 18 checks)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: no live executor or Hermes runtime exercised

### Observed Evidence

- `tests.test_delegation_continuity` (new) + `test_goal_ledger` + `test_coding_delegation` + `test_wrapper_contract`: 244 tests OK, after confirming the branch is level with Goal 1. Coverage: state-root resolution (user + project scope, never `.omo`/`.omx`), block presence gating (present with directive, absent and byte-identical otherwise), ledger creation/link with a required merge criterion, subtask completed → gate not ready, OPEN until a merge receipt satisfies the criterion, explicit cancellation, reconciliation from the persisted ledger alone, guardrail text, and the seam (Goal 1's `post_completion_directive` and Goal 2's `delegation_continuity` coexist).
- Full suite in the worktree: 9626 tests, 28 failures confined to `test_cross_harness_adapters` + `test_cross_harness_adapter_security` (`unsafe_read_root`), reproduced identically on a stash of base (nested-worktree sandbox). Zero new failures.
- `coordination_board` already reconciles goal ledgers over `goals_dir`, so the new ledgers surface there automatically — no change made.

### Not Tested / Not Applicable

- No live Hermes runtime or real executor dispatch exercised.
- Deploy has no runtime merge-claim ladder rung, so only its field path is exercised.
- The completion-integrity reuse refuses vague/placeholder evidence but cannot by itself distinguish a merge receipt ref from another observed command ref; the stronger "merge actually observed" guarantee rides the linked run's receipt gate (from #1368), which is why the run is linked, not just the criterion.

## Risk

- Narrow-to-moderate. The payload gains a top-level key only when a directive is present (byte-identical otherwise). The only durable write is a goal ledger in the OMH state root, created/linked idempotently under a deterministic slug.

## Compatibility / Rollout

- Additive; reuses `goal_ledger/v1` with no schema bump. Awareness copies pick up the card/rail text through `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ6enDfqFG9ft8yCL2d5P5
