### PR TITLE
fix(update): staged re-entry judges the candidate pack by its own manifest

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import sys
 import time
-from typing import cast
+from typing import Any, cast
 import unicodedata
 
 try:
@@ -851,8 +851,31 @@ def _run_command_package_self_update(args: argparse.Namespace, plan: dict[str, o
     elif result.get("ok"):
         print("OMH update complete: command and workflow pack activated together.")
     else:
-        print(f"OMH update stopped during {result.get('phase')}; the known-good generation remains active.")
+        for line in _self_update_stop_lines(result):
+            print(line)
     return 0 if result.get("ok") else 1
+
+
+def _self_update_stop_lines(result: dict[str, Any]) -> list[str]:
+    """Say why the transaction stopped, not only where.
+
+    The phase alone was the whole report, and "stopped during post_activation"
+    sent people to a bug tracker: the re-entered update had printed its own
+    error, but nothing tied that error to the rollback. The failing phase's
+    recorded reason closes that gap; its last line is the one that names the
+    cause, and the full text stays in the JSON result.
+    """
+    phase = str(result.get("phase") or "unknown")
+    lines = [f"OMH update stopped during {phase}; the known-good generation remains active."]
+    detail = result.get(phase)
+    reason = str(detail.get("reason") or "").strip() if isinstance(detail, dict) else ""
+    if reason:
+        lines.append(f"  reason: {reason.splitlines()[-1].strip()}")
+    restored = str((result.get("rollback") or {}).get("restored") or "")
+    if restored:
+        lines.append(f"  rolled back to generation {restored}")
+    lines.append("  Resolve the reason above, then rerun `omh update`.")
+    return lines
 
 
 def _run_package_manager_self_update(

--- a/src/install/installer.py
+++ b/src/install/installer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -112,6 +113,22 @@ def _write_skill_reference(
     atomic_write_text(target_file, template.content)
 
 
+def _manifest_describes(manifest: dict | None, skills_dir: Path) -> bool:
+    """Whether ``manifest`` records the pack that lives in ``skills_dir``.
+
+    Real paths on both sides: the legacy bootstrap generation reaches the old
+    ``<omh_home>/skills`` through a directory link, and that is still the same
+    pack. A manifest without a recorded directory predates generations and can
+    only describe the one pack directory that existed then.
+    """
+    if not manifest:
+        return False
+    recorded = manifest.get("skills_dir")
+    if not recorded:
+        return True
+    return os.path.realpath(str(recorded)) == os.path.realpath(str(skills_dir))
+
+
 def _overwrite_allowed(force: bool) -> bool:
     """The DECISION for every installer overwrite/removal guard in this module.
 
@@ -182,6 +199,14 @@ def install_skill_pack(
             template for template in reference_templates if template.skill_name in refreshable
         ]
     manifest = read_manifest(paths.manifest_path)
+    # A staged self-update renders the candidate pack into its own generation
+    # directory while the home manifest still describes the generation that is
+    # active. That manifest cannot witness local edits in a directory it never
+    # recorded, so judging the candidate by it flagged every skill the catalog
+    # had changed since the last install as a "local modification", refused the
+    # post-activation re-entry, and rolled the whole update back.
+    if not _manifest_describes(manifest, paths.skills_dir):
+        manifest = None
     modified = local_modifications(manifest, paths.skills_dir)
     if modified and not _overwrite_allowed(force):
         raise OmhError("local modifications detected; rerun with --force or resolve: " + ", ".join(modified))

--- a/src/install/self_update.py
+++ b/src/install/self_update.py
@@ -101,10 +101,17 @@ def _reenter(root: Path, generation: Path, args: Any, runner: Runner, platform: 
     if not same_existing_path(pointed, trusted):
         raise OmhError("cannot re-enter an untrusted self-update generation")
     env = dict(os.environ, OMH_UPDATE_COMMAND_PACKAGE_REENTERED="1", OMH_SELF_UPDATE_GENERATION=str(trusted))
+    command = [_python(root / "current", platform), "-m", "omh.cli", *_reentry_argv()]
+    # stdout stays on the terminal so the re-entered update's own progress and
+    # prompts show live; stderr is captured so the failure that stops the
+    # update reaches the summary line, then replayed so nothing is lost.
     try:
-        checked = _run(runner, [_python(root / "current", platform), "-m", "omh.cli", *_reentry_argv()], env=env, timeout=REENTRY_TIMEOUT_SECONDS, capture=False)
+        checked = runner(command, text=True, stdout=None, stderr=subprocess.PIPE, env=env, timeout=REENTRY_TIMEOUT_SECONDS)
     except (OSError, subprocess.TimeoutExpired):
         return False, "post-activation re-entry timed out"
+    if checked.stderr:
+        sys.stderr.write(str(checked.stderr))
+        sys.stderr.flush()
     return (checked.returncode == 0, _detail(checked, "post-activation re-entry failed"))
 
 

--- a/tests/test_staged_self_update.py
+++ b/tests/test_staged_self_update.py
@@ -212,6 +212,10 @@ class StagedSelfUpdateTests(unittest.TestCase):
                 self.assertFalse(result["ok"])
                 self.assertEqual(result["phase"], "post_activation")
                 self.assertTrue(result["rollback"]["performed"])
+                # The re-entered update's stderr is the only place the cause
+                # is written; it has to reach the result, not just the terminal.
+                expected_reason = "post failed" if failure == "post" else "post-activation re-entry timed out"
+                self.assertEqual(result["post_activation"]["reason"], expected_reason)
                 self.assertEqual(sum("--command-package-updated" in call and "update" not in call for call in calls), 2)
                 self._assert_pair(root, previous)
 
@@ -700,15 +704,73 @@ class StagedSelfUpdateTests(unittest.TestCase):
                 self.assertFalse(result["ok"])
                 self.assertNotEqual(result["post_activation"]["status"], "ok")
         output = io.StringIO()
-        failed = {"ok": False, "phase": "post_activation"}
+        failed = {
+            "ok": False,
+            "phase": "post_activation",
+            "post_activation": {"status": "failed", "reason": "Traceback line\nerror: local modifications detected; rerun with --force"},
+            "rollback": {"performed": True, "restored": "bootstrap-legacy"},
+        }
         with (
             patch("omh.install.self_update.run_installer_self_update", return_value=failed),
             contextlib.redirect_stdout(output),
         ):
             status = _run_command_package_self_update(SimpleNamespace(json=False), {"method": "installer"})
         self.assertEqual(status, 1)
-        self.assertIn("stopped during post_activation", output.getvalue())
-        self.assertNotIn("update complete", output.getvalue().lower())
+        printed = output.getvalue()
+        self.assertIn("stopped during post_activation", printed)
+        # The phase alone sent people to the bug tracker; the line names the cause.
+        self.assertIn("reason: error: local modifications detected; rerun with --force", printed)
+        self.assertNotIn("Traceback line", printed)
+        self.assertIn("rolled back to generation bootstrap-legacy", printed)
+        self.assertIn("rerun `omh update`", printed)
+        self.assertNotIn("update complete", printed.lower())
+        bare = io.StringIO()
+        with (
+            patch("omh.install.self_update.run_installer_self_update", return_value={"ok": False, "phase": "staging"}),
+            contextlib.redirect_stdout(bare),
+        ):
+            _run_command_package_self_update(SimpleNamespace(json=False), {"method": "installer"})
+        self.assertIn("stopped during staging", bare.getvalue())
+        self.assertNotIn("reason:", bare.getvalue())
+
+    def test_reentry_judges_the_candidate_pack_by_its_own_manifest(self):
+        # The home manifest describes the active generation's pack. Rendering
+        # the candidate into a new generation and then judging it by that
+        # manifest turned every catalog change since the last install into a
+        # "local modification" and rolled the update back (reported on 2.0.1).
+        from omh.install.installer import install_skill_pack
+        from omh.system.paths import OmhPaths
+
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            home = OmhPaths(omh_home=root / "omh", hermes_home=root / "hermes")
+            install_skill_pack(home)
+            manifest_path = root / "omh" / "manifest.json"
+            recorded = json.loads(manifest_path.read_text())
+            self.assertEqual(recorded["skills_dir"], str(root / "omh" / "skills"))
+            candidate = root / "generations" / "candidate" / "skills"
+            smoke_home = OmhPaths(omh_home=root / "smoke-omh", hermes_home=root / "smoke-hermes", managed_skills_dir=candidate)
+            install_skill_pack(smoke_home)
+            # The active generation was installed from an older catalog.
+            recorded["skills"][0]["sha256"] = "0" * 64
+            manifest_path.write_text(json.dumps(recorded))
+            reentry = OmhPaths(omh_home=root / "omh", hermes_home=root / "hermes", managed_skills_dir=candidate)
+            written = install_skill_pack(reentry)
+            self.assertEqual(written["skills_dir"], str(candidate))
+            self.assertEqual(json.loads(manifest_path.read_text())["skills_dir"], str(candidate))
+            # The same manifest still guards the directory it does describe.
+            (root / "omh" / "skills" / Path(recorded["skills"][0]["path"])).write_text("edited")
+            manifest_path.write_text(json.dumps(recorded))
+            with self.assertRaisesRegex(OmhError, "local modifications detected"):
+                install_skill_pack(home)
+            # A bootstrap generation reaching the legacy pack through a link is
+            # the same pack, so its edits are still seen.
+            bootstrap = root / "generations" / "bootstrap-legacy"
+            bootstrap.mkdir(parents=True)
+            (bootstrap / "skills").symlink_to(root / "omh" / "skills", target_is_directory=True)
+            linked = OmhPaths(omh_home=root / "omh", hermes_home=root / "hermes", managed_skills_dir=bootstrap / "skills")
+            with self.assertRaisesRegex(OmhError, "local modifications detected"):
+                install_skill_pack(linked)
 
 
 class ManagedWorkflowRegistrationTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

- The staged installer self-update no longer rolls back at `post_activation` when the active generation's workflow pack was installed from an older catalog than the candidate.
- `install_skill_pack` applies its local-modification and orphan-prune guards only when the prior manifest records the directory being installed into.
- The human summary for a stopped update names the failing phase's reason, the generation rolled back to, and the rerun, instead of only the phase.
- The re-entered `omh update --command-package-updated` child's stderr is captured for that reason and replayed to the terminal so nothing it printed is lost.

### Why This Exists

- A user updating 2.0.0 → 2.0.1 on an installer-managed machine reported `OMH update stopped during post_activation; the known-good generation remains active.` with nothing else to act on.
- The staged transaction renders the candidate pack into a new generation directory, then re-enters the update against the real home. That home's `manifest.json` still describes the active generation's pack, so the installer compared the candidate's fresh render against the recorded hashes and reported every skill the catalog had changed since the last install as a "local modification", refused without `--force`, and the transaction rolled back.
- A machine whose recorded pack already matched the candidate render passed, which is why it did not reproduce locally. Every real version bump through the staged path would have hit it.

### User / Operator Impact

- `omh update` through the staged path completes on machines whose recorded pack predates the candidate render.
- When an update does stop, the terminal says why and what to rerun.

### How It Works

- `_manifest_describes(manifest, skills_dir)` compares the manifest's recorded `skills_dir` with the install target on real paths. The legacy `bootstrap-legacy` generation reaches `<omh_home>/skills` through a directory link and is still the same pack, so its guards keep firing. A manifest with no recorded directory predates generations and is treated as describing the one pack that existed then.
- `_reenter` runs the child with stdout inherited (progress and prompts stay live) and stderr piped, replays the stderr after exit, and records it as the phase reason.
- `_self_update_stop_lines` prints the stop line, the last line of the failing phase's reason, the rollback target, and the rerun instruction.

### Files And Contracts Touched

- `src/install/installer.py`, `src/install/self_update.py`, `src/commands/setup.py`, `tests/test_staged_self_update.py`
- JSON result schema unchanged; `post_activation.reason` now carries the child's stderr where it was the fixed fallback string before.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: reproduction script with the real installer (candidate directory + older-hash home manifest) refused before the change and installed after it
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `tests/test_staged_self_update.py`: 30 tests pass, including the new `test_reentry_judges_the_candidate_pack_by_its_own_manifest` (candidate installs; the guard still fires for the directory the manifest describes, directly and through the bootstrap link) and the extended human-output test (reason line, rollback target, rerun hint; no reason line when none was recorded).
- Full suite: 9627 tests, 28 failures all in `test_cross_harness_adapters*`. Those reject any read root under a `.claude` path segment (`_SENSITIVE_PARTS` in `cross_harness_adapter_sandbox.py`); this branch was developed in a worktree under `.claude/worktrees/`, and the same two modules pass on a clean `origin/main` worktree outside that path. CI runs from a plain checkout.

### Not Tested / Not Applicable

- capability-families, harness validate, release checklist, hermes-smoke, `omh --help`: no catalog, capability, harness, or CLI surface changed.
- Manual live machine crossing a real version bump through the staged path: not run; the reporter's terminal output beyond the summary line was not available, so the exact trigger on their machine is inferred from the reproduced mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
