### PR TITLE
fix(tui): the route label names the model, never its provider

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -292,7 +292,14 @@ export default function register(sdk) {
     const state = safeText(row.state) || 'running'
     const stateText = columns < 100 ? ({ running: 'run', blocked: 'block', failed: 'fail' })[state] || state : state
     const taskId = truncateCells(safeText(row.task_id) || safeText(row.role) || 'agent', 8).padEnd(8)
-    const model = [safeText(row.model), safeText(row.effort)].filter(Boolean).join(':')
+    // The route column shows WHICH model runs, not who serves it: a
+    // provider-prefixed id (`anthropic/claude-opus-5`) spent the whole
+    // column on the prefix and truncated to `category:architect(anthropic/`,
+    // so opus and fable were indistinguishable (the owner's report). The
+    // reader still carries `provider` as its own field for anything that
+    // needs it; the label keeps only the segment after the last slash.
+    const modelName = safeText(row.model).split('/').pop()
+    const model = [modelName, safeText(row.effort)].filter(Boolean).join(':')
     // A row `omh coding fanout dispatch` opened (the Maestro lane spawning an
     // external CLI directly, not a Hermes-native delegate_task child) carries
     // `dispatch_lane` from the reader. It renders like every other row in
@@ -303,7 +310,7 @@ export default function register(sdk) {
     const dispatchLane = safeText(row.dispatch_lane)
     const dispatchExecutor = safeText(row.executor_profile)
     const dispatchIdentity = dispatchLane
-      ? `(${MAESTRO_EXECUTOR_SHORT_NAMES[dispatchExecutor] || dispatchExecutor}/${dispatchLane}${safeText(row.model) ? ` ${truncateCells(row.model, 20)}` : ''})`
+      ? `(${MAESTRO_EXECUTOR_SHORT_NAMES[dispatchExecutor] || dispatchExecutor}/${dispatchLane}${modelName ? ` ${truncateCells(modelName, 20)}` : ''})`
       : ''
     const category = safeText(row.category)
     // Prepared-route provenance from the reader, rendered as one shape:
@@ -386,7 +393,9 @@ export default function register(sdk) {
     // row without a route holds the grid with blank cells so the tail after
     // it stays on the same screen column, and a wave with no routes at all
     // spends none of the width.
-    const routeCap = Math.max(10, Math.min(30, Math.floor(columns * 0.24)))
+    // Sized so `category:architect(claude-fable-5-1:xhigh)` survives on a
+    // wide terminal and the model family is still readable on a narrow one.
+    const routeCap = Math.max(10, Math.min(44, Math.floor(columns * 0.3)))
     const routeWidth = routeColumn ? cellWidth(separator) + routeCap : 0
     const routeCell = routeColumn
       ? `${separator}${padCells(truncateCells(routeSegment.text, routeCap), routeCap)}`

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -574,7 +574,16 @@ class TuiWidgetPackTests(unittest.TestCase):
         # and only then rate, cache, turn and cost, which the drop loop still
         # sheds by rank without ever touching the tail.
         self.assertIn("` · ${tokenText.padStart(6)} tokens`", widget)
-        self.assertIn("const routeCap = Math.max(10, Math.min(30, Math.floor(columns * 0.24)))", widget)
+        self.assertIn("const routeCap = Math.max(10, Math.min(44, Math.floor(columns * 0.3)))", widget)
+        # The label names the model, never its provider: `anthropic/` ate the
+        # column and truncated to `category:architect(anthropic/`, hiding
+        # whether the lane ran opus or fable. Only the segment after the last
+        # slash reaches the label (both the category route and the maestro
+        # dispatch identity); `row.provider` stays a separate reader field.
+        self.assertIn("const modelName = safeText(row.model).split('/').pop()", widget)
+        self.assertIn("const model = [modelName, safeText(row.effort)].filter(Boolean).join(':')", widget)
+        self.assertIn("${modelName ? ` ${truncateCells(modelName, 20)}` : ''}", widget)
+        self.assertNotIn("truncateCells(row.model, 20)", widget)
         # The route column reserves its width per LIST, exactly like tokens:
         # otherwise a row without a category would slide its tail left and
         # break the very alignment this ordering exists to keep.


### PR DESCRIPTION
## Feature Report

### Capability
The TUI activity row's route label names the model that runs the lane, never the provider that serves it: `category:architect(claude-fable-5-1:xhigh)` instead of `category:architect(anthropic/`.

### Motivation
Owner report: the route column showed `category(anthropic/)` and nothing after it, so an opus lane and a fable lane looked identical. The provider prefix on the wire model id (`anthropic/claude-opus-5`) filled the 30-cell column before the model name arrived, and truncation cut exactly the part the reader needs.

### Implementation (boundary level)
- `src/omh/tui_widgets/omh-status.mjs`: the row label keeps only the segment after the last slash of `row.model` (`modelName`), for both the category route and the maestro dispatch identity. `row.provider` remains a separate reader field and is not rendered in the label.
- Route column cap grows from `min(30, 24% of columns)` to `min(44, 30% of columns)` so the documented `category:name(model:effort)` shape fits on a wide terminal and the family stays readable on a narrow one. The action column yields the width.
- `tests/test_tui_widget_pack.py`: pins the new cap and the provider-free label, and asserts the old `truncateCells(row.model, 20)` is gone.

### Verification (observed)
- `node --check src/omh/tui_widgets/omh-status.mjs`
- `PYTHONPATH=tests uv run python -m unittest tests/test_tui_widget_pack.py tests/test_hermes_tui_preflight.py tests/test_release_smoke.py tests/test_cli.py` → 417 tests OK
- `uv run --group lint ruff check src tests` → All checks passed
- `uv run python -m compileall -q src tests`, `git diff --check` clean

### Risks
- Two providers serving the same model id would now read the same in the HUD; the label never distinguished them usefully before either (it truncated before the model), and `provider` still travels on the row.
- Not observed: a live Hermes TUI repaint on the owner machine; it reaches there through `omh update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
