### PR TITLE
fix(tui): the route column is never truncated mid-model

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -288,10 +288,7 @@ export default function register(sdk) {
   const observedPercent = (label, value) =>
     Number.isFinite(value) ? `${label} ${value}%` : ''
 
-  const activityLayout = (row, columns, main, extraSeconds, tokensColumn, routeColumn) => {
-    const state = safeText(row.state) || 'running'
-    const stateText = columns < 100 ? ({ running: 'run', blocked: 'block', failed: 'fail' })[state] || state : state
-    const taskId = truncateCells(safeText(row.task_id) || safeText(row.role) || 'agent', 8).padEnd(8)
+  const routeIdentity = row => {
     // The route column shows WHICH model runs, not who serves it: a
     // provider-prefixed id (`anthropic/claude-opus-5`) spent the whole
     // column on the prefix and truncated to `category:architect(anthropic/`,
@@ -310,7 +307,7 @@ export default function register(sdk) {
     const dispatchLane = safeText(row.dispatch_lane)
     const dispatchExecutor = safeText(row.executor_profile)
     const dispatchIdentity = dispatchLane
-      ? `(${MAESTRO_EXECUTOR_SHORT_NAMES[dispatchExecutor] || dispatchExecutor}/${dispatchLane}${modelName ? ` ${truncateCells(modelName, 20)}` : ''})`
+      ? `(${MAESTRO_EXECUTOR_SHORT_NAMES[dispatchExecutor] || dispatchExecutor}/${dispatchLane}${modelName ? ` ${modelName}` : ''})`
       : ''
     const category = safeText(row.category)
     // Prepared-route provenance from the reader, rendered as one shape:
@@ -330,6 +327,19 @@ export default function register(sdk) {
       ? `category:${displayCategory}${routeDetail ? `(${routeDetail})` : ''}`
       : model
     const routeKind = routeOrigin === 'fallback' || routeOrigin === 'exhausted_to_inherit' ? 'route-fallback' : 'route'
+    return dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route)
+  }
+
+  // The route column takes the widest identity in the list (0 = no column):
+  // the label is never truncated, the action column yields the width
+  // instead. `category:architect(anthropic/` with the model cut off was the
+  // owner's report; a route that cannot be read is not worth its cells.
+  const routeColumnWidth = rows => rows.reduce((width, row) => Math.max(width, cellWidth(routeIdentity(row).text)), 0)
+
+  const activityLayout = (row, columns, main, extraSeconds, tokensColumn, routeColumn) => {
+    const state = safeText(row.state) || 'running'
+    const stateText = columns < 100 ? ({ running: 'run', blocked: 'block', failed: 'fail' })[state] || state : state
+    const taskId = truncateCells(safeText(row.task_id) || safeText(row.role) || 'agent', 8).padEnd(8)
     const turn = Number.isFinite(row.turn_count) ? `turn ${row.turn_count}` : ''
     const tools = Number.isFinite(row.tool_count) ? `${row.tool_count} tools` : ''
     const turnTools = turn && tools ? `${turn} (${tools})` : turn || tools
@@ -339,7 +349,7 @@ export default function register(sdk) {
     // state/elapsed/tokens block the owner asked to move beside it, padded
     // to a constant width so the token figures still line up vertically
     // from row to row.
-    const routeSegment = dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route)
+    const routeSegment = routeIdentity(row)
     const optional = [
       metricSegment('fallback', Number.isFinite(row.fallback_count) && row.fallback_count > 0 ? `fallback:${row.fallback_count}` : '', 1),
       // Rate reads immediately after the tail's token count ('tokens, tok/s,
@@ -393,12 +403,19 @@ export default function register(sdk) {
     // row without a route holds the grid with blank cells so the tail after
     // it stays on the same screen column, and a wave with no routes at all
     // spends none of the width.
-    // Sized so `category:architect(claude-fable-5-1:xhigh)` survives on a
-    // wide terminal and the model family is still readable on a narrow one.
-    const routeCap = Math.max(10, Math.min(44, Math.floor(columns * 0.3)))
+    // `routeColumn` is the widest identity in the list, so the label is
+    // padded, never truncated; only a terminal too narrow for the prefix,
+    // the tail and an 8-cell action column clips it at all.
+    const routeCap = Math.min(routeColumn, Math.max(10, budget - cellWidth(prefix) - tailWidth - cellWidth(separator) - 8 - 2))
     const routeWidth = routeColumn ? cellWidth(separator) + routeCap : 0
+    // When even that is too narrow, the `category:` prefix goes before the
+    // model does: `architect(claude-fable-5-1:xhigh)` still says which model
+    // ran, `category:architect(claude-` does not.
+    const routeText = cellWidth(routeSegment.text) > routeCap && routeSegment.text.startsWith('category:')
+      ? routeSegment.text.slice('category:'.length)
+      : routeSegment.text
     const routeCell = routeColumn
-      ? `${separator}${padCells(truncateCells(routeSegment.text, routeCap), routeCap)}`
+      ? `${separator}${padCells(truncateCells(routeText, routeCap), routeCap)}`
       : ''
     const actionCap = Math.max(10, Math.min(48, Math.floor(columns * 0.4)))
     const actionWidth = Math.max(8, Math.min(actionCap, budget - cellWidth(prefix) - routeWidth - tailWidth - 2))
@@ -505,7 +522,7 @@ export default function register(sdk) {
     // Same rule for the route/category column, which now carries the grid:
     // it is what the fixed tail is anchored against, so every row reserves
     // it as soon as one row has a route to show.
-    const routeColumn = [...mainRows, ...rows].some(row => safeText(row.category) || safeText(row.model) || safeText(row.dispatch_lane))
+    const routeColumn = routeColumnWidth([...mainRows, ...rows])
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -340,7 +340,7 @@ class TuiWidgetPackTests(unittest.TestCase):
         # first droppable metadata entry, so it is bound once and rendered
         # between the title and the measured tail.
         self.assertIn(
-            "const routeSegment = dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route)",
+            "return dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route)",
             widget,
         )
         self.assertIn("layout.routeKind === 'route-fallback' || layout.routeKind === 'maestro'", widget)
@@ -574,7 +574,16 @@ class TuiWidgetPackTests(unittest.TestCase):
         # and only then rate, cache, turn and cost, which the drop loop still
         # sheds by rank without ever touching the tail.
         self.assertIn("` · ${tokenText.padStart(6)} tokens`", widget)
-        self.assertIn("const routeCap = Math.max(10, Math.min(44, Math.floor(columns * 0.3)))", widget)
+        # The route column is never truncated: it takes the widest identity
+        # in the list and the action column yields the width. The old
+        # percentage cap cut `category:architect(claude-fable-5-1:xhigh)`
+        # mid-model on every ordinary terminal (the owner's second report).
+        self.assertIn("const routeColumnWidth = rows => rows.reduce((width, row) => Math.max(width, cellWidth(routeIdentity(row).text)), 0)", widget)
+        self.assertIn("const routeCap = Math.min(routeColumn, Math.max(10, budget - cellWidth(prefix) - tailWidth - cellWidth(separator) - 8 - 2))", widget)
+        self.assertNotIn("Math.floor(columns * 0.3)", widget)
+        self.assertNotIn("Math.floor(columns * 0.24)", widget)
+        # Below that floor the `category:` prefix is shed before the model is.
+        self.assertIn("? routeSegment.text.slice('category:'.length)", widget)
         # The label names the model, never its provider: `anthropic/` ate the
         # column and truncated to `category:architect(anthropic/`, hiding
         # whether the lane ran opus or fable. Only the segment after the last
@@ -582,13 +591,14 @@ class TuiWidgetPackTests(unittest.TestCase):
         # dispatch identity); `row.provider` stays a separate reader field.
         self.assertIn("const modelName = safeText(row.model).split('/').pop()", widget)
         self.assertIn("const model = [modelName, safeText(row.effort)].filter(Boolean).join(':')", widget)
-        self.assertIn("${modelName ? ` ${truncateCells(modelName, 20)}` : ''}", widget)
+        self.assertIn("${modelName ? ` ${modelName}` : ''}", widget)
+        self.assertNotIn("truncateCells(modelName, 20)", widget)
         self.assertNotIn("truncateCells(row.model, 20)", widget)
         # The route column reserves its width per LIST, exactly like tokens:
         # otherwise a row without a category would slide its tail left and
         # break the very alignment this ordering exists to keep.
         self.assertIn(
-            "const routeColumn = [...mainRows, ...rows].some(row => safeText(row.category)",
+            "const routeColumn = routeColumnWidth([...mainRows, ...rows])",
             widget,
         )
         self.assertIn("h(Text, { color: statusColor }, layout.tailState)", widget)


### PR DESCRIPTION
## Feature Report

### Capability
The TUI activity row's route column is never truncated mid-model. It takes the widest identity in the list, and the action column yields the width.

### Motivation
Owner report after #1388: the label still came out cut. Dropping the provider prefix was not enough because the column width was a percentage cap (44 cells at 30% of the terminal), which clips `category:architect(claude-fable-5-1:xhigh)` on every ordinary terminal.

### Implementation (boundary level)
- `src/omh/tui_widgets/omh-status.mjs`: the route identity moves into `routeIdentity(row)`; `routeColumnWidth(rows)` measures the widest one per list and replaces the boolean column flag. `routeCap` is that width, bounded only by what remains after the task-id prefix, the fixed tail, and an 8-cell action column. When even that is too narrow, the `category:` prefix is shed before the model is. The maestro dispatch identity loses its 20-cell model truncation.
- `tests/test_tui_widget_pack.py`: pins the new width rule, the prefix shedding, and the absence of the old percentage caps.

### Verification (observed)
Layout arithmetic at common widths (tokens column present):

| columns | route cell | action cells |
| --- | --- | --- |
| 160 | `category:architect(claude-fable-5-1:xhigh)` | 48 |
| 120 | `category:architect(claude-fable-5-1:xhigh)` | 25 |
| 100 | `architect(claude-fable-5-1:xhigh)` | 8 |
| 80 | `architect(claude-fabl` | 8 |

- `node --check src/omh/tui_widgets/omh-status.mjs`
- `PYTHONPATH=tests uv run python -m unittest tests/test_tui_widget_pack.py tests/test_hermes_tui_preflight.py tests/test_release_smoke.py tests/test_cli.py` → 417 OK
- ruff, compileall, `git diff --check` clean

### Risks
- On narrow terminals the action title shrinks to 8 cells while a route is showing; the middle metadata drop loop is unchanged.
- Not observed: a live Hermes TUI repaint on the owner machine; it reaches there through `omh update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
