### PR TITLE
fix(tui): category, model and effort always render whole in the route column

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -330,11 +330,19 @@ export default function register(sdk) {
     return dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route)
   }
 
-  // The route column takes the widest identity in the list (0 = no column):
-  // the label is never truncated, the action column yields the width
-  // instead. `category:architect(anthropic/` with the model cut off was the
-  // owner's report; a route that cannot be read is not worth its cells.
-  const routeColumnWidth = rows => rows.reduce((width, row) => Math.max(width, cellWidth(routeIdentity(row).text)), 0)
+  // The route column takes the widest identity in the list (0 = no column)
+  // and the label is NEVER truncated: category, model and effort are what
+  // the column is for ('category, modelname, effort만 잘 나오면 되니까'),
+  // so the action title yields the width instead. `full` measures the
+  // documented `category:name(model:effort)` shape; `compact` the same list
+  // with the `category:` literal shed, the fallback for a terminal that
+  // cannot hold the full shape.
+  const ROUTE_PREFIX = 'category:'
+  const routeCompact = text => text.startsWith(ROUTE_PREFIX) ? text.slice(ROUTE_PREFIX.length) : text
+  const routeColumnWidth = rows => rows.reduce((width, row) => {
+    const text = routeIdentity(row).text
+    return { compact: Math.max(width.compact, cellWidth(routeCompact(text))), full: Math.max(width.full, cellWidth(text)) }
+  }, { compact: 0, full: 0 })
 
   const activityLayout = (row, columns, main, extraSeconds, tokensColumn, routeColumn) => {
     const state = safeText(row.state) || 'running'
@@ -403,22 +411,22 @@ export default function register(sdk) {
     // row without a route holds the grid with blank cells so the tail after
     // it stays on the same screen column, and a wave with no routes at all
     // spends none of the width.
-    // `routeColumn` is the widest identity in the list, so the label is
-    // padded, never truncated; only a terminal too narrow for the prefix,
-    // the tail and an 8-cell action column clips it at all.
-    const routeCap = Math.min(routeColumn, Math.max(10, budget - cellWidth(prefix) - tailWidth - cellWidth(separator) - 8 - 2))
-    const routeWidth = routeColumn ? cellWidth(separator) + routeCap : 0
-    // When even that is too narrow, the `category:` prefix goes before the
-    // model does: `architect(claude-fable-5-1:xhigh)` still says which model
-    // ran, `category:architect(claude-` does not.
-    const routeText = cellWidth(routeSegment.text) > routeCap && routeSegment.text.startsWith('category:')
-      ? routeSegment.text.slice('category:'.length)
-      : routeSegment.text
-    const routeCell = routeColumn
-      ? `${separator}${padCells(truncateCells(routeText, routeCap), routeCap)}`
+    // The full `category:name(model:effort)` shape renders whenever it fits
+    // beside the prefix, the tail and an 8-cell action title; otherwise the
+    // `category:` literal is shed for the WHOLE list (one column shape per
+    // wave) and the label is still padded, never truncated — the action
+    // title is what shrinks. `architect(claude-fable-5-1:xhigh)` still says
+    // which lane, model and effort ran; `category:architect(claude-` does not.
+    const routeRoom = budget - cellWidth(prefix) - tailWidth - cellWidth(separator) - 8 - 2
+    const routeShedPrefix = routeColumn.full > routeRoom
+    const routeCap = routeShedPrefix ? routeColumn.compact : routeColumn.full
+    const routeWidth = routeCap ? cellWidth(separator) + routeCap : 0
+    const routeText = routeShedPrefix ? routeCompact(routeSegment.text) : routeSegment.text
+    const routeCell = routeCap
+      ? `${separator}${padCells(routeText, routeCap)}`
       : ''
     const actionCap = Math.max(10, Math.min(48, Math.floor(columns * 0.4)))
-    const actionWidth = Math.max(8, Math.min(actionCap, budget - cellWidth(prefix) - routeWidth - tailWidth - 2))
+    const actionWidth = Math.max(4, Math.min(actionCap, budget - cellWidth(prefix) - routeWidth - tailWidth - 2))
     const fixedWidth = cellWidth(prefix) + actionWidth + routeWidth + tailWidth
     const segments = [...optional]
     while (segments.length) {

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -574,16 +574,24 @@ class TuiWidgetPackTests(unittest.TestCase):
         # and only then rate, cache, turn and cost, which the drop loop still
         # sheds by rank without ever touching the tail.
         self.assertIn("` · ${tokenText.padStart(6)} tokens`", widget)
-        # The route column is never truncated: it takes the widest identity
-        # in the list and the action column yields the width. The old
-        # percentage cap cut `category:architect(claude-fable-5-1:xhigh)`
-        # mid-model on every ordinary terminal (the owner's second report).
-        self.assertIn("const routeColumnWidth = rows => rows.reduce((width, row) => Math.max(width, cellWidth(routeIdentity(row).text)), 0)", widget)
-        self.assertIn("const routeCap = Math.min(routeColumn, Math.max(10, budget - cellWidth(prefix) - tailWidth - cellWidth(separator) - 8 - 2))", widget)
+        # The route column is never truncated: category, model and effort are
+        # the column's whole purpose ('category, modelname, effort만 잘
+        # 나오면 되니까'). It takes the widest identity in the list; when the
+        # full `category:name(model:effort)` shape does not fit beside the
+        # prefix, the tail and an 8-cell title, the `category:` literal is
+        # shed for the whole list and the action title shrinks (to 4 cells at
+        # the floor). The old percentage caps cut the model mid-name.
+        self.assertIn("const ROUTE_PREFIX = 'category:'", widget)
+        self.assertIn("const routeCompact = text => text.startsWith(ROUTE_PREFIX) ? text.slice(ROUTE_PREFIX.length) : text", widget)
+        self.assertIn("return { compact: Math.max(width.compact, cellWidth(routeCompact(text))), full: Math.max(width.full, cellWidth(text)) }", widget)
+        self.assertIn("const routeShedPrefix = routeColumn.full > routeRoom", widget)
+        self.assertIn("const routeCap = routeShedPrefix ? routeColumn.compact : routeColumn.full", widget)
+        self.assertIn("? `${separator}${padCells(routeText, routeCap)}`", widget)
+        self.assertNotIn("truncateCells(routeText", widget)
+        self.assertNotIn("truncateCells(routeSegment.text", widget)
+        self.assertIn("const actionWidth = Math.max(4, Math.min(actionCap, budget - cellWidth(prefix) - routeWidth - tailWidth - 2))", widget)
         self.assertNotIn("Math.floor(columns * 0.3)", widget)
         self.assertNotIn("Math.floor(columns * 0.24)", widget)
-        # Below that floor the `category:` prefix is shed before the model is.
-        self.assertIn("? routeSegment.text.slice('category:'.length)", widget)
         # The label names the model, never its provider: `anthropic/` ate the
         # column and truncated to `category:architect(anthropic/`, hiding
         # whether the lane ran opus or fable. Only the segment after the last


### PR DESCRIPTION
## Feature Report

### Capability
The TUI activity row's route column always renders category, model and effort whole. The label is never truncated at any terminal width.

### Motivation
Owner direction after #1389: the only goal for this column is that category, model name and effort are readable. #1389 still clipped the effort at 80 columns because the column was bounded by an 8-cell action floor.

### Implementation (boundary level)
- `src/omh/tui_widgets/omh-status.mjs`: `routeColumnWidth` now measures both the full `category:name(model:effort)` shape and the compact one with the `category:` literal shed. The full shape renders when it fits beside the prefix, the fixed tail and an 8-cell title; otherwise the literal is shed for the whole list (one column shape per wave) and the label is padded, never cut. The action title shrinks instead, down to a 4-cell floor.
- `tests/test_tui_widget_pack.py`: pins the two-width measurement, the list-wide shed, the padded (not truncated) route cell, and the 4-cell action floor.

### Verification (observed)
Layout arithmetic (tokens column present, label `category:architect(claude-fable-5-1:xhigh)`):

| columns | route cell | action cells | row overflow |
| --- | --- | --- | --- |
| 160 | full shape | 48 | 0 |
| 120 | full shape | 25 | 0 |
| 100 | `architect(claude-fable-5-1:xhigh)` | 14 | 0 |
| 80 | `architect(claude-fable-5-1:xhigh)` | 4 | 8 (far-right token count clipped by the row's truncate-end) |

- `node --check src/omh/tui_widgets/omh-status.mjs`
- `PYTHONPATH=tests uv run python -m unittest tests/test_tui_widget_pack.py tests/test_hermes_tui_preflight.py tests/test_release_smoke.py tests/test_cli.py` → 417 OK
- ruff, compileall, `git diff --check` clean

### Risks
- Under ~100 columns the action title gets short and at 80 the token count can be clipped at the right edge; the owner ranked the route label above both.
- Not observed: a live Hermes TUI repaint on the owner machine; it reaches there through `omh update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
