### PR TITLE
fix(menubar): the menu shows a current reading, not the first one

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -244,9 +244,15 @@ Claude Code, OMX, OMO, OMC, or generic coding tools cannot be rendered as
 Hermes agents by accident. `display.menu_cards` is the human-facing model for
 the native helper: a Sessions table, a Models table, and one compact coding
 metadata footer. Sessions uses the exact columns `Hermes session` / `Count` and
-only the `live` and `total` rows. Session source or TUI breakdown is
-intentionally not exposed. In Models, `current` is the model observed on the
-live Hermes session; `main` and auxiliary aliases are configuration values.
+the `live`, `total`, and (only when non-zero) `open, idle` rows. `live` is an
+open session with activity inside `LIVE_WINDOW_SECONDS` (15 minutes); open
+rows Hermes never closed (crash, killed terminal, orphan not yet reaped) are
+reported as `open, idle` so they cannot inflate `live`. Session source or TUI
+breakdown is intentionally not exposed. In Models, `current` is the model
+observed on the most recently active live Hermes session and is absent when
+no session is live; `main`, `delegation` (the model an unrouted
+`delegate_task` child inherits), and auxiliary aliases are configuration
+values.
 
 Plain `omh menubar status` renders a short terminal summary from the same
 payload so operators see Summary, Sessions, Models, the compact coding metadata

--- a/src/commands/menubar.py
+++ b/src/commands/menubar.py
@@ -112,16 +112,20 @@ def _format_menubar_status(payload: Mapping[str, object]) -> str:
     if summary:
         lines.append(f"  Activity: {summary}")
     if _truthy(hermes_sessions.get("observed")):
+        stale = _text(hermes_sessions.get("stale"))
+        idle = f" / idle {stale}" if stale and stale != "0" else ""
         lines.append(
-            f"  Sessions: live {_text(hermes_sessions.get('live'))} / "
+            f"  Sessions: live {_text(hermes_sessions.get('live'))}{idle} / "
             f"total {_text(hermes_sessions.get('total'))}"
         )
     else:
         lines.append("  Sessions: not observed")
     if _truthy(hermes_processes.get("observed")):
+        agent_count = _text(hermes_processes.get("agent_count"))
+        process_count = _text(hermes_processes.get("process_count"))
         lines.append(
-            f"  Processes: {_text(hermes_processes.get('agent_count'))} agent / "
-            f"{_text(hermes_processes.get('process_count'))} processes"
+            f"  Processes: {agent_count} {'agent' if agent_count == '1' else 'agents'} / "
+            f"{process_count} {'process' if process_count == '1' else 'processes'}"
         )
     else:
         lines.append("  Processes: not observed")

--- a/src/surfaces/hermes_model_settings.py
+++ b/src/surfaces/hermes_model_settings.py
@@ -81,7 +81,7 @@ def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[st
             match = _KEY.match(line)
             top_level = match.group(1) if match else ""
             auxiliary_task = ""
-            if top_level in {"model", "agent", "auxiliary"}:
+            if top_level in {"model", "agent", "auxiliary", "delegation"}:
                 value = _scalar_value(line)
                 if value is None or value:
                     return None
@@ -94,7 +94,7 @@ def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[st
                 if value is None or value:
                     return None
             continue
-        if top_level in {"model", "agent"} and line.startswith("  ") and not line.startswith("    "):
+        if top_level in {"model", "agent", "delegation"} and line.startswith("  ") and not line.startswith("    "):
             match = _KEY.match(line[2:])
             if match:
                 key = match.group(1)
@@ -102,6 +102,9 @@ def _parse_settings(config_text: str) -> tuple[dict[str, str], dict[str, dict[st
                     ("model", "default"),
                     ("model", "provider"),
                     ("agent", "reasoning_effort"),
+                    ("delegation", "model"),
+                    ("delegation", "provider"),
+                    ("delegation", "reasoning_effort"),
                 }:
                     value = _scalar_value(line)
                     if value is None:
@@ -141,6 +144,7 @@ def _unreadable_result() -> dict[str, Any]:
         "reason": "config_unreadable",
         "provider": "",
         "aliases": [],
+        "delegation": _alias_entry(alias="delegation", model="", effort="", source="config.delegation.model"),
         "configured_count": 0,
         "inherit_count": 0,
         "claim_boundary": _CLAIM_BOUNDARY,
@@ -176,12 +180,24 @@ def read_hermes_model_settings(paths: OmhPaths) -> dict[str, Any]:
             )
         )
     configured_count = sum(1 for entry in aliases if entry["configured"])
+    # `delegation:` is the model every delegate_task child inherits when no
+    # OMH route is set, so it is what the fan-out actually runs on; it is
+    # reported beside the aliases, not among them, because the alias tuple is
+    # the exact Hermes auxiliary contract.
+    delegation = _alias_entry(
+        alias="delegation",
+        model=settings.get("delegation.model", ""),
+        effort=settings.get("delegation.reasoning_effort", ""),
+        source="config.delegation.model",
+    )
+    delegation["provider"] = settings.get("delegation.provider", "")
     return {
         "schema_version": HERMES_MODEL_SETTINGS_SCHEMA_VERSION,
         "observed": True,
         "reason": "",
         "provider": settings.get("model.provider", ""),
         "aliases": aliases,
+        "delegation": delegation,
         "configured_count": configured_count,
         "inherit_count": len(aliases) - configured_count,
         "claim_boundary": _CLAIM_BOUNDARY,

--- a/src/surfaces/hermes_sessions.py
+++ b/src/surfaces/hermes_sessions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import datetime, timezone
 from json import JSONDecodeError
 from typing import Any
 
@@ -9,13 +10,20 @@ from ..paths import OmhPaths
 
 
 HERMES_SESSION_SCHEMA_VERSION = "hermes_session_observation/v1"
+# An open session (no `ended_at`) counts as live only while Hermes has
+# touched it recently. Hermes closes sessions on agent/TUI shutdown and reaps
+# orphans on its next startup, so a crash, a killed terminal, or a long-lived
+# TUI that never exits leaves rows open for days; on the owner machine 53
+# such rows sat "live" for two days with zero activity, and the menu bar
+# count never moved. Activity within this window is the honest reading.
+LIVE_WINDOW_SECONDS = 900
 _CLAIM_BOUNDARY = (
     "Session counts are a read-only observation of Hermes' own session store; "
     "they are not execution, review, CI, merge, or token-usage evidence."
 )
 
 
-def observe_hermes_sessions(paths: OmhPaths) -> dict[str, Any]:
+def observe_hermes_sessions(paths: OmhPaths, *, now: datetime | str | None = None) -> dict[str, Any]:
     db_path = paths.hermes_home / "state.db"
     if not db_path.exists():
         return _unobserved("state_db_missing")
@@ -29,30 +37,72 @@ def observe_hermes_sessions(paths: OmhPaths) -> dict[str, Any]:
                     "select count(*) from sessions where archived = 0 and hidden = 0"
                 ).fetchone()[0]
             )
-            live = int(
-                cursor.execute(
-                    "select count(*) from sessions where archived = 0 and hidden = 0 and ended_at is null"
-                ).fetchone()[0]
-            )
-            current_row = cursor.execute(
-                "select model, model_config from sessions where archived = 0 and hidden = 0 and ended_at is null "
-                "order by coalesce(last_activity_at, started_at) desc limit 1"
-            ).fetchone()
+            open_rows = cursor.execute(
+                "select model, model_config, coalesce(last_activity_at, started_at) from sessions "
+                "where archived = 0 and hidden = 0 and ended_at is null"
+            ).fetchall()
         finally:
             connection.close()
     except sqlite3.Error:
         return _unobserved("state_db_unreadable")
 
+    reference = _coerce_now(now)
+    live_rows: list[tuple[float, Any, Any]] = []
+    for row in open_rows:
+        seen_at = _epoch(row[2])
+        if seen_at is None or reference - seen_at > LIVE_WINDOW_SECONDS:
+            continue
+        live_rows.append((seen_at, row[0], row[1]))
+    live_rows.sort(key=lambda entry: entry[0], reverse=True)
+    current_row = (live_rows[0][1], live_rows[0][2]) if live_rows else None
+
     return {
         "schema_version": HERMES_SESSION_SCHEMA_VERSION,
         "observed": True,
         "reason": "",
-        "live": live,
+        "live": len(live_rows),
+        "open": len(open_rows),
+        "stale": len(open_rows) - len(live_rows),
+        "live_window_seconds": LIVE_WINDOW_SECONDS,
         "total": total,
         "current_model": _current_model(current_row),
         "source": "hermes_state_db_readonly",
         "claim_boundary": _CLAIM_BOUNDARY,
     }
+
+
+def _coerce_now(now: datetime | str | None) -> float:
+    if isinstance(now, datetime):
+        return _aware(now).timestamp()
+    if isinstance(now, str) and now.strip():
+        parsed = _epoch(now)
+        if parsed is not None:
+            return parsed
+    return datetime.now(timezone.utc).timestamp()
+
+
+def _epoch(value: Any) -> float | None:
+    """Hermes stores REAL epoch seconds; older rows and fixtures carry ISO text."""
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value) if value == value else None
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return _aware(parsed).timestamp()
+
+
+def _aware(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
 
 
 def _current_model(row: tuple[Any, Any] | None) -> dict[str, Any]:
@@ -96,6 +146,9 @@ def _unobserved(reason: str) -> dict[str, Any]:
         "observed": False,
         "reason": reason,
         "live": 0,
+        "open": 0,
+        "stale": 0,
+        "live_window_seconds": LIVE_WINDOW_SECONDS,
         "total": 0,
         "current_model": _current_model_payload(),
         "source": "hermes_state_db_readonly",

--- a/src/surfaces/menubar_app.py
+++ b/src/surfaces/menubar_app.py
@@ -329,9 +329,26 @@ _SWIFT_SOURCE = r'''
 import AppKit
 import Foundation
 
-final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
+// One NSMenu for the life of the process. AppKit updates an open menu in
+// place when its items change, so a refresh that lands while the user is
+// looking at the menu is visible immediately; replacing `statusItem.menu`
+// (the previous design) only took effect on the NEXT open, which read as
+// "the menu never updates". The status subprocess runs off the main thread:
+// a ~0.5s synchronous wait every 8s froze the menu bar for that long.
+final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    private let menu = NSMenu()
+    private let refreshQueue = DispatchQueue(label: "omh.menubar.refresh", qos: .utility)
+    private let clock: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
     private var timer: Timer?
+    private var refreshInFlight = false
+    private var lastPayload: [String: Any]?
+    private var lastRefreshedAt: Date?
+    private var consecutiveFailures = 0
     private var omhCommand = "omh"
     private var omhHome = ""
     private var hermesHome = ""
@@ -342,12 +359,28 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.accessory)
         parseArguments()
         configureStatusButton()
+        // Rows are information, not commands: keep them enabled so they render
+        // in the normal text color instead of the disabled gray that reads as
+        // "still loading". Nothing has an action, so clicking does nothing.
+        menu.autoenablesItems = false
+        menu.delegate = self
+        statusItem.menu = menu
         updateStatusDescription(headline: "OMH", summary: "Loading status")
-        configureMenu(headline: "OMH", summary: "Loading status", cards: [])
+        renderMenu(headline: "OMH", summary: "Loading status", cards: [], footer: "Loading…")
         refresh()
-        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+        // `.common` so the timer keeps firing while the menu is open (menu
+        // tracking runs the event-tracking mode, where a default-mode timer
+        // is silent for as long as the menu stays down).
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
             self?.refresh()
         }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    func menuWillOpen(_ menu: NSMenu) {
+        // Opening the menu is the moment freshness matters most.
+        refresh()
     }
 
     private func parseArguments() {
@@ -409,10 +442,35 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func refresh() {
-        guard let payload = readStatusPayload() else {
+        if refreshInFlight {
+            return
+        }
+        refreshInFlight = true
+        refreshQueue.async { [weak self] in
+            guard let self else {
+                return
+            }
+            let payload = self.readStatusPayload()
+            DispatchQueue.main.async {
+                self.refreshInFlight = false
+                self.apply(payload)
+            }
+        }
+    }
+
+    private func apply(_ payload: [String: Any]?) {
+        guard let payload else {
+            consecutiveFailures += 1
+            // One failed read (a busy state.db, a slow disk) must not flash
+            // the attention mark and blank the cards; keep the last good
+            // reading until the failure persists.
+            if lastPayload != nil && consecutiveFailures < 3 {
+                renderFooter()
+                return
+            }
             statusItem.button?.title = "!"
             updateStatusDescription(headline: "OMH needs attention", summary: "Status unavailable")
-            configureMenu(
+            renderMenu(
                 headline: "OMH needs attention",
                 summary: "Status unavailable",
                 cards: [
@@ -423,34 +481,56 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
                             ["label": "Then", "value": "Run omh setup if registration needs repair"]
                         ]
                     ]
-                ]
+                ],
+                footer: footerText()
             )
             return
         }
+        consecutiveFailures = 0
+        lastPayload = payload
+        lastRefreshedAt = Date()
         let display = payload["display"] as? [String: Any]
         let headline = (display?["headline"] as? String) ?? "OMH ready"
         let summary = (display?["summary_line"] as? String) ?? "OMH ready"
         let menuBarTitle = (display?["menu_bar_title"] as? String) ?? ""
         statusItem.button?.title = menuBarTitle
         updateStatusDescription(headline: headline, summary: summary)
-        configureMenu(headline: headline, summary: summary, cards: menuCards(from: payload))
+        renderMenu(headline: headline, summary: summary, cards: menuCards(from: payload), footer: footerText())
     }
 
-    private func configureMenu(headline: String, summary: String, cards: [[String: Any]]) {
-        let menu = NSMenu()
-        let headlineItem = disabledItem(" \(headline)")
+    private func footerText() -> String {
+        guard let refreshedAt = lastRefreshedAt else {
+            return "Not updated yet"
+        }
+        let stamp = "Updated \(clock.string(from: refreshedAt))"
+        if consecutiveFailures > 0 {
+            return "\(stamp) · last read failed, retrying"
+        }
+        return stamp
+    }
+
+    private func renderFooter() {
+        guard let item = menu.items.first(where: { $0.representedObject as? String == "footer" }) else {
+            return
+        }
+        item.title = " \(footerText())"
+    }
+
+    private func renderMenu(headline: String, summary: String, cards: [[String: Any]], footer: String) {
+        menu.removeAllItems()
+        let headlineItem = infoItem(" \(headline)")
         let font = NSFont.menuBarFont(ofSize: 0)
         headlineItem.attributedTitle = NSAttributedString(
             string: " \(headline)",
             attributes: [.font: NSFont.boldSystemFont(ofSize: font.pointSize)]
         )
         menu.addItem(headlineItem)
-        menu.addItem(disabledItem(" \(summary)"))
+        menu.addItem(infoItem(" \(summary)"))
 
         for card in cards {
             menu.addItem(NSMenuItem.separator())
             if let title = card["title"] as? String, !title.isEmpty {
-                let item = disabledItem(" \(title)")
+                let item = infoItem(" \(title)")
                 item.attributedTitle = NSAttributedString(
                     string: " \(title)",
                     attributes: [.font: NSFont.boldSystemFont(ofSize: font.pointSize)]
@@ -459,18 +539,21 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
             }
             if let columns = card["columns"] as? [String], !columns.isEmpty {
                 let line = tableHeaderTitle(columns)
-                let item = disabledItem("   \(line)")
+                let item = infoItem("   \(line)")
                 item.toolTip = line
                 item.attributedTitle = NSAttributedString(
                     string: "   \(line)",
-                    attributes: [.font: NSFont.monospacedSystemFont(ofSize: font.pointSize, weight: .medium)]
+                    attributes: [
+                        .font: NSFont.monospacedSystemFont(ofSize: font.pointSize, weight: .medium),
+                        .foregroundColor: NSColor.secondaryLabelColor
+                    ]
                 )
                 menu.addItem(item)
             }
             if let rows = card["rows"] as? [[String: Any]] {
                 for row in rows.prefix(6) {
                     let line = rowTitle(row)
-                    let item = disabledItem("   \(line)")
+                    let item = infoItem("   \(line)")
                     item.toolTip = rowToolTip(row)
                     if (row["kind"] as? String) == "table_row" {
                         item.attributedTitle = NSAttributedString(
@@ -482,20 +565,29 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
                 }
             }
             if let footer = card["footer"] as? String, !footer.isEmpty {
-                let item = disabledItem("   \(footer)")
+                let item = infoItem("   \(footer)")
                 item.toolTip = footer
+                item.attributedTitle = NSAttributedString(
+                    string: "   \(footer)",
+                    attributes: [
+                        .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
+                        .foregroundColor: NSColor.secondaryLabelColor
+                    ]
+                )
                 menu.addItem(item)
             }
         }
         menu.addItem(NSMenuItem.separator())
+        let footerItem = infoItem(" \(footer)")
+        footerItem.representedObject = "footer"
+        menu.addItem(footerItem)
         menu.addItem(NSMenuItem(title: "Refresh", action: #selector(refreshClicked(_:)), keyEquivalent: "r"))
         menu.addItem(NSMenuItem(title: "Quit OMH Menu Bar", action: #selector(quitClicked(_:)), keyEquivalent: "q"))
-        statusItem.menu = menu
     }
 
-    private func disabledItem(_ title: String) -> NSMenuItem {
+    private func infoItem(_ title: String) -> NSMenuItem {
         let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
-        item.isEnabled = false
+        item.isEnabled = true
         return item
     }
 
@@ -594,14 +686,16 @@ final class OMHMenuBarDelegate: NSObject, NSApplicationDelegate {
         process.standardError = Pipe()
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
             return nil
         }
+        // Read before waiting: a payload larger than the pipe buffer would
+        // otherwise block the child on write while we block on exit.
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
         guard process.terminationStatus == 0 else {
             return nil
         }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard
             let object = try? JSONSerialization.jsonObject(with: data, options: []),
             let payload = object as? [String: Any]

--- a/src/surfaces/menubar_status.py
+++ b/src/surfaces/menubar_status.py
@@ -59,7 +59,7 @@ def build_menubar_status_payload(
     hermes_agents = _hermes_agent_rows(paths)
     external_executors = _external_executor_rows(paths, limit=safe_limit)
     current_executor, current_executor_source = _select_current_external_executor(paths, external_executors)
-    hermes_sessions = observe_hermes_sessions(paths)
+    hermes_sessions = observe_hermes_sessions(paths, now=now)
     model_settings = read_hermes_model_settings(paths)
     hermes_processes = (
         observe_hermes_processes(now=now) if observe_local_processes else _unrequested_process_observation(now=now)
@@ -463,7 +463,7 @@ def _display(
         headline = "OMH ready" if connection_ready else "OMH needs attention"
     pieces: list[str] = []
     if processes_observed:
-        pieces.append(f"{agent_count} agent · {process_count} processes")
+        pieces.append(f"{_plural(agent_count, 'agent')} · {_plural(process_count, 'process', 'processes')}")
     if sessions_observed:
         pieces.append(f"sessions live {live} / total {_safe_int(hermes_sessions.get('total'), 0)}")
     else:
@@ -481,6 +481,10 @@ def _display(
         "summary_line": " · ".join(pieces),
         "menu_cards": _menu_cards(settings, hermes_sessions, model_settings, current_executor_row),
     }
+
+
+def _plural(count: int, singular: str, plural: str = "") -> str:
+    return f"{count} {singular if count == 1 else (plural or singular + 's')}"
 
 
 def _menu_cards(
@@ -521,15 +525,22 @@ def _sessions_card(hermes_sessions: dict[str, Any]) -> dict[str, Any]:
             "footer": str(hermes_sessions.get("reason", "") or "not observed"),
         }
     live = _safe_int(hermes_sessions.get("live"), 0)
+    stale = _safe_int(hermes_sessions.get("stale"), 0)
     total = _safe_int(hermes_sessions.get("total"), 0)
+    window_minutes = max(1, _safe_int(hermes_sessions.get("live_window_seconds"), 0) // 60)
+    rows = [
+        {"kind": "table_row", "left": "live", "right": str(live), "tone": "ok" if live else "neutral"},
+    ]
+    # Open rows Hermes never closed (crash, killed terminal, orphan not yet
+    # reaped) are shown as their own line instead of inflating `live`.
+    if stale:
+        rows.append({"kind": "table_row", "left": "open, idle", "right": str(stale), "tone": "neutral"})
+    rows.append({"kind": "table_row", "left": "total", "right": str(total), "tone": "ok" if total else "neutral"})
     return {
         "title": "Sessions",
         "columns": ["Hermes session", "Count"],
-        "rows": [
-            {"kind": "table_row", "left": "live", "right": str(live), "tone": "ok" if live else "neutral"},
-            {"kind": "table_row", "left": "total", "right": str(total), "tone": "ok" if total else "neutral"},
-        ],
-        "footer": "Observed from Hermes state.db (read-only).",
+        "rows": rows,
+        "footer": f"live = activity within {window_minutes} min · Hermes state.db (read-only)",
     }
 
 
@@ -549,6 +560,11 @@ def _models_card(hermes_sessions: dict[str, Any], model_settings: dict[str, Any]
     main = aliases.get("main")
     if main is not None and len(rows) < 5:
         rows.append({"kind": "table_row", "left": "main", "right": str(main.get("label", "") or "inherit")})
+    # The delegation model is what fan-out children run when no OMH route is
+    # set; on a machine whose main model differs it is the more useful line.
+    delegation = _dict(model_settings.get("delegation"))
+    if delegation.get("configured") and len(rows) < 5:
+        rows.append({"kind": "table_row", "left": "delegation", "right": str(delegation.get("label", "") or "inherit")})
     inherit_count = sum(
         1
         for alias in HERMES_AUX_ALIASES
@@ -566,7 +582,7 @@ def _models_card(hermes_sessions: dict[str, Any], model_settings: dict[str, Any]
         "title": "Models",
         "columns": ["Alias", "Model"],
         "rows": rows,
-        "footer": "current = live session · main/aux = config.yaml",
+        "footer": "current = live session · main/delegation/aux = config.yaml",
     }
 
 

--- a/tests/test_hermes_model_settings.py
+++ b/tests/test_hermes_model_settings.py
@@ -149,6 +149,32 @@ class HermesModelSettingsTests(unittest.TestCase):
                 self.assertFalse(result["observed"])
                 self.assertEqual(result["reason"], "config_unreadable")
 
+    def test_delegation_block_is_read_beside_the_aliases(self) -> None:
+        # `delegation:` is what every delegate_task child inherits when no OMH
+        # route is set; it is reported as its own entry so the alias tuple
+        # stays the exact auxiliary contract.
+        result = self._read(
+            "model:\n  default: gpt-5.6-sol\nagent:\n  reasoning_effort: medium\n"
+            "delegation:\n  model: 'gpt-6-astra'\n  reasoning_effort: 'high'\n  provider: 'openai-codex'\n"
+            "  max_iterations: 250\n"
+        )
+        self.assertEqual(
+            result["delegation"],
+            {
+                "alias": "delegation",
+                "model": "gpt-6-astra",
+                "effort": "high",
+                "provider": "openai-codex",
+                "source": "config.delegation.model",
+                "configured": True,
+                "label": "gpt-6-astra:high",
+            },
+        )
+        self.assertEqual(tuple(entry["alias"] for entry in result["aliases"]), ("main",) + HERMES_AUX_ALIASES)
+        absent = self._read("model:\n  default: gpt-5.6-sol\n")
+        self.assertFalse(absent["delegation"]["configured"])
+        self.assertEqual(absent["delegation"]["label"], "inherit")
+
     def test_alias_order_is_the_exact_hermes_contract(self) -> None:
         result = self._read("model:\n  default:\n")
         self.assertEqual(

--- a/tests/test_hermes_sessions.py
+++ b/tests/test_hermes_sessions.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -12,7 +13,7 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.paths import OmhPaths
-from omh.surfaces.hermes_sessions import HERMES_SESSION_SCHEMA_VERSION, observe_hermes_sessions
+from omh.surfaces.hermes_sessions import HERMES_SESSION_SCHEMA_VERSION, LIVE_WINDOW_SECONDS, observe_hermes_sessions
 
 
 CREATE_SESSIONS = """
@@ -32,7 +33,7 @@ create table sessions (
 
 
 class HermesSessionObservationTests(unittest.TestCase):
-    def test_observes_visible_sessions_and_latest_live_model_with_three_selects(self) -> None:
+    def test_observes_visible_sessions_and_latest_live_model_with_two_selects(self) -> None:
         with TemporaryDirectory() as tmp:
             paths = self._paths(Path(tmp))
             paths.hermes_home.mkdir()
@@ -68,13 +69,13 @@ class HermesSessionObservationTests(unittest.TestCase):
                 return observed_connection
 
             with patch("omh.surfaces.hermes_sessions.sqlite3.connect", side_effect=recording_connect):
-                payload = observe_hermes_sessions(paths)
+                payload = observe_hermes_sessions(paths, now="2026-08-04T00:05:00Z")
 
             self.assertEqual(
                 connect_calls,
                 [(f"{db_path.resolve().as_uri()}?mode=ro", {"uri": True, "timeout": 1.0})],
             )
-            self.assertEqual(len(statements), 3)
+            self.assertEqual(len(statements), 2)
             self.assertTrue(all(statement.lower().startswith("select ") for statement in statements))
             self.assertTrue(all("source" not in statement.lower() for statement in statements))
             self.assertTrue(all("title" not in statement.lower() for statement in statements))
@@ -82,7 +83,12 @@ class HermesSessionObservationTests(unittest.TestCase):
             self.assertEqual(payload["schema_version"], HERMES_SESSION_SCHEMA_VERSION)
             self.assertTrue(payload["observed"])
             self.assertEqual(payload["reason"], "")
-            self.assertEqual(payload["live"], 2)
+            # Two rows are open, but only the one touched within the live
+            # window counts as live; the other is open and idle.
+            self.assertEqual(payload["live"], 1)
+            self.assertEqual(payload["open"], 2)
+            self.assertEqual(payload["stale"], 1)
+            self.assertEqual(payload["live_window_seconds"], LIVE_WINDOW_SECONDS)
             self.assertEqual(payload["total"], 3)
             self.assertEqual(
                 payload["current_model"],
@@ -154,7 +160,7 @@ class HermesSessionObservationTests(unittest.TestCase):
                 connection.commit()
                 connection.close()
 
-                payload = observe_hermes_sessions(paths)
+                payload = observe_hermes_sessions(paths, now="2026-08-01T00:01:00Z")
 
                 self.assertTrue(payload["observed"])
                 self.assertEqual(payload["reason"], "")
@@ -175,7 +181,7 @@ class HermesSessionObservationTests(unittest.TestCase):
                 connection.commit()
                 connection.close()
 
-                payload = observe_hermes_sessions(paths)
+                payload = observe_hermes_sessions(paths, now="2026-08-01T00:01:00Z")
 
                 self.assertTrue(payload["observed"])
                 self.assertEqual(
@@ -188,6 +194,39 @@ class HermesSessionObservationTests(unittest.TestCase):
                         "label": "model-only",
                     },
                 )
+
+    def test_open_sessions_without_recent_activity_are_idle_not_live(self) -> None:
+        # The owner's state.db held 53 rows with no `ended_at` (crashes,
+        # killed terminals, orphans Hermes reaps only on its next startup)
+        # whose last activity was two days old, and the menu bar read
+        # "live 53" for two days. Hermes stores REAL epoch seconds.
+        now = 1_800_000_000.0
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(Path(tmp))
+            paths.hermes_home.mkdir()
+            connection = sqlite3.connect(paths.hermes_home / "state.db")
+            connection.execute(CREATE_SESSIONS)
+            rows = [
+                ("tui", "stale-a", None, None, 0, 0, now - 200_000, now - 172_800, "secret", 1),
+                ("tui", "stale-b", None, None, 0, 0, now - 200_000, None, "secret", 2),
+                ("tui", "fresh", '{"provider": "og"}', None, 0, 0, now - 3_000, now - LIVE_WINDOW_SECONDS + 5, "secret", 3),
+                ("tui", "just-outside", None, None, 0, 0, now - 3_000, now - LIVE_WINDOW_SECONDS - 5, "secret", 4),
+            ]
+            connection.executemany("insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows)
+            connection.commit()
+            connection.close()
+
+            payload = observe_hermes_sessions(paths, now=datetime.fromtimestamp(now, tz=timezone.utc))
+
+            self.assertEqual((payload["live"], payload["open"], payload["stale"], payload["total"]), (1, 4, 3, 4))
+            self.assertEqual(payload["current_model"]["value"], "fresh")
+            self.assertEqual(payload["current_model"]["provider"], "og")
+
+            nothing_recent = observe_hermes_sessions(paths, now=datetime.fromtimestamp(now + 86_400, tz=timezone.utc))
+            self.assertEqual((nothing_recent["live"], nothing_recent["stale"]), (0, 4))
+            # No live session means no "current" model: the newest idle row's
+            # model is not what is running now.
+            self.assertFalse(nothing_recent["current_model"]["observed"])
 
     @staticmethod
     def _paths(root: Path) -> OmhPaths:

--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -304,6 +304,38 @@ class MenubarAppTests(unittest.TestCase):
         self.assertIn('display?["menu_bar_title"]', source)
         self.assertNotIn('agent_status', source)
 
+    def test_native_helper_refreshes_off_the_main_thread_and_updates_the_open_menu(self) -> None:
+        # The owner's report: the menu looked stuck on its first reading.
+        # Three causes, each pinned here. The status subprocess ran on the
+        # main thread (a ~0.5s freeze every tick); the timer lived in the
+        # default run-loop mode, silent for as long as the menu stayed open;
+        # and every refresh replaced `statusItem.menu`, which AppKit only
+        # shows on the NEXT open. One long-lived NSMenu mutated in place,
+        # a `.common`-mode timer, a background queue, and a refresh on
+        # `menuWillOpen` are the fix; the footer stamps the reading's time.
+        source = menubar_app_module._SWIFT_SOURCE
+
+        self.assertIn("NSMenuDelegate", source)
+        self.assertIn("func menuWillOpen(_ menu: NSMenu)", source)
+        self.assertIn("RunLoop.main.add(timer, forMode: .common)", source)
+        self.assertIn("refreshQueue.async { [weak self] in", source)
+        self.assertIn("DispatchQueue.main.async {", source)
+        self.assertIn("menu.removeAllItems()", source)
+        self.assertEqual(source.count("statusItem.menu = menu"), 1)
+        self.assertNotIn("let menu = NSMenu()", source.split("private let menu = NSMenu()", 1)[1])
+        self.assertIn('let stamp = "Updated \\(clock.string(from: refreshedAt))"', source)
+        # A single failed read keeps the last good cards instead of flashing
+        # the attention mark; the mark returns once the failure persists.
+        self.assertIn("if lastPayload != nil && consecutiveFailures < 3 {", source)
+        # Rows are information, not commands: enabled so they render in the
+        # normal text color rather than the disabled gray that reads as
+        # "still loading".
+        self.assertIn("menu.autoenablesItems = false", source)
+        self.assertIn("item.isEnabled = true", source)
+        self.assertNotIn("item.isEnabled = false", source)
+        # Drain stdout before waiting so a large payload cannot deadlock.
+        self.assertLess(source.index("readDataToEndOfFile()"), source.index("process.waitUntilExit()"))
+
     def test_native_helper_loads_template_icon_at_18_points_with_accessible_label(self) -> None:
         source = menubar_app_module._SWIFT_SOURCE
 

--- a/tests/test_menubar_status.py
+++ b/tests/test_menubar_status.py
@@ -4,6 +4,7 @@ import io
 import json
 import sqlite3
 import subprocess
+import time
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -16,7 +17,7 @@ load_local_package()
 from omh.cli import build_parser
 from omh.menubar_status import build_menubar_status_payload, model_icon_descriptor, source_icon_descriptor
 from omh.paths import resolve_paths
-from omh.surfaces.menubar_status import _display, _models_card
+from omh.surfaces.menubar_status import _display, _models_card, _sessions_card
 from omh.targets import record_target_observation
 
 
@@ -117,6 +118,51 @@ class MenubarStatusTests(unittest.TestCase):
             payload = json.loads(stdout)
             current_row = next(row for row in payload["display"]["menu_cards"][1]["rows"] if row["left"] == "current")
             self.assertEqual(current_row["right"], long_model)
+
+    def test_sessions_card_shows_idle_open_rows_apart_from_live(self) -> None:
+        # The owner's menu bar read "live 53" for two days: 53 rows Hermes
+        # never closed, none touched since. Idle rows get their own line and
+        # never inflate `live`; the footer says what live means.
+        card = _sessions_card({"observed": True, "live": 1, "open": 54, "stale": 53, "total": 642, "live_window_seconds": 900})
+        self.assertEqual(
+            [(row["left"], row["right"], row["tone"]) for row in card["rows"]],
+            [("live", "1", "ok"), ("open, idle", "53", "neutral"), ("total", "642", "ok")],
+        )
+        self.assertEqual(card["footer"], "live = activity within 15 min · Hermes state.db (read-only)")
+        quiet = _sessions_card({"observed": True, "live": 0, "open": 0, "stale": 0, "total": 2, "live_window_seconds": 900})
+        self.assertEqual([row["left"] for row in quiet["rows"]], ["live", "total"])
+
+    def test_summary_line_pluralizes_agents_and_processes(self) -> None:
+        one = _display(
+            {"omh_connection": {"value": "ready"}},
+            {"observed": True, "agent_count": 1, "process_count": 1},
+            {"observed": True, "live": 0, "total": 4},
+            {},
+            {},
+        )
+        self.assertEqual(one["summary_line"], "1 agent · 1 process · sessions live 0 / total 4")
+        many = _display(
+            {"omh_connection": {"value": "ready"}},
+            {"observed": True, "agent_count": 2, "process_count": 3},
+            {"observed": True, "live": 1, "total": 4},
+            {},
+            {},
+        )
+        self.assertEqual(many["summary_line"], "2 agents · 3 processes · sessions live 1 / total 4")
+
+    def test_models_card_lists_the_delegation_model_after_main(self) -> None:
+        card = _models_card(
+            {"current_model": {"observed": False}},
+            {
+                "aliases": [{"alias": "main", "configured": True, "label": "gpt-5.6-sol:medium"}],
+                "delegation": {"alias": "delegation", "configured": True, "label": "gpt-6-astra:high"},
+            },
+        )
+        self.assertEqual(
+            [(row["left"], row["right"]) for row in card["rows"]],
+            [("main", "gpt-5.6-sol:medium"), ("delegation", "gpt-6-astra:high")],
+        )
+        self.assertEqual(card["footer"], "current = live session · main/delegation/aux = config.yaml")
 
     def test_models_card_reserves_final_row_for_inherited_auxiliary_summary(self) -> None:
         card = _models_card(
@@ -823,11 +869,14 @@ class MenubarStatusTests(unittest.TestCase):
             )"""
         )
         current_config = json.dumps({"provider": "openai-codex", "reasoning_config": {"effort": "medium"}})
+        # Hermes stores REAL epoch seconds; the open row was touched just now
+        # so it counts as live under the real clock the CLI path runs on.
+        now = time.time()
         connection.executemany(
             "insert into sessions values (?, ?, ?, ?, ?, ?, ?, ?)",
             [
-                ("tui", "gpt-5.6-sol", current_config, None, 0, 0, "2026-08-15", "2026-08-16"),
-                ("api", "older", "{}", "2026-08-15", 0, 0, "2026-08-14", "2026-08-15"),
+                ("tui", "gpt-5.6-sol", current_config, None, 0, 0, now - 600, now - 30),
+                ("api", "older", "{}", now - 86_400, 0, 0, now - 90_000, now - 86_400),
             ],
         )
         connection.commit()


### PR DESCRIPTION
## Feature Report

### Capability
The macOS menu bar helper shows a reading that is actually current: the sessions count reflects sessions with recent activity, the menu updates while it is open, refreshes never freeze the menu bar, and the Models card names the model fan-out children really run.

### Motivation
Owner report with a screenshot: the menu looked stuck ("loading 최신화가 안 되는 것 같고 버그가 많은 것 같은데"). Measured on the owner machine:

- `sessions live 53` for two days. All 53 were open rows Hermes never closed (crashes, killed terminals, orphans reaped only on the next startup); none had activity in the last hour. The number could not move.
- Every refresh ran the status subprocess synchronously on the main thread (~0.5 s), the timer lived in the default run-loop mode (silent while a menu is open), and each refresh replaced `statusItem.menu`, which AppKit shows only on the next open. Together: what you see when you open the menu is the previous reading, and it never changes while open.
- All rows were disabled `NSMenuItem`s, rendered in the disabled gray that reads as "still loading".
- `1 processes`; Models listed `current`/`main` but not the `delegation` model, which is what `delegate_task` children inherit (Astra on the owner machine while main is Sol).

### Implementation (boundary level)
- `src/surfaces/hermes_sessions.py`: `live` = open session with activity within `LIVE_WINDOW_SECONDS` (15 min); new `open`, `stale`, `live_window_seconds` fields; `current_model` comes from the most recently active live session and is absent when none is live. Handles Hermes' REAL epoch columns and ISO text. Two selects instead of three. `now` seam.
- `src/surfaces/hermes_model_settings.py`: reads the `delegation:` block (model, reasoning_effort, provider) into a separate `delegation` entry; the alias tuple stays the exact Hermes auxiliary contract.
- `src/surfaces/menubar_status.py`: Sessions card adds an `open, idle` row only when non-zero and a footer that says what live means; Models card adds `delegation` after `main`; summary pluralizes agent/process.
- `src/surfaces/menubar_app.py` (embedded Swift): one long-lived `NSMenu` mutated in place (`autoenablesItems = false`, rows enabled), `NSMenuDelegate.menuWillOpen` triggers a refresh, timer scheduled in `.common` mode, status subprocess on a background queue with results applied on main, stdout drained before `waitUntilExit`, a single failed read keeps the last good cards (attention mark after 3 consecutive failures), and an `Updated HH:MM:SS` footer.
- `src/commands/menubar.py`: human output shows `idle N` and pluralizes.
- `docs/ARCHITECTURE.md`: Sessions/Models card contract updated.

### Verification (observed)
- Owner machine, this branch: `Activity: 1 agent · 1 process · sessions live 0 / total 642`, Sessions `live 0 / open, idle 53 / total 642`, Models `main gpt-5.6-sol:medium / delegation gpt-6-astra:high`.
- `swiftc -framework AppKit` compile of the embedded helper source: exit 0 (also covered by `test_native_helper_swift_source_compiles_on_darwin`).
- `PYTHONPATH=tests uv run python -m unittest tests/test_hermes_sessions.py tests/test_hermes_model_settings.py tests/test_menubar_status.py tests/test_menubar_app.py` → 63 OK.
- `docs workflows --check`, `docs roles --check`, ruff, compileall, `git diff --check` clean.
- Full suite: see the commit trailer.

### Risks
- A session idle for more than 15 minutes but still open is now `open, idle`, not `live`; the menu bar title (`agents·live`) drops accordingly. That is the intended reading.
- Not observed: the rebuilt helper running on the owner machine. It reaches there through `omh update` (which recompiles and restarts the LaunchAgent) after the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
