### PR TITLE
fix(update): spawned interpreters run the generation's package, not the cwd's

### DIFF
--- a/src/commands/main.py
+++ b/src/commands/main.py
@@ -521,8 +521,11 @@ def _run_auto_update(args: argparse.Namespace, paths, result: dict[str, object])
             # Fail fast on a malformed argv rather than handing it to a
             # subprocess that can only report it as an opaque exit code.
             build_parser().parse_args(update_argv)
+            # `-P`: the launch may happen inside a source checkout whose
+            # top-level `omh/` shim would otherwise sit at sys.path[0] and run
+            # the checkout instead of this installed package.
             completed = subprocess.run(
-                [sys.executable, "-m", "omh.cli", *update_argv],
+                [sys.executable, "-P", "-m", "omh.cli", *update_argv],
                 timeout=_AUTO_UPDATE_SUBPROCESS_TIMEOUT_SECONDS,
             )
             if completed.returncode == 0:

--- a/src/install/self_update.py
+++ b/src/install/self_update.py
@@ -41,6 +41,21 @@ def _python(generation: Path, platform: SelfUpdatePlatform) -> str:
     return str(platform.scripts_dir(generation / "venv") / executable)
 
 
+def _omh_cli(python: str, *arguments: str) -> list[str]:
+    """`python -P -m omh.cli ...`: the generation's own package, never the cwd's.
+
+    `python -m` puts the working directory at `sys.path[0]`. An `omh update`
+    run from inside a source checkout (which ships a top-level `omh/` shim
+    package) therefore re-entered the checkout's code instead of the
+    generation that had just been activated: on the owner machine the 2.0.2
+    candidate was judged by a stale 2.0.1 checkout, refused, rolled back, and
+    the rollback re-entry stamped the manifest `2.0.1`. `-P` (Python 3.11+,
+    the package floor) drops that entry so the interpreter resolves `omh`
+    from its own site-packages wherever the operator happens to stand.
+    """
+    return [python, "-P", "-m", "omh.cli", *arguments]
+
+
 def _run(runner: Runner, command: list[str], *, env: dict[str, str] | None = None, timeout: float | None = None, capture: bool = True) -> subprocess.CompletedProcess[str]:
     return runner(command, text=True, stdout=subprocess.PIPE if capture else None, stderr=subprocess.PIPE if capture else None, env=env, timeout=timeout)
 
@@ -70,7 +85,7 @@ def _smoke(candidate: Path, expected_version: str, *, runner: Runner, platform: 
         env["OMH_HOME"] = str(Path(temporary) / "omh")
         env["HERMES_HOME"] = str(Path(temporary) / "hermes")
         python = _python(candidate, platform)
-        checks = (([python, "-c", "import omh.cli"], "import"), ([python, "-m", "omh.cli", "--version"], "version"), ([python, "-m", "omh.cli", "update", "--command-package-updated", "--no-interactive", "--json"], "workflow-pack"))
+        checks = (([python, "-P", "-c", "import omh.cli"], "import"), (_omh_cli(python, "--version"), "version"), (_omh_cli(python, "update", "--command-package-updated", "--no-interactive", "--json"), "workflow-pack"))
         try:
             for command, name in checks:
                 checked = _run(runner, command, env=env)
@@ -101,7 +116,7 @@ def _reenter(root: Path, generation: Path, args: Any, runner: Runner, platform: 
     if not same_existing_path(pointed, trusted):
         raise OmhError("cannot re-enter an untrusted self-update generation")
     env = dict(os.environ, OMH_UPDATE_COMMAND_PACKAGE_REENTERED="1", OMH_SELF_UPDATE_GENERATION=str(trusted))
-    command = [_python(root / "current", platform), "-m", "omh.cli", *_reentry_argv()]
+    command = _omh_cli(_python(root / "current", platform), *_reentry_argv())
     # stdout stays on the terminal so the re-entered update's own progress and
     # prompts show live; stderr is captured so the failure that stops the
     # update reaches the summary line, then replayed so nothing is lost.

--- a/tests/test_staged_self_update.py
+++ b/tests/test_staged_self_update.py
@@ -98,7 +98,7 @@ class StagedSelfUpdateTests(unittest.TestCase):
                 return subprocess.CompletedProcess(command, 0, "", "")
             if command[1:4] == ["-m", "pip", "install"]:
                 return subprocess.CompletedProcess(command, failure == "pip", "", "pip failed")
-            if command[1:3] == ["-c", "import omh.cli"]:
+            if command[1:4] == ["-P", "-c", "import omh.cli"]:
                 return subprocess.CompletedProcess(command, failure == "import", "", "import failed")
             if "--version" in command:
                 return subprocess.CompletedProcess(command, 0, version or "1.0.7\n", "")
@@ -816,6 +816,54 @@ class StagedSelfUpdateTests(unittest.TestCase):
             candidate = Path(result["candidate"]["path"])
             self.assertEqual(json.loads(manifest_path.read_text())["skills_dir"], str(candidate / "skills"))
             self._assert_pair(root, candidate)
+
+    def test_every_generation_interpreter_call_ignores_the_working_directory(self):
+        # The owner's 2.0.2 -> "2.0.1" update: `omh update` was run from inside
+        # a source checkout, whose top-level `omh/` shim sat at `sys.path[0]`
+        # for every `python -m omh.cli` the transaction spawned. The stale
+        # checkout judged the fresh candidate, refused it, rolled back, and
+        # stamped the manifest with its own version. `-P` keeps the smoke and
+        # both re-entries on the generation's own package.
+        with TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            legacy, args, plan = self._fixture(root, pointer=True)
+            plan["release"].version = "1.0.7"
+            commands: list[list[str]] = []
+            fake = self._runner(version="1.0.7\n")
+
+            def run(command, **kwargs):
+                commands.append(list(command))
+                return fake(command, **kwargs)
+
+            result = self._run(root, args, plan, run)
+            self.assertTrue(result["ok"], result)
+            omh_calls = [command for command in commands if "omh.cli" in " ".join(command)]
+            self.assertEqual(len(omh_calls), 4, omh_calls)  # import, version, pack smoke, re-entry
+            for command in omh_calls:
+                self.assertEqual(command[1], "-P", command)
+            self.assertEqual(omh_calls[0][1:4], ["-P", "-c", "import omh.cli"])
+            self.assertEqual(omh_calls[-1][1:4], ["-P", "-m", "omh.cli"])
+            self.assertIn("--command-package-updated", omh_calls[-1])
+
+    def test_dash_p_is_what_keeps_a_checkout_shim_out_of_the_interpreter(self):
+        # The mechanism itself, on the real interpreter: a directory holding an
+        # `omh/cli.py` wins `python -m omh.cli` when it is the cwd, and loses
+        # once `-P` drops the cwd from sys.path.
+        with TemporaryDirectory() as temporary:
+            shadow = Path(temporary) / "omh"
+            shadow.mkdir()
+            (shadow / "__init__.py").write_text("")
+            (shadow / "cli.py").write_text("print('SHADOWED')\n")
+            env = {key: value for key, value in os.environ.items() if key != "PYTHONPATH"}
+            env["PYTHONSAFEPATH"] = ""
+            plain = subprocess.run(
+                [sys.executable, "-m", "omh.cli"], cwd=temporary, env=env, text=True, capture_output=True, check=False
+            )
+            isolated = subprocess.run(
+                [sys.executable, "-P", "-m", "omh.cli"], cwd=temporary, env=env, text=True, capture_output=True, check=False
+            )
+            self.assertEqual(plain.stdout.strip(), "SHADOWED")
+            self.assertNotIn("SHADOWED", isolated.stdout)
 
     def test_staged_transaction_regression_guard_names_the_refusal_it_prevents(self):
         # Proves the guard above is load-bearing: judging the candidate by the

--- a/tests/test_update_check_command.py
+++ b/tests/test_update_check_command.py
@@ -312,7 +312,8 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
             run.assert_called_once()
             spawned_argv = run.call_args.args[0]
             self.assertEqual(spawned_argv[0], sys.executable)
-            self.assertEqual(spawned_argv[1:3], ["-m", "omh.cli"])
+            # `-P` keeps a source checkout at the launch cwd from shadowing the package.
+            self.assertEqual(spawned_argv[1:4], ["-P", "-m", "omh.cli"])
             self.assertIn("update", spawned_argv)
             self.assertIn("--no-interactive", spawned_argv)
             # `--yes` would preset the branded-TUI identity choice
@@ -321,7 +322,7 @@ class StartupCheckLaunchIntegrationTests(unittest.TestCase):
             self.assertNotIn("--yes", spawned_argv)
             # The synthesized argv (after the interpreter/module prefix) must
             # be a valid CLI invocation, not just plausible-looking strings.
-            main_module.build_parser().parse_args(spawned_argv[3:])
+            main_module.build_parser().parse_args(spawned_argv[4:])
 
             state = read_json_object(paths.runtime_state_path) or {}
             self.assertIn("last_update", state)


### PR DESCRIPTION
## Feature Report

### Capability
Every interpreter the self-update spawns (`import`/`--version`/pack smokes, the post-activation re-entry, the rollback re-entry) and the startup auto-update re-exec run with `python -P`, so they execute the generation's own installed package regardless of the directory `omh update` was launched from.

### Motivation
Owner report: `omh update` printed `Previous release: 2.0.2 / Installed release: 2.0.1 / Release version: 2.0.2 -> 2.0.1`. Reconstructed on the owner machine:

- The update was run from inside the source checkout, which ships a top-level `omh/` shim package (`omh/__init__.py` re-pointing at `src/`). The checkout was 74 commits behind main, at version 2.0.1.
- `python -m omh.cli` puts the working directory at `sys.path[0]`, so every re-entry imported the checkout's stale code instead of the generation venv's 2.0.2 package. Verified: the same venv python reports `omh 2.0.1` from the checkout cwd and `omh 2.0.2` from `/tmp`; with `-P` it reports 2.0.2 from the checkout.
- The stale 2.0.1 installer (pre-#1377) judged the fresh candidate against the home manifest, refused, and the transaction rolled back to the 2.0.2 generation. The rollback re-entry, also running checkout code, printed the card and stamped `~/.omh/manifest.json` with `"version": "2.0.1"`. The active generation remained 2.0.2 throughout (`omh --version` says 2.0.2); only the manifest and the card were wrong.

### Implementation (boundary level)
- `src/install/self_update.py`: new `_omh_cli(python, *args)` builds `[python, "-P", "-m", "omh.cli", ...]`; `_smoke` and `_reenter` use it (the import smoke gets `-P -c`). `-P` is Python 3.11+, the package floor.
- `src/commands/main.py`: the auto-update re-exec gets the same `-P`.
- `tests/test_staged_self_update.py`: a transaction test asserts all four `omh.cli` spawns carry `-P` right after the interpreter; a real-interpreter test shows a cwd `omh/cli.py` wins `python -m omh.cli` and loses under `-P`.
- `tests/test_update_check_command.py`: pinned argv updated.

### Verification (observed)
- Mechanism proved on the owner machine (see Motivation).
- `PYTHONPATH=tests uv run python -m unittest tests/test_staged_self_update.py tests/test_update_check_command.py tests/test_update_check.py tests/test_atomic_installer_update.py` → 103 OK.
- ruff, compileall, `git diff --check` clean; full suite result in the commit trailer.

### Risks
- `-P` also stops `PYTHONSAFEPATH`-style script-dir lookups for these spawns; nothing in the generation relies on that, and the console script path never did.
- The owner machine's manifest still says 2.0.1 until the next successful update rewrites it; running `omh update` from any directory outside the checkout does that with the installed 2.0.2 today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
