### PR TITLE
test(menubar): Swift interpolation assertions are raw strings

### DIFF
--- a/tests/test_menubar_app.py
+++ b/tests/test_menubar_app.py
@@ -345,9 +345,9 @@ class MenubarAppTests(unittest.TestCase):
         self.assertIn('image.isTemplate = true', source)
         self.assertIn('button.imagePosition = .imageLeading', source)
         self.assertIn('button.setAccessibilityLabel(', source)
-        self.assertIn('"OMH — \(headline) — \(summary)"', source)
+        self.assertIn(r'"OMH — \(headline) — \(summary)"', source)
         self.assertNotIn('statusItem.button?.title = "omh !"', source)
-        self.assertNotIn('? "\(title) \(mark)" : menuBarTitle', source)
+        self.assertNotIn(r'? "\(title) \(mark)" : menuBarTitle', source)
 
     def test_native_helper_keeps_sessions_table_header_visible(self) -> None:
         source = menubar_app_module._SWIFT_SOURCE


### PR DESCRIPTION
## Feature Report

### What Changed

- Two assertions in `tests/test_menubar_app.py` that pin Swift string interpolation (`\(headline)`, `\(title) \(mark)`) become raw string literals.

### Why This Exists

- Python 3.12+ emits `SyntaxWarning: invalid escape sequence '\('` on every compile of the file (seen in `compileall` output since #1393), and a future Python turns it into a `SyntaxError`. Flagged as a follow-up in #1402.

### User / Operator Impact

- None at runtime; the test suite compiles warning-free.

### How It Works

- Raw strings keep the exact bytes the Swift source-contract test compares.

### Files And Contracts Touched

- `tests/test_menubar_app.py`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests` (scoped to the file)
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests` (run as `python -W error -m compileall` on the file: clean)
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -W error::SyntaxWarning -m unittest tests/test_menubar_app.py` → 22 OK
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: test-only change

### Observed Evidence

- `python -W error -m compileall tests/test_menubar_app.py` exits clean; the 22 menubar tests pass with SyntaxWarning promoted to error.

### Not Tested / Not Applicable

- Full suite and doc byte gates: one test file changed, no source or generated artifact touched; CI runs them.

## Risk

- None.

## Compatibility / Rollout

- None.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
