### PR TITLE
feat(runtime): host-supplied session activity receipts for cross-workflow learning

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@ Use [Capabilities](CAPABILITIES.md) for the manifest contract and
 | Chat cards and grounded wrapper examples | [Chat Wrapper Examples](CHAT_WRAPPER_EXAMPLES.md) |
 | Harness and quality-gate contracts | [Harness Quality Contract](HARNESS_QUALITY.md) |
 | Memory/context review and handoff packs | [Memory Context Review](MEMORY_CONTEXT.md) |
+| Host-supplied session activity receipts for cross-workflow learning | [Session Activity Receipts](SESSION-ACTIVITY-RECEIPTS.md) |
 | Common oh-my capability axes and gaps | [Parity Matrix](PARITY.md) |
 | Implemented application surfaces | [Application Cases](APPLICATION_CASES.md) |
 | Public roadmap | [Roadmap](ROADMAP.md) |

--- a/docs/SESSION-ACTIVITY-RECEIPTS.md
+++ b/docs/SESSION-ACTIVITY-RECEIPTS.md
@@ -1,0 +1,127 @@
+# Session Activity Receipts
+
+`session_activity_receipt/v1` is one bounded, host-supplied summary of one
+observed interval of one Hermes session. It exists so that workflow learning,
+context-budget review, run-efficiency analysis, skill health, achievements,
+and agent-ops review can reuse one observed record instead of each scraping a
+transcript, and so that "the skill was not used" can be told apart from "nobody
+saw whether the skill was offered".
+
+## What a receipt is, and is not
+
+A receipt is **supplied observed evidence**. The Hermes host, an observer
+plugin, a wrapper, or an operator observed a session and handed OMH a summary.
+OMH validates that summary, records it once, and projects it for consumers.
+
+A receipt is not:
+
+- automatic host execution or collection. OMH does not crawl Hermes
+  databases, patch Hermes hooks, or start any telemetry of its own. The only
+  input is a payload someone chose to supply, through
+  `omh runtime session-receipt ingest --input <file>`.
+- proof of an unobserved interval. A producer loaded mid-session reports a
+  floor for the part it watched, never the whole session.
+- execution, verification, review, CI, merge-readiness, or merge evidence.
+  Every record carries the claim boundary that says so.
+
+## Contract
+
+Every string on a receipt is either a closed-vocabulary value or an opaque
+reference; the key set is closed; arrays are capped. Raw prompts, tool
+arguments or results, transcripts, secrets, and filesystem paths cannot be
+carried, by key name (`prompt`, `transcript`, `tool_args`, `path`, ...) and by
+shape.
+
+| Field | Meaning |
+| --- | --- |
+| `receipt_id` | Stable identity for idempotent ingestion. The same id with the same observation records once; the same id with a different observation is quarantined. |
+| `producer` | `kind` in `hermes_host`, `observer_plugin`, `wrapper`, `operator`; an opaque `ref` and optional `version`. |
+| `profile_ref`, `session_ref` | Opaque identities or privacy-preserving handles. Ingestion bound to an expected profile quarantines any other. |
+| `boundary` | `kind` in `turn`, `compaction`, `snapshot`, `process_exit`, `session_end`; `final` may be true only on `session_end`; `sequence` orders boundaries within a session. |
+| `observed_interval` | `started_at`, `ended_at` (ISO-8601 UTC, `Z`), and `coverage` in `full_session`, `from_producer_load`, `unknown`. |
+| `metrics` | Per-counter readings, each `{value, availability, measurement}`. Counters: `skills_exposed`, `skills_activated`, `tool_calls`, `tool_errors`, `subagent_spawns`, `subagent_completions`, `compaction_boundaries`, `model_calls`, `model_errors`, `tokens_input`, `tokens_output`, `tokens_total`, `context_peak_tokens`, `wall_clock_ms`, `model_latency_ms`. |
+| `skills` | Bounded `exposed_names` and `activated_names` (skill labels or digest handles), truncation flags, and `name_form` (`plain` or `digest`). |
+| `model_refs`, `evidence_refs` | Bounded opaque handles. Links, secrets, and control characters fold to digests. |
+
+### Availability and measurement
+
+- `availability` is `observed`, `heuristic`, or `unavailable` per counter. A
+  counter the producer did not observe is omitted or `unavailable` with a
+  `null` value. It is never zero and never inferred from prose. A count the
+  producer derived from text, such as tool errors read off output when the
+  host supplied no structured status, is `heuristic`, and consumers list it
+  apart from observed counters.
+- `measurement` is `exact` or `floor`. When `coverage` is anything but
+  `full_session`, every observed counter must be a `floor`: a producer that
+  did not watch the whole session cannot report an exact total. The
+  validator refuses an `exact` reading under partial coverage.
+
+### Exposure versus activation
+
+`skills_exposed` and `skills_activated` are separate readings. Exposed-but-
+unused is derived only when both were observed: from the two name lists when
+both are complete, from the two counters otherwise, and `unavailable` with a
+named reason when either side is missing or the counters disagree.
+
+### Partial versus final
+
+Only a `session_end` boundary may carry `final: true`. Turn, compaction,
+snapshot, and process-exit receipts are partial; every consumer projection
+reports them as `session_outcome: partial` with `terminal: false`, so a turn
+boundary is never mistaken for the session's terminal result.
+
+## Ingestion
+
+```sh
+omh runtime session-receipt ingest --input receipt.json \
+  [--expected-profile <ref>] [--max-age-seconds <n>] [--redact-skill-names] \
+  [--consumer workflow-learning --consumer skill-health ...] [--dry-run]
+omh runtime session-receipt list [--session <ref>] [--limit <n>]
+```
+
+This is an agent, wrapper, and operator surface, not a normal user step.
+
+Outcomes:
+
+| Outcome | Meaning |
+| --- | --- |
+| `recorded` | The receipt validated and was appended to `$OMH_HOME/runtime/session_activity_receipts.jsonl`. |
+| `already_recorded` | The same receipt identity with the same observation is already on record; nothing was written. |
+| `rejected` | The payload is not a receipt. `errors` names every fault. Nothing reaches disk. |
+| `quarantined` | The payload is a receipt this store may not take: `cross_profile`, `stale_after_final` (a final receipt for the session exists), `stale_sequence` (a later boundary exists), `stale_age` (older than `--max-age-seconds`), or `identity_conflict`. Bounded handles and the reason go to `session_activity_quarantine.jsonl`; the payload does not. |
+
+`--redact-skill-names` stores every skill name as a stable digest handle for
+installs where the names themselves are sensitive. Exposed-but-unused still
+derives across digests.
+
+## Consumers
+
+The six named workflows read the same record through
+`session_activity_evidence(receipt, consumer)`, each asking about its own
+counters:
+
+| Consumer | Counters |
+| --- | --- |
+| `workflow-learning` | skills exposed/activated, tool calls, tool errors, compaction boundaries |
+| `context-budget-review` | context peak, tokens in/out/total, compaction boundaries |
+| `run-efficiency` | wall clock, model latency, tool calls, model calls, tokens total |
+| `skill-health` | skills exposed/activated |
+| `achievements` | skills activated, tool calls, subagent spawns/completions |
+| `agent-ops-review` | tool calls, tool errors, subagent spawns/completions, model calls, model errors |
+
+Every projection carries `observed_metrics`, `heuristic_metrics`, and
+`unavailable_metrics` as separate lists, `observation_floor` when coverage was
+partial, `terminal` only for a final receipt, and the claim boundary.
+Consumers that read skill counters also carry the exposure summary.
+
+Coding-unit telemetry (`omh_unit_telemetry/v1`) remains the specialized
+surface for executor units; a session receipt describes a Hermes session and
+does not replace it.
+
+## Boundaries the producer owns
+
+Token and context accounting differ by provider; a reading stays attributed
+to the producer that reported it. Text-derived error counts are heuristic
+unless the host supplies structured status. A producer that restarted or
+loaded mid-session sets `coverage: from_producer_load` (or `unknown`) and
+reports floors.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -8251,6 +8251,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - prepared-vs-observed boundary
 - Artifact expectations:
   - hermes_achievements_observation/v1 metadata-only payload from `omh achievements` when recorded
+  - supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero
 - Safety rules:
   - An achievements card reflects only locally observed hermes-achievements plugin artifacts; it is not a session-history rescan, badge recomputation, unlock proof beyond those artifacts, or productivity evidence.
   - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
@@ -8810,6 +8811,7 @@ These surfaces are generated command references, not installed Hermes workflow s
   - not_observed provider and host gaps
 - Artifact expectations:
   - run_efficiency_report/v1 metadata-only report
+  - supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero
 - Safety rules:
   - Run efficiency is supplied OMH-local metadata, not provider, billing, cron, or host evidence.
   - Do not claim connector, gateway, runtime, file generation, memory mutation, or host automation evidence from prepared guidance.
@@ -10556,6 +10558,7 @@ Plan compact context, token/cost budgets, summarization checkpoints, and overflo
   - expected duration and artifacts
   - available context sources and must-keep facts
   - token, cost, latency, or message-size constraints
+  - supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero
 - Outputs:
   - context_budget_plan/v1
   - must_keep_context_pack/v1
@@ -12723,6 +12726,7 @@ Prepare a manager-facing quality and throughput review for AI-agent research, co
   - work context or run/session references when available
   - target outcome
   - known evidence gaps
+  - supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero
 - Outputs:
   - agent_operator_productivity/v1
   - agent_operator_status_card/v1
@@ -12990,6 +12994,7 @@ Prepare a metadata-only health dashboard for OMH skills, observed failure signal
   - catalog/generated/reference surfaces
   - observed failure signals or explicit missing-signal statement
   - pending amendment sources when available
+  - supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero
 - Outputs:
   - catalog, generated, reference, harness, and capability-surface status
   - observed failure signals, or an explicit statement that none were supplied
@@ -13040,6 +13045,7 @@ Route self-improvement signals to memory, skill, wiki, failure-retrospective, au
   - self-improvement signal when available
   - observed evidence refs when available
   - feedback or failure summary
+  - supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero
 - Outputs:
   - self_improvement_store_routing/v1
   - workflow_learning_trace/v1

--- a/skills/omh-achievements/SKILL.md
+++ b/skills/omh-achievements/SKILL.md
@@ -96,6 +96,7 @@ Expected outputs:
 Artifact expectations:
 
 - hermes_achievements_observation/v1 metadata-only payload from `omh achievements` when recorded
+- supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero
 
 Safety rules:
 

--- a/skills/omh-run-efficiency/SKILL.md
+++ b/skills/omh-run-efficiency/SKILL.md
@@ -95,6 +95,7 @@ Expected outputs:
 Artifact expectations:
 
 - run_efficiency_report/v1 metadata-only report
+- supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero
 
 Safety rules:
 

--- a/src/commands/runtime.py
+++ b/src/commands/runtime.py
@@ -1303,6 +1303,7 @@ def _add_runtime_commands(sub) -> None:
     from .run_efficiency import add_runtime_efficiency_command
     from .run_health import add_runtime_health_summary_command
     from .runtime_artifact_shape import add_runtime_artifacts_show_shape_command
+    from .session_activity import add_runtime_session_receipt_commands
     from .workflow_artifacts import add_runtime_workflow_artifact_commands
 
     runtime = sub.add_parser("runtime", help="Read and record local prepared-vs-observed runtime evidence.")
@@ -1313,6 +1314,7 @@ def _add_runtime_commands(sub) -> None:
 
     add_runtime_efficiency_command(runtime_sub)
     add_runtime_health_summary_command(runtime_sub)
+    add_runtime_session_receipt_commands(runtime_sub)
 
     runtime_runs = runtime_sub.add_parser("runs")
     runtime_runs.add_argument("--limit", type=int, default=50, help="Maximum recent runs to return. Use --all for an unbounded listing.")

--- a/src/commands/session_activity.py
+++ b/src/commands/session_activity.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..installer import OmhError
+from ..workflows.session_activity_receipts import (
+    CLAIM_BOUNDARY,
+    SESSION_ACTIVITY_CONSUMERS,
+    SessionActivityReceiptError,
+    admit_session_activity_receipt,
+    ingest_session_activity_receipt,
+    read_session_activity_quarantine,
+    read_session_activity_receipts,
+    session_activity_evidence,
+)
+from .common import _paths, _print_json
+
+
+def cmd_runtime_session_receipt_ingest(args: argparse.Namespace) -> int:
+    try:
+        payload = json.loads(Path(args.input).expanduser().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OmhError(str(exc)) from exc
+    if args.max_age_seconds is not None and args.max_age_seconds < 0:
+        raise OmhError("--max-age-seconds must be zero or greater")
+    if args.dry_run:
+        admission = admit_session_activity_receipt(
+            payload,
+            expected_profile_ref=args.expected_profile or "",
+            known=read_session_activity_receipts(_paths(args)),
+            max_age_seconds=args.max_age_seconds,
+            redact_skill_names=args.redact_skill_names,
+        )
+        result = {**admission, "written": False}
+        receipt = admission["receipt"] if admission["outcome"] == "accepted" else None
+    else:
+        result = ingest_session_activity_receipt(
+            _paths(args),
+            payload,
+            expected_profile_ref=args.expected_profile or "",
+            max_age_seconds=args.max_age_seconds,
+            redact_skill_names=args.redact_skill_names,
+        )
+        receipt = result["receipt"] if result["outcome"] in ("recorded", "already_recorded") else None
+    try:
+        result["evidence"] = {
+            consumer: session_activity_evidence(receipt, consumer) if receipt else None
+            for consumer in (args.consumer or [])
+        }
+    except SessionActivityReceiptError as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(result)
+    return 0
+
+
+def cmd_runtime_session_receipt_list(args: argparse.Namespace) -> int:
+    limit = int(args.limit)
+    if limit < 1:
+        raise OmhError("--limit must be at least 1")
+    paths = _paths(args)
+    _print_json(
+        {
+            "schema_version": "session_activity_receipt_list/v1",
+            "receipts": read_session_activity_receipts(paths, session_ref=args.session, limit=limit),
+            "quarantined": read_session_activity_quarantine(paths)[-limit:],
+            "claim_boundary": CLAIM_BOUNDARY,
+        }
+    )
+    return 0
+
+
+def add_runtime_session_receipt_commands(runtime_sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    receipt = runtime_sub.add_parser(
+        "session-receipt",
+        help="Ingest or list host-supplied session_activity_receipt/v1 payloads. OMH validates what it is handed; it collects nothing.",
+    )
+    receipt_sub = receipt.add_subparsers(dest="session_receipt_command", required=True)
+
+    ingest = receipt_sub.add_parser(
+        "ingest",
+        help="Validate one supplied receipt payload, record it once, and project consumer evidence.",
+    )
+    ingest.add_argument("--input", required=True, help="Path to a session_activity_receipt/v1 JSON payload.")
+    ingest.add_argument(
+        "--expected-profile",
+        default="",
+        help="Profile ref this store is bound to; a receipt naming another profile is quarantined.",
+    )
+    ingest.add_argument(
+        "--max-age-seconds",
+        type=int,
+        default=None,
+        help="Quarantine a receipt whose observed interval ended more than this many seconds ago.",
+    )
+    ingest.add_argument(
+        "--redact-skill-names",
+        action="store_true",
+        help="Store skill names as digest handles instead of plain labels.",
+    )
+    ingest.add_argument(
+        "--consumer",
+        action="append",
+        choices=sorted(SESSION_ACTIVITY_CONSUMERS),
+        help="Project the admitted receipt as evidence for this workflow; repeatable.",
+    )
+    ingest.add_argument("--dry-run", action="store_true", help="Admit without writing anything.")
+    ingest.set_defaults(func=cmd_runtime_session_receipt_ingest)
+
+    listing = receipt_sub.add_parser("list", help="List recorded receipts and quarantined payload handles.")
+    listing.add_argument("--session", default=None, help="Only receipts for this session ref.")
+    listing.add_argument("--limit", type=int, default=20)
+    listing.set_defaults(func=cmd_runtime_session_receipt_list)

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -693,7 +693,14 @@ STANDALONE_CAPABILITY_SKILL_ITEM_CHAR_LIMIT = 2200
 # and delegation fallback contracts, and real artifact CLI pointers in their
 # bodies. Their complete skill-specific contracts move to per-skill references;
 # shared rails remain referenced rather than copied.
-FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 914399
+# 914399 -> 914611: `achievements` and `run-efficiency` name the supplied
+# `session_activity_receipt/v1` as an artifact expectation (issue #1404). One
+# bounded line each, in the always-loaded body because it is an input the
+# workflow must ask for BEFORE it reports: without it "the skill was not used"
+# reads as a finding when nobody observed whether the skill was exposed, and
+# a missing counter reads as zero. The contract itself lives in
+# `docs/SESSION-ACTIVITY-RECEIPTS.md`, outside this budget; warranted growth.
+FULL_PROFILE_SKILL_BODY_CHAR_LIMIT = 914611
 FULL_PROFILE_SKILL_BODY_REVIEWED_EXCEPTION_CHARS = 0
 
 

--- a/src/skills/catalog_feature_surfaces.py
+++ b/src/skills/catalog_feature_surfaces.py
@@ -1294,6 +1294,7 @@ _FEATURE_SURFACE_SKILLS = (
         ),
         artifact_expectations=(
             "hermes_achievements_observation/v1 metadata-only payload from `omh achievements` when recorded",
+            "supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero",
         ),
     ),
     _feature_surface_skill(

--- a/src/skills/catalog_harnesses.py
+++ b/src/skills/catalog_harnesses.py
@@ -1580,6 +1580,7 @@ _HARNESSES = [
             "expected duration and artifacts",
             "available context sources and must-keep facts",
             "token, cost, latency, or message-size constraints",
+            "supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero",
         ),
         (
             "context_budget_plan/v1",
@@ -2916,7 +2917,13 @@ _FEATURE_SURFACE_HARNESSES = (
         "agent-ops-review",
         "Prepare a manager-facing quality and throughput review for AI-agent research, coding, review, and status work.",
         "Use when a third-party operator or team lead wants to understand progress, blockers, quality gates, next actions, and safe throughput levers without running shell catalog commands.",
-        ("manager request", "work context or run/session references when available", "target outcome", "known evidence gaps"),
+        (
+            "manager request",
+            "work context or run/session references when available",
+            "target outcome",
+            "known evidence gaps",
+            "supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero",
+        ),
         ("agent_operator_productivity/v1", "agent_operator_status_card/v1", "quality lanes", "blockers", "next action", "throughput levers"),
         quality_tier="manager-review-gated",
         evidence_ladder=(
@@ -3096,6 +3103,7 @@ _FEATURE_SURFACE_HARNESSES = (
             "catalog/generated/reference surfaces",
             "observed failure signals or explicit missing-signal statement",
             "pending amendment sources when available",
+            "supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero",
         ),
         (
             "catalog, generated, reference, harness, and capability-surface status",
@@ -3130,6 +3138,7 @@ _FEATURE_SURFACE_HARNESSES = (
             "self-improvement signal when available",
             "observed evidence refs when available",
             "feedback or failure summary",
+            "supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero",
         ),
         (
             "self_improvement_store_routing/v1",

--- a/src/skills/native_capability_surfaces.py
+++ b/src/skills/native_capability_surfaces.py
@@ -48,7 +48,7 @@ def native_capability_skill_definitions(feature_surface_skill: Callable[..., obj
             good_prompt="Show the local run efficiency report from this run's supplied context budget and timings.",
             bad_prompt="Claim this report proves provider billing, host load, or cron execution without observations.",
             expected_outputs=("run_efficiency_report/v1", "context utilization", "not_observed provider and host gaps"),
-            artifact_expectations=("run_efficiency_report/v1 metadata-only report",),
+            artifact_expectations=("run_efficiency_report/v1 metadata-only report", "supplied `session_activity_receipt/v1` when available; unavailable metrics stay unavailable, never zero"),
             final_checklist=(
                 "The run ID, context budget, surfaces, and supplied observations are explicit.",
                 "Provider billing, cron, and host claims remain not_observed unless separately recorded.",

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -68,6 +68,13 @@ class OmhPaths:
         return self.runtime_dir / "plugin_host_observations.jsonl"
 
     @property
+    def runtime_session_activity_receipts_path(self) -> Path:
+        # Beside the plugin host observations, not under `journal/`: a session
+        # receipt names a host session, never a run, so the run-scoped store
+        # validators have nothing to scope it by.
+        return self.runtime_dir / "session_activity_receipts.jsonl"
+
+    @property
     def runtime_worktrees_path(self) -> Path:
         return self.runtime_dir / "worktrees.jsonl"
 

--- a/src/workflows/session_activity_receipts.py
+++ b/src/workflows/session_activity_receipts.py
@@ -955,4 +955,3 @@ def attach_session_activity_evidence(
     """
     payload["session_activity"] = session_activity_evidence(receipt, consumer) if receipt else None
     return payload
-

--- a/src/workflows/session_activity_receipts.py
+++ b/src/workflows/session_activity_receipts.py
@@ -1,0 +1,958 @@
+"""Host-supplied session activity receipts (`session_activity_receipt/v1`, issue #1404).
+
+A session activity receipt is one bounded summary of one observed interval of
+one Hermes session, supplied by the host or by an observer plugin that watched
+it. OMH does not produce one. It validates what it is handed, records it once,
+and lets the learning and operations workflows read the same record instead of
+each scraping a transcript.
+
+What the receipt separates, and why each split is a field of its own:
+
+- Exposed versus activated. "The skill was not used" is ambiguous when nobody
+  knows whether the host listed the skill in that session. `skills_exposed`
+  and `skills_activated` are separate readings, and exposed-but-unused is
+  derived only when both are present (`skill_exposure_summary`).
+- Final versus partial. A turn boundary, a compaction, a snapshot, or the
+  producer's own process exit is `final: false`. Only a `session_end` boundary
+  may be final, so a mid-session receipt can never be reported as the
+  session's terminal result.
+- Observed versus heuristic versus unavailable. Every counter carries its own
+  `availability`. A counter the producer did not observe is `unavailable` with
+  a null value -- never zero, never inferred from prose -- and a counter the
+  producer derived from text (a tool-error count read off output) is
+  `heuristic`, which every consumer keeps apart from an observed one.
+- Full session versus floor. A producer loaded mid-session saw only part of
+  it. Its `observed_interval.coverage` says so, and under that coverage every
+  observed counter must be a `floor`, because an exact total for an interval
+  the producer did not fully watch is a claim it cannot make.
+
+What the receipt never carries: prompts, tool arguments or results, secrets,
+filesystem paths, or transcripts. Every string on it is either a closed
+vocabulary value or an opaque reference, the key set is closed, the arrays are
+bounded, and skill names can be folded to digests when they are themselves
+sensitive. Nothing here crawls a host database, patches a Hermes hook, or
+collects anything on its own: the only input is a payload someone chose to
+hand over.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+from typing import Any
+
+from ..system.append_only_store import (
+    RAW_OR_HIDDEN_KEYS,
+    append_sidecar_line,
+    append_store_line,
+    digest_ref,
+    record_fingerprint,
+    redacted_ref,
+    reference_errors,
+)
+from ..system.local_store import file_lock, read_jsonl_objects, utc_now
+from ..system.metadata_safety import is_sensitive_metadata_text
+from ..system.paths import OmhPaths
+
+
+SESSION_ACTIVITY_RECEIPT_SCHEMA_VERSION = "session_activity_receipt/v1"
+SESSION_ACTIVITY_ADMISSION_SCHEMA_VERSION = "session_activity_admission/v1"
+SESSION_ACTIVITY_INGEST_RESULT_SCHEMA_VERSION = "session_activity_ingest_result/v1"
+SESSION_ACTIVITY_QUARANTINE_SCHEMA_VERSION = "session_activity_quarantine/v1"
+SESSION_ACTIVITY_EVIDENCE_SCHEMA_VERSION = "session_activity_evidence/v1"
+SESSION_ACTIVITY_STORE_VALIDATION_SCHEMA_VERSION = "session_activity_receipt_store_validation/v1"
+
+SESSION_ACTIVITY_RECEIPT_STORE_NAME = "session_activity_receipts.jsonl"
+SESSION_ACTIVITY_QUARANTINE_STORE_NAME = "session_activity_quarantine.jsonl"
+
+RECEIPT_PRIVACY = "metadata_only"
+CLAIM_BOUNDARY = (
+    "A session activity receipt is bounded metadata a host or observer supplied about one observed "
+    "interval of one session. It is not automatic host execution, not proof of anything outside the "
+    "interval it names, and never execution, verification, review, CI, merge-readiness, or merge evidence."
+)
+
+PRODUCER_KINDS = ("hermes_host", "observer_plugin", "wrapper", "operator")
+# Only `session_end` may carry `final: true`. A process exit is the producer's
+# boundary, not the session's: the session may go on without its observer.
+BOUNDARY_KINDS = ("turn", "compaction", "snapshot", "process_exit", "session_end")
+FINAL_BOUNDARY_KINDS = ("session_end",)
+# How much of the session the producer watched. Anything but `full_session`
+# is a floor: the producer arrived after the session started, or cannot say.
+COVERAGE_KINDS = ("full_session", "from_producer_load", "unknown")
+AVAILABILITIES = ("observed", "heuristic", "unavailable")
+MEASUREMENTS = ("exact", "floor")
+NAME_FORMS = ("plain", "digest")
+
+METRIC_NAMES = (
+    "skills_exposed",
+    "skills_activated",
+    "tool_calls",
+    "tool_errors",
+    "subagent_spawns",
+    "subagent_completions",
+    "compaction_boundaries",
+    "model_calls",
+    "model_errors",
+    "tokens_input",
+    "tokens_output",
+    "tokens_total",
+    "context_peak_tokens",
+    "wall_clock_ms",
+    "model_latency_ms",
+)
+
+# Which readings each named consumer workflow reads off the receipt. The
+# receipt is one record; the consumer projections differ only in which
+# counters they ask about, so a metric one consumer reads as observed can
+# never be a metric another consumer reads as zero.
+SESSION_ACTIVITY_CONSUMERS: dict[str, tuple[str, ...]] = {
+    "workflow-learning": (
+        "skills_exposed",
+        "skills_activated",
+        "tool_calls",
+        "tool_errors",
+        "compaction_boundaries",
+    ),
+    "context-budget-review": (
+        "context_peak_tokens",
+        "tokens_input",
+        "tokens_output",
+        "tokens_total",
+        "compaction_boundaries",
+    ),
+    "run-efficiency": ("wall_clock_ms", "model_latency_ms", "tool_calls", "model_calls", "tokens_total"),
+    "skill-health": ("skills_exposed", "skills_activated"),
+    "achievements": ("skills_activated", "tool_calls", "subagent_spawns", "subagent_completions"),
+    "agent-ops-review": (
+        "tool_calls",
+        "tool_errors",
+        "subagent_spawns",
+        "subagent_completions",
+        "model_calls",
+        "model_errors",
+    ),
+}
+
+RECEIPT_KEYS = (
+    "boundary",
+    "claim_boundary",
+    "evidence_refs",
+    "metrics",
+    "model_refs",
+    "observed_at",
+    "observed_interval",
+    "privacy",
+    "producer",
+    "profile_ref",
+    "receipt_id",
+    "schema_version",
+    "session_ref",
+    "skills",
+)
+PRODUCER_KEYS = ("kind", "ref", "version")
+BOUNDARY_KEYS = ("kind", "final", "sequence")
+INTERVAL_KEYS = ("started_at", "ended_at", "coverage")
+READING_KEYS = ("value", "availability", "measurement")
+SKILLS_KEYS = (
+    "exposed_names",
+    "activated_names",
+    "exposed_names_truncated",
+    "activated_names_truncated",
+    "name_form",
+)
+
+# Key names raw session material arrives under, on top of the shared list.
+# The key set is closed anyway; naming these makes the refusal say why.
+RAW_SESSION_KEYS = frozenset(
+    {
+        "tool_args",
+        "tool_arguments",
+        "tool_input",
+        "tool_inputs",
+        "tool_output",
+        "tool_outputs",
+        "tool_result",
+        "tool_results",
+        "messages",
+        "prompts",
+        "path",
+        "paths",
+        "cwd",
+        "file_path",
+        "file_paths",
+    }
+)
+
+# A skill name is a catalog label, never a path: no slash, unlike the wider
+# opaque-reference shape evidence handles use.
+_SKILL_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
+
+MAX_METRIC_VALUE = 10**12
+MAX_SEQUENCE = 10**9
+MAX_SKILL_NAMES = 64
+MAX_MODEL_REFS = 16
+MAX_EVIDENCE_REFS = 8
+MAX_QUARANTINE_ERRORS = 8
+
+# Everything that identifies *which observation* a receipt records. The
+# ingest stamp is excluded: re-sending the same receipt must not become a
+# second record because the clock moved.
+_OBSERVATION_IDENTITY_KEYS = (
+    "boundary",
+    "evidence_refs",
+    "metrics",
+    "model_refs",
+    "observed_interval",
+    "producer",
+    "profile_ref",
+    "receipt_id",
+    "session_ref",
+    "skills",
+)
+
+ADMISSION_ACCEPTED = "accepted"
+ADMISSION_REJECTED = "rejected"
+ADMISSION_QUARANTINED = "quarantined"
+ADMISSION_OUTCOMES = (ADMISSION_ACCEPTED, ADMISSION_REJECTED, ADMISSION_QUARANTINED)
+
+REASON_INVALID = "invalid"
+REASON_CROSS_PROFILE = "cross_profile"
+REASON_STALE_AFTER_FINAL = "stale_after_final"
+REASON_STALE_SEQUENCE = "stale_sequence"
+REASON_STALE_AGE = "stale_age"
+REASON_IDENTITY_CONFLICT = "identity_conflict"
+QUARANTINE_REASONS = (
+    REASON_CROSS_PROFILE,
+    REASON_STALE_AFTER_FINAL,
+    REASON_STALE_SEQUENCE,
+    REASON_STALE_AGE,
+    REASON_IDENTITY_CONFLICT,
+)
+
+_LABEL = "session_activity_receipt"
+
+
+class SessionActivityReceiptError(ValueError):
+    """Raised when a supplied payload cannot be admitted as a receipt."""
+
+
+# --- normalization -------------------------------------------------------
+
+
+def normalize_session_activity_receipt(payload: Mapping[str, Any], *, redact_skill_names: bool = False) -> dict[str, Any]:
+    """Bound a supplied payload into the stored shape without retaining raw material.
+
+    Bounding is not validation: this folds oversized arrays to their caps
+    (marking the truncation), folds every skill name that is not an opaque
+    identifier into a digest, and fills the fixed constants. Everything it
+    cannot fold is left for `validate_session_activity_receipt` to refuse.
+    A payload that is not a mapping is returned as an empty record so the
+    validator reports the shape fault by name.
+    """
+    if not isinstance(payload, Mapping):
+        return {}
+    record: dict[str, Any] = {key: payload[key] for key in RECEIPT_KEYS if key in payload}
+    for key in payload:
+        if key not in RECEIPT_KEYS:
+            record[key] = payload[key]
+    record["schema_version"] = SESSION_ACTIVITY_RECEIPT_SCHEMA_VERSION
+    record["privacy"] = RECEIPT_PRIVACY
+    record["claim_boundary"] = CLAIM_BOUNDARY
+    record["skills"] = _normalized_skills(payload.get("skills"), redact_skill_names=redact_skill_names)
+    record["model_refs"] = _bounded_ref_list(payload.get("model_refs"), MAX_MODEL_REFS)
+    record["evidence_refs"] = _bounded_ref_list(payload.get("evidence_refs"), MAX_EVIDENCE_REFS)
+    if "observed_at" not in payload:
+        record["observed_at"] = utc_now()
+    return record
+
+
+def _normalized_skills(value: Any, *, redact_skill_names: bool) -> Any:
+    if value is None:
+        return {
+            "exposed_names": [],
+            "activated_names": [],
+            "exposed_names_truncated": False,
+            "activated_names_truncated": False,
+            "name_form": "plain",
+        }
+    if not isinstance(value, Mapping):
+        return value
+    skills: dict[str, Any] = dict(value)
+    name_form = str(value.get("name_form", "plain") or "plain")
+    if redact_skill_names:
+        name_form = "digest"
+    for field in ("exposed_names", "activated_names"):
+        names, truncated = _bounded_names(value.get(field), digest=redact_skill_names)
+        skills[field] = names
+        skills[f"{field}_truncated"] = bool(value.get(f"{field}_truncated", False)) or truncated
+    skills["name_form"] = name_form
+    return skills
+
+
+def _bounded_names(value: Any, *, digest: bool) -> tuple[Any, bool]:
+    """Bounded, opaque skill names. Non-lists are returned as they came."""
+    if value is None:
+        return [], False
+    if not isinstance(value, list):
+        return value, False
+    names: list[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if not text:
+            continue
+        names.append(digest_ref(text) if digest else _skill_name_or_digest(text))
+        if len(names) == MAX_SKILL_NAMES:
+            break
+    return names, len([item for item in value if str(item or "").strip()]) > len(names)
+
+
+def _bounded_ref_list(value: Any, limit: int) -> Any:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        return value
+    refs: list[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if not text:
+            continue
+        refs.append(_opaque_or_digest(text))
+        if len(refs) == limit:
+            break
+    return refs
+
+
+def _opaque_or_digest(text: str) -> str:
+    """The value when it is an opaque reference, a digest handle otherwise.
+
+    A model name or an evidence handle that carries a link, a space, a secret
+    shape, or a control character is not retained: the digest is stable
+    enough to dedupe on and reveals nothing.
+    """
+    return redacted_ref(text, field=_LABEL)
+
+
+def _skill_name_or_digest(text: str) -> str:
+    """A skill name when it is one, a digest handle otherwise.
+
+    A name carrying a path separator, whitespace, or a secret shape is not a
+    catalog label and is never stored as typed.
+    """
+    if is_skill_name(text):
+        return text
+    return digest_ref(text)
+
+
+def is_skill_name(value: Any) -> bool:
+    return isinstance(value, str) and bool(_SKILL_NAME.fullmatch(value)) and not is_sensitive_metadata_text(value)
+
+
+# --- validation ----------------------------------------------------------
+
+
+def validate_session_activity_receipt(record: Any) -> list[str]:
+    """Every reason a record is not a `session_activity_receipt/v1`.
+
+    Strict on purpose: this runs on the normalized shape, so an unsafe value
+    that reaches it was one the adapter could not bound, and a stored record
+    that fails it was hand-edited.
+    """
+    if not isinstance(record, Mapping):
+        return [f"{_LABEL} must be an object"]
+    errors: list[str] = []
+    errors.extend(_key_set_errors(record, RECEIPT_KEYS, path=_LABEL))
+    if record.get("schema_version") != SESSION_ACTIVITY_RECEIPT_SCHEMA_VERSION:
+        errors.append(f"{_LABEL} schema_version must be {SESSION_ACTIVITY_RECEIPT_SCHEMA_VERSION}")
+    if record.get("privacy") != RECEIPT_PRIVACY:
+        errors.append(f"{_LABEL} privacy must be {RECEIPT_PRIVACY}")
+    if record.get("claim_boundary") != CLAIM_BOUNDARY:
+        errors.append(f"{_LABEL} claim_boundary must state the receipt boundary")
+    for field in ("receipt_id", "profile_ref", "session_ref", "observed_at"):
+        errors.extend(reference_errors(record.get(field), field=field, label=_LABEL, required=True))
+    errors.extend(_stamp_errors(record.get("observed_at"), field="observed_at"))
+    errors.extend(_producer_errors(record.get("producer")))
+    boundary_errors = _boundary_errors(record.get("boundary"))
+    errors.extend(boundary_errors)
+    interval_errors = _interval_errors(record.get("observed_interval"))
+    errors.extend(interval_errors)
+    coverage = _coverage_of(record)
+    errors.extend(_metrics_errors(record.get("metrics"), coverage=coverage))
+    errors.extend(_skills_errors(record.get("skills")))
+    errors.extend(_ref_list_errors(record.get("model_refs"), field="model_refs", limit=MAX_MODEL_REFS))
+    errors.extend(_ref_list_errors(record.get("evidence_refs"), field="evidence_refs", limit=MAX_EVIDENCE_REFS))
+    return errors
+
+
+def _key_set_errors(value: Mapping[str, Any], allowed: tuple[str, ...], *, path: str) -> list[str]:
+    errors: list[str] = []
+    raw = sorted(str(key) for key in value if str(key).lower() in RAW_OR_HIDDEN_KEYS or str(key).lower() in RAW_SESSION_KEYS)
+    if raw:
+        errors.append(f"{path} must not carry raw session material keys: {raw}")
+    extra = sorted(str(key) for key in value if key not in allowed and str(key) not in raw)
+    if extra:
+        errors.append(f"{path} has unsupported keys: {extra}")
+    missing = sorted(set(allowed) - set(value))
+    if missing:
+        errors.append(f"{path} is missing keys: {missing}")
+    return errors
+
+
+def _producer_errors(value: Any) -> list[str]:
+    path = f"{_LABEL} producer"
+    if not isinstance(value, Mapping):
+        return [f"{path} must be an object"]
+    errors = _key_set_errors(value, PRODUCER_KEYS, path=path)
+    if value.get("kind") not in PRODUCER_KINDS:
+        errors.append(f"{path} kind is unsupported: {value.get('kind')!r}")
+    errors.extend(reference_errors(value.get("ref"), field="producer ref", label=_LABEL, required=True))
+    errors.extend(reference_errors(value.get("version"), field="producer version", label=_LABEL, required=False))
+    return errors
+
+
+def _boundary_errors(value: Any) -> list[str]:
+    path = f"{_LABEL} boundary"
+    if not isinstance(value, Mapping):
+        return [f"{path} must be an object"]
+    errors = _key_set_errors(value, BOUNDARY_KEYS, path=path)
+    kind = value.get("kind")
+    if kind not in BOUNDARY_KINDS:
+        errors.append(f"{path} kind is unsupported: {kind!r}")
+    final = value.get("final")
+    if not isinstance(final, bool):
+        errors.append(f"{path} final must be a boolean")
+    elif final and kind not in FINAL_BOUNDARY_KINDS:
+        errors.append(f"{path} final is only allowed on a session_end boundary; a {kind} boundary is partial")
+    sequence = value.get("sequence")
+    if not _is_int(sequence) or sequence < 0 or sequence > MAX_SEQUENCE:
+        errors.append(f"{path} sequence must be an integer from 0 to {MAX_SEQUENCE}")
+    return errors
+
+
+def _interval_errors(value: Any) -> list[str]:
+    path = f"{_LABEL} observed_interval"
+    if not isinstance(value, Mapping):
+        return [f"{path} must be an object"]
+    errors = _key_set_errors(value, INTERVAL_KEYS, path=path)
+    if value.get("coverage") not in COVERAGE_KINDS:
+        errors.append(f"{path} coverage is unsupported: {value.get('coverage')!r}")
+    for field in ("started_at", "ended_at"):
+        errors.extend(reference_errors(value.get(field), field=f"observed_interval {field}", label=_LABEL, required=True))
+        errors.extend(_stamp_errors(value.get(field), field=f"observed_interval {field}"))
+    started = parse_utc_stamp(value.get("started_at"))
+    ended = parse_utc_stamp(value.get("ended_at"))
+    if started is not None and ended is not None and ended < started:
+        errors.append(f"{path} ended_at must not precede started_at")
+    return errors
+
+
+def _metrics_errors(value: Any, *, coverage: str) -> list[str]:
+    path = f"{_LABEL} metrics"
+    if not isinstance(value, Mapping):
+        return [f"{path} must be an object"]
+    errors: list[str] = []
+    unknown = sorted(str(key) for key in value if key not in METRIC_NAMES)
+    if unknown:
+        errors.append(f"{path} has unsupported metric names: {unknown}")
+    for name in METRIC_NAMES:
+        if name in value:
+            errors.extend(_reading_errors(value[name], path=f"{path} {name}", coverage=coverage))
+    return errors
+
+
+def _reading_errors(value: Any, *, path: str, coverage: str) -> list[str]:
+    if not isinstance(value, Mapping):
+        return [f"{path} must be an object"]
+    errors = _key_set_errors(value, READING_KEYS, path=path)
+    availability = value.get("availability")
+    measurement = value.get("measurement")
+    count = value.get("value")
+    if availability not in AVAILABILITIES:
+        errors.append(f"{path} availability is unsupported: {availability!r}")
+        return errors
+    if availability == "unavailable":
+        if count is not None:
+            errors.append(f"{path} is unavailable and must carry a null value, not {count!r}")
+        if measurement != "":
+            errors.append(f"{path} is unavailable and must carry an empty measurement")
+        return errors
+    if not _is_int(count) or count < 0 or count > MAX_METRIC_VALUE:
+        errors.append(f"{path} value must be an integer from 0 to {MAX_METRIC_VALUE}")
+    if measurement not in MEASUREMENTS:
+        errors.append(f"{path} measurement is unsupported: {measurement!r}")
+    elif measurement == "exact" and coverage != "full_session":
+        errors.append(
+            f"{path} cannot be exact when observed_interval coverage is {coverage}; "
+            "a producer that did not watch the whole session reports a floor"
+        )
+    return errors
+
+
+def _skills_errors(value: Any) -> list[str]:
+    path = f"{_LABEL} skills"
+    if not isinstance(value, Mapping):
+        return [f"{path} must be an object"]
+    errors = _key_set_errors(value, SKILLS_KEYS, path=path)
+    if value.get("name_form") not in NAME_FORMS:
+        errors.append(f"{path} name_form is unsupported: {value.get('name_form')!r}")
+    for field in ("exposed_names", "activated_names"):
+        errors.extend(_skill_name_list_errors(value.get(field), field=f"skills {field}"))
+        if not isinstance(value.get(f"{field}_truncated"), bool):
+            errors.append(f"{path} {field}_truncated must be a boolean")
+    return errors
+
+
+def _skill_name_list_errors(value: Any, *, field: str) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{_LABEL} {field} must be a list"]
+    errors: list[str] = []
+    if len(value) > MAX_SKILL_NAMES:
+        errors.append(f"{_LABEL} {field} must have at most {MAX_SKILL_NAMES} items")
+    for index, item in enumerate(value):
+        if not is_skill_name(item):
+            errors.append(f"{_LABEL} {field}[{index}] must be a skill name or a digest handle, not a path or secret")
+    return errors
+
+
+def _ref_list_errors(value: Any, *, field: str, limit: int) -> list[str]:
+    if not isinstance(value, list):
+        return [f"{_LABEL} {field} must be a list"]
+    errors: list[str] = []
+    if len(value) > limit:
+        errors.append(f"{_LABEL} {field} must have at most {limit} items")
+    for index, item in enumerate(value):
+        errors.extend(reference_errors(item, field=f"{field}[{index}]", label=_LABEL, required=True))
+    return errors
+
+
+def _stamp_errors(value: Any, *, field: str) -> list[str]:
+    if not isinstance(value, str) or not value:
+        return []
+    if parse_utc_stamp(value) is None:
+        return [f"{_LABEL} {field} must be an ISO-8601 UTC stamp ending in Z"]
+    return []
+
+
+def parse_utc_stamp(value: Any) -> datetime | None:
+    """A `...Z` ISO-8601 stamp as an aware UTC datetime, or None."""
+    text = str(value or "")
+    if not text.endswith("Z"):
+        return None
+    try:
+        parsed = datetime.fromisoformat(text[:-1] + "+00:00")
+    except ValueError:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _coverage_of(record: Mapping[str, Any]) -> str:
+    interval = record.get("observed_interval")
+    if not isinstance(interval, Mapping):
+        return "unknown"
+    coverage = interval.get("coverage")
+    return coverage if coverage in COVERAGE_KINDS else "unknown"
+
+
+# --- readings ------------------------------------------------------------
+
+
+def metric_reading(receipt: Mapping[str, Any], name: str) -> dict[str, Any]:
+    """One counter as the producer reported it, or an explicit `unavailable`.
+
+    Absence is the honest reading, never zero: a receipt that omits a metric
+    is a producer that did not observe it.
+    """
+    metrics = receipt.get("metrics")
+    reading = metrics.get(name) if isinstance(metrics, Mapping) else None
+    if not isinstance(reading, Mapping) or reading.get("availability") not in AVAILABILITIES:
+        return {"value": None, "availability": "unavailable", "measurement": ""}
+    if reading.get("availability") == "unavailable":
+        return {"value": None, "availability": "unavailable", "measurement": ""}
+    return {
+        "value": reading.get("value"),
+        "availability": str(reading.get("availability")),
+        "measurement": str(reading.get("measurement", "")),
+    }
+
+
+def is_final_receipt(receipt: Mapping[str, Any]) -> bool:
+    boundary = receipt.get("boundary")
+    if not isinstance(boundary, Mapping):
+        return False
+    return boundary.get("final") is True and boundary.get("kind") in FINAL_BOUNDARY_KINDS
+
+
+def boundary_sequence(receipt: Mapping[str, Any]) -> int:
+    boundary = receipt.get("boundary")
+    if not isinstance(boundary, Mapping):
+        return -1
+    sequence = boundary.get("sequence")
+    return sequence if _is_int(sequence) else -1
+
+
+def skill_exposure_summary(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """Exposed-but-unused, derived only when both sides were observed.
+
+    Names win over counters when both lists are complete: the difference of
+    two complete name lists is the actual set. Counters are the fallback when
+    both were observed but a list is missing or truncated. Anything less is
+    `unavailable`, with the reason named, because "not used" is not a finding
+    when nobody saw whether it was offered.
+    """
+    exposed = metric_reading(receipt, "skills_exposed")
+    activated = metric_reading(receipt, "skills_activated")
+    skills = receipt.get("skills") if isinstance(receipt.get("skills"), Mapping) else {}
+    exposed_names = [str(name) for name in skills.get("exposed_names", []) if isinstance(name, str)]
+    activated_names = [str(name) for name in skills.get("activated_names", []) if isinstance(name, str)]
+    names_complete = (
+        bool(exposed_names)
+        and skills.get("exposed_names_truncated") is False
+        and skills.get("activated_names_truncated") is False
+        and activated["availability"] != "unavailable"
+    )
+    summary: dict[str, Any] = {
+        "skills_exposed": exposed,
+        "skills_activated": activated,
+        "exposed_unused_count": None,
+        "exposed_unused_names": [],
+        "derivation": "unavailable",
+        "reason": "",
+    }
+    if exposed["availability"] == "unavailable" or activated["availability"] == "unavailable":
+        summary["reason"] = "exposure and activation must both be observed before exposed-but-unused can be derived"
+        return summary
+    if names_complete:
+        unused = [name for name in exposed_names if name not in set(activated_names)]
+        summary["exposed_unused_count"] = len(unused)
+        summary["exposed_unused_names"] = unused
+        summary["derivation"] = "names"
+        return summary
+    difference = int(exposed["value"]) - int(activated["value"])
+    if difference < 0:
+        summary["reason"] = "activated count exceeds exposed count; the producer's readings disagree"
+        return summary
+    summary["exposed_unused_count"] = difference
+    summary["derivation"] = "counters"
+    if exposed["measurement"] == "floor" or activated["measurement"] == "floor":
+        summary["reason"] = "derived from floor readings; the true count may be higher"
+    return summary
+
+
+# --- admission -----------------------------------------------------------
+
+
+def admit_session_activity_receipt(
+    payload: Mapping[str, Any],
+    *,
+    expected_profile_ref: str = "",
+    known: Sequence[Mapping[str, Any]] = (),
+    now: str = "",
+    max_age_seconds: int | None = None,
+    redact_skill_names: bool = False,
+) -> dict[str, Any]:
+    """Validate one supplied payload against the contract and the records already held.
+
+    Returns a `session_activity_admission/v1` mapping whose `outcome` is
+    `accepted`, `rejected` (the payload is not a receipt; `errors` says why),
+    or `quarantined` (it is a receipt, but not one this store may take:
+    `reason` names the cross-profile, staleness, or identity fault). Only an
+    accepted admission carries a `receipt`.
+
+    Pure: no file is read or written here. `known` is whatever the caller
+    already holds for this store, and `now` is the caller's clock.
+    """
+    receipt = normalize_session_activity_receipt(payload, redact_skill_names=redact_skill_names)
+    errors = validate_session_activity_receipt(receipt)
+    if errors:
+        return _admission(ADMISSION_REJECTED, REASON_INVALID, errors, None)
+    reason = _quarantine_reason(
+        receipt,
+        expected_profile_ref=expected_profile_ref,
+        known=known,
+        now=now,
+        max_age_seconds=max_age_seconds,
+    )
+    if reason:
+        return _admission(ADMISSION_QUARANTINED, reason, [_quarantine_message(reason)], receipt)
+    return _admission(ADMISSION_ACCEPTED, "", [], receipt)
+
+
+def _admission(outcome: str, reason: str, errors: list[str], receipt: dict[str, Any] | None) -> dict[str, Any]:
+    return {
+        "schema_version": SESSION_ACTIVITY_ADMISSION_SCHEMA_VERSION,
+        "outcome": outcome,
+        "reason": reason,
+        "errors": list(errors),
+        "receipt": receipt if outcome != ADMISSION_REJECTED else None,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _quarantine_reason(
+    receipt: Mapping[str, Any],
+    *,
+    expected_profile_ref: str,
+    known: Sequence[Mapping[str, Any]],
+    now: str,
+    max_age_seconds: int | None,
+) -> str:
+    if expected_profile_ref and str(receipt.get("profile_ref", "")) != expected_profile_ref:
+        return REASON_CROSS_PROFILE
+    same_id = [record for record in known if str(record.get("receipt_id", "")) == str(receipt.get("receipt_id", ""))]
+    if same_id:
+        # An identical re-send is the caller's idempotent path, not a fault;
+        # only a different observation under a reused identity is quarantined.
+        if all(_observation_fingerprint(record) == _observation_fingerprint(receipt) for record in same_id):
+            return ""
+        return REASON_IDENTITY_CONFLICT
+    session_records = [
+        record for record in known if str(record.get("session_ref", "")) == str(receipt.get("session_ref", ""))
+    ]
+    if any(is_final_receipt(record) for record in session_records):
+        return REASON_STALE_AFTER_FINAL
+    latest_sequence = max((boundary_sequence(record) for record in session_records), default=-1)
+    if boundary_sequence(receipt) < latest_sequence:
+        return REASON_STALE_SEQUENCE
+    if max_age_seconds is not None and _older_than(receipt, now=now, max_age_seconds=max_age_seconds):
+        return REASON_STALE_AGE
+    return ""
+
+
+def _older_than(receipt: Mapping[str, Any], *, now: str, max_age_seconds: int) -> bool:
+    interval = receipt.get("observed_interval")
+    ended = parse_utc_stamp(interval.get("ended_at")) if isinstance(interval, Mapping) else None
+    reference = parse_utc_stamp(now or utc_now())
+    if ended is None or reference is None:
+        return False
+    return (reference - ended).total_seconds() > max_age_seconds
+
+
+def _quarantine_message(reason: str) -> str:
+    messages = {
+        REASON_CROSS_PROFILE: "receipt names a profile other than the one this store is bound to",
+        REASON_STALE_AFTER_FINAL: "a final receipt for this session is already on record",
+        REASON_STALE_SEQUENCE: "a later boundary for this session is already on record",
+        REASON_STALE_AGE: "the observed interval ended before the accepted freshness window",
+        REASON_IDENTITY_CONFLICT: "receipt_id is already on record with a different observation",
+    }
+    return messages.get(reason, reason)
+
+
+# --- store ---------------------------------------------------------------
+
+
+def session_activity_quarantine_path(store_path: Path) -> Path:
+    return store_path.with_name(SESSION_ACTIVITY_QUARANTINE_STORE_NAME)
+
+
+def ingest_session_activity_receipt(
+    paths: OmhPaths,
+    payload: Mapping[str, Any],
+    *,
+    expected_profile_ref: str = "",
+    now: str = "",
+    max_age_seconds: int | None = None,
+    redact_skill_names: bool = False,
+) -> dict[str, Any]:
+    """Admit one supplied payload against the store and record the outcome.
+
+    Returns a `session_activity_ingest_result/v1` mapping:
+
+        outcome     -- "recorded" | "already_recorded" | "rejected" | "quarantined"
+        reason      -- "" or the admission reason
+        errors      -- the admission errors
+        receipt_id  -- the identity now on record, "" when nothing was recorded
+        receipt     -- the record on file for accepted or duplicate payloads
+
+    `already_recorded` is what makes ingestion idempotent by receipt identity:
+    the same receipt sent three times is one line. A quarantined payload is
+    logged to the quarantine sidecar as bounded metadata (identity handles,
+    reason, errors) and never reaches the store. A rejected payload reaches
+    nothing on disk.
+
+    The read of the prior records and the append happen under one lock, so
+    two concurrent sends of one receipt cannot both record it.
+    """
+    store_path = paths.runtime_session_activity_receipts_path
+    with file_lock(store_path, private=True):
+        known, _ = read_jsonl_objects(store_path)
+        admission = admit_session_activity_receipt(
+            payload,
+            expected_profile_ref=expected_profile_ref,
+            known=known,
+            now=now,
+            max_age_seconds=max_age_seconds,
+            redact_skill_names=redact_skill_names,
+        )
+        if admission["outcome"] == ADMISSION_REJECTED:
+            return _ingest_result("rejected", admission, receipt=None)
+        receipt = admission["receipt"]
+        if admission["outcome"] == ADMISSION_QUARANTINED:
+            _append_quarantine(store_path, receipt, admission)
+            return _ingest_result("quarantined", admission, receipt=None)
+        prior = _same_receipt_in(known, str(receipt["receipt_id"]))
+        if prior:
+            return _ingest_result("already_recorded", admission, receipt=prior)
+        append_store_line(store_path, receipt)
+    return _ingest_result("recorded", admission, receipt=receipt)
+
+
+def _ingest_result(outcome: str, admission: Mapping[str, Any], *, receipt: Mapping[str, Any] | None) -> dict[str, Any]:
+    return {
+        "schema_version": SESSION_ACTIVITY_INGEST_RESULT_SCHEMA_VERSION,
+        "outcome": outcome,
+        "reason": str(admission.get("reason", "")),
+        "errors": list(admission.get("errors", [])),
+        "receipt_id": str(receipt.get("receipt_id", "")) if receipt else "",
+        "receipt": dict(receipt) if receipt else None,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _append_quarantine(store_path: Path, receipt: Mapping[str, Any], admission: Mapping[str, Any]) -> None:
+    append_sidecar_line(
+        session_activity_quarantine_path(store_path),
+        {
+            "schema_version": SESSION_ACTIVITY_QUARANTINE_SCHEMA_VERSION,
+            "quarantined_at": utc_now(),
+            "reason": str(admission.get("reason", "")),
+            "errors": list(admission.get("errors", []))[:MAX_QUARANTINE_ERRORS],
+            "receipt_id": redacted_ref(str(receipt.get("receipt_id", "")), field="receipt_id"),
+            "session_ref": redacted_ref(str(receipt.get("session_ref", "")), field="session_ref"),
+            "profile_ref": redacted_ref(str(receipt.get("profile_ref", "")), field="profile_ref"),
+            "claim_boundary": CLAIM_BOUNDARY,
+        },
+    )
+
+
+def _same_receipt_in(records: Sequence[Mapping[str, Any]], receipt_id: str) -> dict[str, Any]:
+    matches = [dict(record) for record in records if str(record.get("receipt_id", "")) == receipt_id]
+    return matches[-1] if matches else {}
+
+
+def read_session_activity_receipts(
+    paths: OmhPaths,
+    *,
+    session_ref: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    receipts, _ = read_jsonl_objects(paths.runtime_session_activity_receipts_path)
+    if session_ref is not None:
+        receipts = [receipt for receipt in receipts if str(receipt.get("session_ref", "")) == session_ref]
+    if limit is None:
+        return receipts
+    if limit < 1:
+        return []
+    return receipts[-limit:]
+
+
+def read_session_activity_quarantine(paths: OmhPaths) -> list[dict[str, Any]]:
+    records, _ = read_jsonl_objects(session_activity_quarantine_path(paths.runtime_session_activity_receipts_path))
+    return records
+
+
+def latest_session_activity_receipt(
+    receipts: Sequence[Mapping[str, Any]],
+    session_ref: str,
+) -> dict[str, Any]:
+    """The receipt that speaks for one session: highest boundary sequence, latest on a tie."""
+    matches = [dict(receipt) for receipt in receipts if str(receipt.get("session_ref", "")) == str(session_ref)]
+    if not matches:
+        return {}
+    best = matches[0]
+    for receipt in matches[1:]:
+        if boundary_sequence(receipt) >= boundary_sequence(best):
+            best = receipt
+    return best
+
+
+def validate_session_activity_receipt_store(path: Path) -> dict[str, Any]:
+    receipts, read_errors = read_jsonl_objects(path)
+    errors = list(read_errors)
+    seen: dict[str, str] = {}
+    for index, receipt in enumerate(receipts, start=1):
+        errors.extend(f"{path}:{index}: {error}" for error in validate_session_activity_receipt(receipt))
+        receipt_id = str(receipt.get("receipt_id", ""))
+        fingerprint = _observation_fingerprint(receipt)
+        if receipt_id in seen and seen[receipt_id] != fingerprint:
+            errors.append(f"{path}:{index}: {_LABEL} receipt_id is on record with a different observation: {receipt_id}")
+        seen.setdefault(receipt_id, fingerprint)
+    return {
+        "schema_version": SESSION_ACTIVITY_STORE_VALIDATION_SCHEMA_VERSION,
+        "path": str(path),
+        "ok": not errors,
+        "receipt_count": len(receipts),
+        "errors": errors,
+    }
+
+
+def _observation_fingerprint(receipt: Mapping[str, Any]) -> str:
+    return record_fingerprint(receipt, _OBSERVATION_IDENTITY_KEYS)
+
+
+# --- consumers -----------------------------------------------------------
+
+
+def session_activity_evidence(receipt: Mapping[str, Any], consumer: str) -> dict[str, Any]:
+    """One consumer workflow's view of one receipt, with every limit preserved.
+
+    Every consumer reads through this projection, so none can read an
+    unavailable counter as zero, report a partial boundary as a session
+    result, or present a floor as a total. `consumer` must be one of
+    `SESSION_ACTIVITY_CONSUMERS`.
+    """
+    if consumer not in SESSION_ACTIVITY_CONSUMERS:
+        raise SessionActivityReceiptError(f"session activity consumer is unsupported: {consumer!r}")
+    errors = validate_session_activity_receipt(receipt)
+    if errors:
+        raise SessionActivityReceiptError(errors[0])
+    names = SESSION_ACTIVITY_CONSUMERS[consumer]
+    readings = {name: metric_reading(receipt, name) for name in names}
+    final = is_final_receipt(receipt)
+    coverage = _coverage_of(receipt)
+    boundary = receipt["boundary"]
+    evidence: dict[str, Any] = {
+        "schema_version": SESSION_ACTIVITY_EVIDENCE_SCHEMA_VERSION,
+        "consumer": consumer,
+        "receipt_id": str(receipt["receipt_id"]),
+        "session_ref": str(receipt["session_ref"]),
+        "profile_ref": str(receipt["profile_ref"]),
+        "producer_kind": str(receipt["producer"]["kind"]),
+        "boundary_kind": str(boundary["kind"]),
+        "boundary_sequence": int(boundary["sequence"]),
+        "session_outcome": "final" if final else "partial",
+        "terminal": final,
+        "coverage": coverage,
+        "observation_floor": coverage != "full_session",
+        "metrics": readings,
+        "observed_metrics": [name for name in names if readings[name]["availability"] == "observed"],
+        "heuristic_metrics": [name for name in names if readings[name]["availability"] == "heuristic"],
+        "unavailable_metrics": [name for name in names if readings[name]["availability"] == "unavailable"],
+        "evidence_refs": list(receipt["evidence_refs"]),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    if "skills_exposed" in names:
+        evidence["skill_exposure"] = skill_exposure_summary(receipt)
+    return evidence
+
+
+def attach_session_activity_evidence(
+    payload: dict[str, Any],
+    receipt: Mapping[str, Any] | None,
+    consumer: str,
+) -> dict[str, Any]:
+    """Add a receipt's evidence to a consumer payload under one fixed key.
+
+    With no receipt the key still lands, as `None`: a consumer that renders
+    the key can then say the receipt was not supplied instead of saying
+    nothing happened.
+    """
+    payload["session_activity"] = session_activity_evidence(receipt, consumer) if receipt else None
+    return payload
+

--- a/tests/test_session_activity_receipts.py
+++ b/tests/test_session_activity_receipts.py
@@ -1,0 +1,596 @@
+"""Contracts for `session_activity_receipt/v1` (issue #1404).
+
+What is asserted here, against the issue's success criteria:
+
+- the schema and validator define identity, boundary, bounded counters,
+  availability, and evidence-reference semantics
+- a partial (turn) receipt is never reported as a terminal session result
+- ingestion is idempotent by receipt identity; stale, cross-profile, and
+  identity-conflicting payloads are quarantined, never stored
+- a missing metric stays `unavailable`; it is never zero
+- exposure and activation are separate, and exposed-but-unused is derived
+  only when both were observed
+- hostile or oversized arrays and strings are bounded without retaining raw
+  material
+- six named consumers ingest the same fixture and keep observed, heuristic,
+  and unavailable readings apart
+- a producer loaded mid-session reports a floor, never an exact total
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from copy import deepcopy
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import resolve_paths  # noqa: E402
+from omh.skills.catalog import installable_skill_names  # noqa: E402
+from omh.skills.render import workflow_reference_markdown  # noqa: E402
+from omh.system.append_only_store import RAW_OR_HIDDEN_KEYS  # noqa: E402
+from omh.workflows.session_activity_receipts import (  # noqa: E402
+    CLAIM_BOUNDARY,
+    MAX_EVIDENCE_REFS,
+    MAX_SKILL_NAMES,
+    METRIC_NAMES,
+    QUARANTINE_REASONS,
+    RAW_SESSION_KEYS,
+    REASON_CROSS_PROFILE,
+    REASON_IDENTITY_CONFLICT,
+    REASON_STALE_AFTER_FINAL,
+    REASON_STALE_AGE,
+    REASON_STALE_SEQUENCE,
+    SESSION_ACTIVITY_CONSUMERS,
+    SESSION_ACTIVITY_RECEIPT_SCHEMA_VERSION,
+    SessionActivityReceiptError,
+    admit_session_activity_receipt,
+    attach_session_activity_evidence,
+    ingest_session_activity_receipt,
+    latest_session_activity_receipt,
+    metric_reading,
+    read_session_activity_quarantine,
+    read_session_activity_receipts,
+    session_activity_evidence,
+    skill_exposure_summary,
+    validate_session_activity_receipt,
+    validate_session_activity_receipt_store,
+)
+
+
+def _reading(value: int, availability: str = "observed", measurement: str = "exact") -> dict[str, Any]:
+    return {"value": value, "availability": availability, "measurement": measurement}
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    """A final, full-session receipt as an observer plugin would supply it."""
+    payload: dict[str, Any] = {
+        "schema_version": SESSION_ACTIVITY_RECEIPT_SCHEMA_VERSION,
+        "receipt_id": "sar-20260908-0001",
+        "producer": {"kind": "observer_plugin", "ref": "hermes-observer", "version": "0.3.0"},
+        "profile_ref": "profile-a1",
+        "session_ref": "sess-9f2c4a",
+        "boundary": {"kind": "session_end", "final": True, "sequence": 12},
+        "observed_interval": {
+            "started_at": "2026-09-08T09:00:00Z",
+            "ended_at": "2026-09-08T09:42:10Z",
+            "coverage": "full_session",
+        },
+        "metrics": {
+            "skills_exposed": _reading(4),
+            "skills_activated": _reading(1),
+            "tool_calls": _reading(31),
+            "tool_errors": _reading(2, availability="heuristic"),
+            "compaction_boundaries": _reading(1),
+            "tokens_total": _reading(48210),
+            "context_peak_tokens": _reading(91000),
+            "wall_clock_ms": _reading(2530000),
+        },
+        "skills": {
+            "exposed_names": ["plan", "research", "review", "wiki"],
+            "activated_names": ["plan"],
+            "exposed_names_truncated": False,
+            "activated_names_truncated": False,
+            "name_form": "plain",
+        },
+        "model_refs": ["glm-5.3"],
+        "evidence_refs": ["observer:session:sess-9f2c4a:end"],
+        "observed_at": "2026-09-08T09:42:11Z",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _turn_payload(sequence: int, receipt_id: str) -> dict[str, Any]:
+    payload = _payload(receipt_id=receipt_id)
+    payload["boundary"] = {"kind": "turn", "final": False, "sequence": sequence}
+    payload["observed_interval"]["ended_at"] = "2026-09-08T09:10:00Z"
+    return payload
+
+
+class TheSchemaDefinesIdentityBoundaryCountersAndAvailability(unittest.TestCase):
+    def test_a_supplied_final_receipt_validates_and_keeps_its_readings(self) -> None:
+        admission = admit_session_activity_receipt(_payload())
+
+        self.assertEqual(admission["outcome"], "accepted", admission["errors"])
+        receipt = admission["receipt"]
+        self.assertEqual(validate_session_activity_receipt(receipt), [])
+        self.assertEqual(receipt["privacy"], "metadata_only")
+        self.assertEqual(receipt["claim_boundary"], CLAIM_BOUNDARY)
+        self.assertEqual(metric_reading(receipt, "tool_calls"), _reading(31))
+        self.assertEqual(metric_reading(receipt, "tool_errors")["availability"], "heuristic")
+
+    def test_every_string_is_a_closed_value_or_an_opaque_reference(self) -> None:
+        for field, value in (
+            ("receipt_id", "https://host/receipt?1"),
+            ("profile_ref", "sk-live-abcdefghijklmnop"),
+            ("session_ref", "/Users/someone/.hermes/sessions/1"),
+            ("observed_at", "2026-09-08 09:42"),
+        ):
+            with self.subTest(field=field):
+                admission = admit_session_activity_receipt(_payload(**{field: value}))
+                self.assertEqual(admission["outcome"], "rejected")
+                self.assertTrue(any(field in error for error in admission["errors"]), admission["errors"])
+                self.assertNotIn(value, json.dumps(admission))
+
+    def test_counters_are_bounded_integers_and_unknown_metric_names_are_refused(self) -> None:
+        oversized = _payload()
+        oversized["metrics"]["tool_calls"] = _reading(10**13)
+        negative = _payload()
+        negative["metrics"]["tool_calls"] = _reading(-1)
+        boolean = _payload()
+        boolean["metrics"]["tool_calls"] = _reading(True)
+        unknown = _payload()
+        unknown["metrics"]["raw_prompt_tokens"] = _reading(1)
+        for name, payload in (("oversized", oversized), ("negative", negative), ("boolean", boolean), ("unknown", unknown)):
+            with self.subTest(payload=name):
+                self.assertEqual(admit_session_activity_receipt(payload)["outcome"], "rejected")
+
+    def test_the_producer_and_boundary_vocabularies_are_closed(self) -> None:
+        producer = _payload(producer={"kind": "crawler", "ref": "x", "version": ""})
+        boundary = _payload()
+        boundary["boundary"]["kind"] = "guess"
+        coverage = _payload()
+        coverage["observed_interval"]["coverage"] = "most_of_it"
+        for name, payload in (("producer", producer), ("boundary", boundary), ("coverage", coverage)):
+            with self.subTest(payload=name):
+                admission = admit_session_activity_receipt(payload)
+                self.assertEqual(admission["outcome"], "rejected")
+                self.assertTrue(any("unsupported" in error for error in admission["errors"]), admission["errors"])
+
+    def test_an_interval_that_ends_before_it_starts_is_refused(self) -> None:
+        payload = _payload()
+        payload["observed_interval"]["ended_at"] = "2026-09-08T08:59:59Z"
+        admission = admit_session_activity_receipt(payload)
+        self.assertEqual(admission["outcome"], "rejected")
+        self.assertTrue(any("ended_at must not precede" in error for error in admission["errors"]))
+
+
+class APartialReceiptIsNeverATerminalResult(unittest.TestCase):
+    def test_a_turn_boundary_cannot_claim_final(self) -> None:
+        payload = _payload()
+        payload["boundary"] = {"kind": "turn", "final": True, "sequence": 3}
+        admission = admit_session_activity_receipt(payload)
+        self.assertEqual(admission["outcome"], "rejected")
+        self.assertTrue(any("only allowed on a session_end boundary" in error for error in admission["errors"]))
+
+    def test_a_process_exit_is_the_producers_boundary_not_the_sessions(self) -> None:
+        payload = _payload()
+        payload["boundary"] = {"kind": "process_exit", "final": True, "sequence": 3}
+        self.assertEqual(admit_session_activity_receipt(payload)["outcome"], "rejected")
+
+    def test_a_partial_receipt_projects_as_partial_for_every_consumer(self) -> None:
+        receipt = admit_session_activity_receipt(_turn_payload(3, "sar-turn-3"))["receipt"]
+        for consumer in SESSION_ACTIVITY_CONSUMERS:
+            with self.subTest(consumer=consumer):
+                evidence = session_activity_evidence(receipt, consumer)
+                self.assertFalse(evidence["terminal"])
+                self.assertEqual(evidence["session_outcome"], "partial")
+                self.assertEqual(evidence["boundary_kind"], "turn")
+
+    def test_a_final_receipt_projects_as_final(self) -> None:
+        receipt = admit_session_activity_receipt(_payload())["receipt"]
+        evidence = session_activity_evidence(receipt, "agent-ops-review")
+        self.assertTrue(evidence["terminal"])
+        self.assertEqual(evidence["session_outcome"], "final")
+
+
+class AProducerLoadedMidSessionReportsAFloor(unittest.TestCase):
+    def test_an_exact_counter_under_partial_coverage_is_refused(self) -> None:
+        payload = _payload()
+        payload["observed_interval"]["coverage"] = "from_producer_load"
+        admission = admit_session_activity_receipt(payload)
+        self.assertEqual(admission["outcome"], "rejected")
+        self.assertTrue(any("reports a floor" in error for error in admission["errors"]), admission["errors"])
+
+    def test_floor_counters_under_partial_coverage_are_accepted_and_flagged(self) -> None:
+        payload = _payload()
+        payload["observed_interval"]["coverage"] = "from_producer_load"
+        for reading in payload["metrics"].values():
+            reading["measurement"] = "floor"
+        admission = admit_session_activity_receipt(payload)
+        self.assertEqual(admission["outcome"], "accepted", admission["errors"])
+        evidence = session_activity_evidence(admission["receipt"], "run-efficiency")
+        self.assertTrue(evidence["observation_floor"])
+        self.assertEqual(evidence["coverage"], "from_producer_load")
+        self.assertEqual(evidence["metrics"]["tool_calls"]["measurement"], "floor")
+        exposure = skill_exposure_summary(admission["receipt"])
+        self.assertEqual(exposure["derivation"], "names")
+
+    def test_a_restarted_producer_that_cannot_say_reports_unknown_coverage_as_a_floor(self) -> None:
+        payload = _payload()
+        payload["observed_interval"]["coverage"] = "unknown"
+        payload["metrics"] = {"tool_calls": _reading(5, measurement="floor")}
+        admission = admit_session_activity_receipt(payload)
+        self.assertEqual(admission["outcome"], "accepted", admission["errors"])
+        self.assertTrue(session_activity_evidence(admission["receipt"], "run-efficiency")["observation_floor"])
+
+
+class AMissingMetricStaysUnavailable(unittest.TestCase):
+    def test_an_absent_metric_reads_as_unavailable_with_a_null_value(self) -> None:
+        receipt = admit_session_activity_receipt(_payload())["receipt"]
+        self.assertEqual(metric_reading(receipt, "subagent_spawns"), {"value": None, "availability": "unavailable", "measurement": ""})
+        evidence = session_activity_evidence(receipt, "agent-ops-review")
+        self.assertIn("subagent_spawns", evidence["unavailable_metrics"])
+        self.assertIsNone(evidence["metrics"]["subagent_spawns"]["value"])
+        self.assertNotEqual(evidence["metrics"]["subagent_spawns"]["value"], 0)
+
+    def test_an_explicit_unavailable_reading_must_carry_a_null_value(self) -> None:
+        payload = _payload()
+        payload["metrics"]["subagent_spawns"] = {"value": 0, "availability": "unavailable", "measurement": ""}
+        admission = admit_session_activity_receipt(payload)
+        self.assertEqual(admission["outcome"], "rejected")
+        self.assertTrue(any("must carry a null value" in error for error in admission["errors"]))
+
+    def test_a_heuristic_counter_is_kept_apart_from_observed_ones(self) -> None:
+        receipt = admit_session_activity_receipt(_payload())["receipt"]
+        evidence = session_activity_evidence(receipt, "agent-ops-review")
+        self.assertEqual(evidence["heuristic_metrics"], ["tool_errors"])
+        self.assertNotIn("tool_errors", evidence["observed_metrics"])
+        self.assertIn("tool_calls", evidence["observed_metrics"])
+        self.assertEqual(evidence["metrics"]["tool_errors"]["availability"], "heuristic")
+
+
+class ExposureAndActivationAreSeparate(unittest.TestCase):
+    def test_exposed_but_unused_is_derived_from_complete_name_lists(self) -> None:
+        receipt = admit_session_activity_receipt(_payload())["receipt"]
+        exposure = skill_exposure_summary(receipt)
+        self.assertEqual(exposure["derivation"], "names")
+        self.assertEqual(exposure["exposed_unused_count"], 3)
+        self.assertEqual(exposure["exposed_unused_names"], ["research", "review", "wiki"])
+
+    def test_exposed_but_unused_falls_back_to_counters_when_a_list_is_truncated(self) -> None:
+        payload = _payload()
+        payload["skills"]["exposed_names_truncated"] = True
+        receipt = admit_session_activity_receipt(payload)["receipt"]
+        exposure = skill_exposure_summary(receipt)
+        self.assertEqual(exposure["derivation"], "counters")
+        self.assertEqual(exposure["exposed_unused_count"], 3)
+        self.assertEqual(exposure["exposed_unused_names"], [])
+
+    def test_exposed_but_unused_is_unavailable_when_exposure_was_not_observed(self) -> None:
+        payload = _payload()
+        del payload["metrics"]["skills_exposed"]
+        payload["skills"]["exposed_names"] = []
+        receipt = admit_session_activity_receipt(payload)["receipt"]
+        exposure = skill_exposure_summary(receipt)
+        self.assertEqual(exposure["derivation"], "unavailable")
+        self.assertIsNone(exposure["exposed_unused_count"])
+        self.assertIn("both be observed", exposure["reason"])
+        self.assertEqual(exposure["skills_activated"]["value"], 1)
+
+    def test_exposed_but_unused_is_unavailable_when_activation_was_not_observed(self) -> None:
+        payload = _payload()
+        del payload["metrics"]["skills_activated"]
+        payload["skills"]["activated_names"] = []
+        exposure = skill_exposure_summary(admit_session_activity_receipt(payload)["receipt"])
+        self.assertEqual(exposure["derivation"], "unavailable")
+
+    def test_disagreeing_counters_do_not_produce_a_negative_finding(self) -> None:
+        payload = _payload()
+        payload["metrics"]["skills_activated"] = _reading(9)
+        payload["skills"]["exposed_names_truncated"] = True
+        exposure = skill_exposure_summary(admit_session_activity_receipt(payload)["receipt"])
+        self.assertEqual(exposure["derivation"], "unavailable")
+        self.assertIn("disagree", exposure["reason"])
+
+
+class HostileInputIsBoundedWithoutRetainingRawMaterial(unittest.TestCase):
+    def test_raw_session_material_keys_are_refused_by_name(self) -> None:
+        for key in sorted(RAW_OR_HIDDEN_KEYS | RAW_SESSION_KEYS):
+            with self.subTest(key=key):
+                admission = admit_session_activity_receipt(_payload(**{key: "do not store"}))
+                self.assertEqual(admission["outcome"], "rejected")
+                self.assertTrue(any("raw session material" in error for error in admission["errors"]), admission["errors"])
+                self.assertNotIn("do not store", json.dumps(admission))
+
+    def test_nested_raw_keys_are_refused_too(self) -> None:
+        payload = _payload()
+        payload["skills"]["prompt"] = "the user said"
+        admission = admit_session_activity_receipt(payload)
+        self.assertEqual(admission["outcome"], "rejected")
+        self.assertNotIn("the user said", json.dumps(admission))
+
+    def test_path_shaped_and_secret_shaped_skill_names_become_digests(self) -> None:
+        payload = _payload()
+        payload["skills"]["exposed_names"] = ["plan", "/Users/someone/.hermes/skills/private", "sk-live-abcdefghijklmnop", "with space"]
+        payload["skills"]["activated_names"] = ["plan"]
+        admission = admit_session_activity_receipt(payload)
+        self.assertEqual(admission["outcome"], "accepted", admission["errors"])
+        names = admission["receipt"]["skills"]["exposed_names"]
+        self.assertEqual(names[0], "plan")
+        for name in names[1:]:
+            self.assertTrue(name.startswith("ref-"), name)
+        serialized = json.dumps(admission)
+        self.assertNotIn("/Users/", serialized)
+        self.assertNotIn("sk-live", serialized)
+        self.assertNotIn("with space", serialized)
+
+    def test_redact_skill_names_folds_every_name_to_a_digest(self) -> None:
+        admission = admit_session_activity_receipt(_payload(), redact_skill_names=True)
+        receipt = admission["receipt"]
+        self.assertEqual(receipt["skills"]["name_form"], "digest")
+        self.assertTrue(all(name.startswith("ref-") for name in receipt["skills"]["exposed_names"]))
+        self.assertNotIn("research", json.dumps(receipt))
+        # Digests are stable, so exposed-but-unused still derives across them.
+        self.assertEqual(skill_exposure_summary(receipt)["exposed_unused_count"], 3)
+
+    def test_oversized_name_lists_are_truncated_and_marked(self) -> None:
+        payload = _payload()
+        payload["skills"]["exposed_names"] = [f"skill-{index}" for index in range(MAX_SKILL_NAMES + 20)]
+        payload["metrics"]["skills_exposed"] = _reading(MAX_SKILL_NAMES + 20)
+        admission = admit_session_activity_receipt(payload)
+        self.assertEqual(admission["outcome"], "accepted", admission["errors"])
+        skills = admission["receipt"]["skills"]
+        self.assertEqual(len(skills["exposed_names"]), MAX_SKILL_NAMES)
+        self.assertTrue(skills["exposed_names_truncated"])
+        # A truncated list is not a complete set, so the derivation falls back
+        # to the counters instead of naming an incomplete difference.
+        self.assertEqual(skill_exposure_summary(admission["receipt"])["derivation"], "counters")
+
+    def test_oversized_evidence_refs_are_capped_and_links_become_digests(self) -> None:
+        payload = _payload(evidence_refs=[f"observer:event:{index}" for index in range(MAX_EVIDENCE_REFS + 5)] + ["https://host/log?x=1"])
+        receipt = admit_session_activity_receipt(payload)["receipt"]
+        self.assertEqual(len(receipt["evidence_refs"]), MAX_EVIDENCE_REFS)
+        linked = admit_session_activity_receipt(_payload(evidence_refs=["https://host/log?x=1"]))["receipt"]
+        self.assertTrue(linked["evidence_refs"][0].startswith("ref-"))
+        self.assertNotIn("host/log", json.dumps(linked))
+
+    def test_a_control_character_in_a_model_ref_is_not_stored_as_typed(self) -> None:
+        receipt = admit_session_activity_receipt(_payload(model_refs=["glm-5.3\x1b[2K"]))["receipt"]
+        self.assertTrue(receipt["model_refs"][0].startswith("ref-"))
+        self.assertNotIn("\x1b", json.dumps(receipt))
+
+    def test_a_non_object_payload_is_rejected_by_name(self) -> None:
+        admission = admit_session_activity_receipt("not a receipt")  # type: ignore[arg-type]
+        self.assertEqual(admission["outcome"], "rejected")
+        self.assertIsNone(admission["receipt"])
+
+
+class IngestionIsIdempotentAndQuarantinesWhatItMustNotKeep(unittest.TestCase):
+    def test_the_same_receipt_sent_three_times_is_one_line(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            outcomes = [ingest_session_activity_receipt(paths, _payload())["outcome"] for _ in range(3)]
+            self.assertEqual(outcomes, ["recorded", "already_recorded", "already_recorded"])
+            self.assertEqual(len(read_session_activity_receipts(paths)), 1)
+            self.assertEqual(read_session_activity_quarantine(paths), [])
+
+    def test_a_resend_without_observed_at_is_still_the_same_receipt(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            ingest_session_activity_receipt(paths, _payload())
+            resend = _payload()
+            del resend["observed_at"]
+            self.assertEqual(ingest_session_activity_receipt(paths, resend)["outcome"], "already_recorded")
+
+    def test_a_reused_identity_with_a_different_observation_is_quarantined(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            ingest_session_activity_receipt(paths, _payload())
+            conflicting = _payload()
+            conflicting["metrics"]["tool_calls"] = _reading(99)
+            result = ingest_session_activity_receipt(paths, conflicting)
+            self.assertEqual(result["outcome"], "quarantined")
+            self.assertEqual(result["reason"], REASON_IDENTITY_CONFLICT)
+            self.assertEqual(len(read_session_activity_receipts(paths)), 1)
+            self.assertEqual(read_session_activity_receipts(paths)[0]["metrics"]["tool_calls"]["value"], 31)
+            quarantine = read_session_activity_quarantine(paths)
+            self.assertEqual(len(quarantine), 1)
+            self.assertEqual(quarantine[0]["reason"], REASON_IDENTITY_CONFLICT)
+
+    def test_a_cross_profile_receipt_is_quarantined_not_stored(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            result = ingest_session_activity_receipt(paths, _payload(profile_ref="profile-b2"), expected_profile_ref="profile-a1")
+            self.assertEqual(result["outcome"], "quarantined")
+            self.assertEqual(result["reason"], REASON_CROSS_PROFILE)
+            self.assertEqual(read_session_activity_receipts(paths), [])
+            quarantine = read_session_activity_quarantine(paths)
+            self.assertEqual(quarantine[0]["profile_ref"], "profile-b2")
+            self.assertEqual(set(quarantine[0]), {
+                "schema_version", "quarantined_at", "reason", "errors", "receipt_id", "session_ref", "profile_ref", "claim_boundary",
+            })
+
+    def test_a_receipt_after_the_sessions_final_receipt_is_stale(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            ingest_session_activity_receipt(paths, _payload())
+            result = ingest_session_activity_receipt(paths, _turn_payload(13, "sar-late-turn"))
+            self.assertEqual(result["outcome"], "quarantined")
+            self.assertEqual(result["reason"], REASON_STALE_AFTER_FINAL)
+
+    def test_an_earlier_boundary_arriving_after_a_later_one_is_stale(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            self.assertEqual(ingest_session_activity_receipt(paths, _turn_payload(5, "sar-turn-5"))["outcome"], "recorded")
+            result = ingest_session_activity_receipt(paths, _turn_payload(4, "sar-turn-4"))
+            self.assertEqual(result["outcome"], "quarantined")
+            self.assertEqual(result["reason"], REASON_STALE_SEQUENCE)
+            self.assertEqual(ingest_session_activity_receipt(paths, _turn_payload(6, "sar-turn-6"))["outcome"], "recorded")
+            latest = latest_session_activity_receipt(read_session_activity_receipts(paths), "sess-9f2c4a")
+            self.assertEqual(latest["receipt_id"], "sar-turn-6")
+
+    def test_an_interval_older_than_the_freshness_window_is_stale(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            result = ingest_session_activity_receipt(paths, _payload(), now="2026-09-09T09:42:10Z", max_age_seconds=3600)
+            self.assertEqual(result["outcome"], "quarantined")
+            self.assertEqual(result["reason"], REASON_STALE_AGE)
+            fresh = ingest_session_activity_receipt(paths, _payload(), now="2026-09-08T10:00:00Z", max_age_seconds=3600)
+            self.assertEqual(fresh["outcome"], "recorded")
+
+    def test_a_rejected_payload_reaches_nothing_on_disk(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            result = ingest_session_activity_receipt(paths, _payload(prompt="never"))
+            self.assertEqual(result["outcome"], "rejected")
+            self.assertFalse(paths.runtime_session_activity_receipts_path.exists())
+            self.assertEqual(read_session_activity_quarantine(paths), [])
+
+    def test_the_store_validator_reports_a_hand_edited_record_and_a_reused_identity(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")
+            ingest_session_activity_receipt(paths, _payload())
+            self.assertTrue(validate_session_activity_receipt_store(paths.runtime_session_activity_receipts_path)["ok"])
+            edited = deepcopy(read_session_activity_receipts(paths)[0])
+            edited["metrics"]["tool_calls"]["value"] = "many"
+            with paths.runtime_session_activity_receipts_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(edited, sort_keys=True) + "\n")
+            report = validate_session_activity_receipt_store(paths.runtime_session_activity_receipts_path)
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["receipt_count"], 2)
+            self.assertTrue(any("different observation" in error for error in report["errors"]))
+
+
+class SixNamedConsumersReadOneFixture(unittest.TestCase):
+    def test_every_consumer_reads_only_its_metrics_and_keeps_the_boundaries(self) -> None:
+        receipt = admit_session_activity_receipt(_payload())["receipt"]
+        self.assertGreaterEqual(len(SESSION_ACTIVITY_CONSUMERS), 3)
+        for consumer, names in SESSION_ACTIVITY_CONSUMERS.items():
+            with self.subTest(consumer=consumer):
+                evidence = session_activity_evidence(receipt, consumer)
+                self.assertEqual(evidence["schema_version"], "session_activity_evidence/v1")
+                self.assertEqual(evidence["consumer"], consumer)
+                self.assertEqual(tuple(evidence["metrics"]), names)
+                self.assertTrue(set(names) <= set(METRIC_NAMES))
+                self.assertEqual(
+                    sorted(evidence["observed_metrics"] + evidence["heuristic_metrics"] + evidence["unavailable_metrics"]),
+                    sorted(names),
+                )
+                self.assertEqual(evidence["claim_boundary"], CLAIM_BOUNDARY)
+                self.assertFalse(evidence["observation_floor"])
+                for name in evidence["unavailable_metrics"]:
+                    self.assertIsNone(evidence["metrics"][name]["value"])
+
+    def test_skill_facing_consumers_carry_the_exposure_summary_and_others_do_not(self) -> None:
+        receipt = admit_session_activity_receipt(_payload())["receipt"]
+        for consumer, names in SESSION_ACTIVITY_CONSUMERS.items():
+            with self.subTest(consumer=consumer):
+                evidence = session_activity_evidence(receipt, consumer)
+                self.assertEqual("skill_exposure" in evidence, "skills_exposed" in names)
+        self.assertEqual(session_activity_evidence(receipt, "skill-health")["skill_exposure"]["exposed_unused_count"], 3)
+
+    def test_every_consumer_is_an_installable_skill_whose_guidance_names_the_receipt(self) -> None:
+        installable = set(installable_skill_names())
+        reference = workflow_reference_markdown()
+        for consumer in SESSION_ACTIVITY_CONSUMERS:
+            with self.subTest(consumer=consumer):
+                self.assertIn(consumer, installable)
+                # A workflow's reference sections are the `### <name>` blocks up
+                # to the next heading; at least one must name the receipt.
+                sections = [part.split("\n#", 1)[0] for part in reference.split(f"\n### {consumer}\n")[1:]]
+                self.assertTrue(sections)
+                self.assertTrue(any("`session_activity_receipt/v1`" in section for section in sections))
+
+    def test_quarantine_reasons_stay_inside_the_closed_vocabulary(self) -> None:
+        for reason in (REASON_CROSS_PROFILE, REASON_STALE_AFTER_FINAL, REASON_STALE_SEQUENCE, REASON_STALE_AGE, REASON_IDENTITY_CONFLICT):
+            self.assertIn(reason, QUARANTINE_REASONS)
+
+    def test_an_unknown_consumer_and_an_invalid_receipt_are_refused(self) -> None:
+        receipt = admit_session_activity_receipt(_payload())["receipt"]
+        with self.assertRaises(SessionActivityReceiptError):
+            session_activity_evidence(receipt, "transcript-scraper")
+        with self.assertRaises(SessionActivityReceiptError):
+            session_activity_evidence({"schema_version": "nonsense"}, "achievements")
+
+    def test_attaching_no_receipt_records_that_none_was_supplied(self) -> None:
+        payload = attach_session_activity_evidence({"summary": {}}, None, "achievements")
+        self.assertIsNone(payload["session_activity"])
+        receipt = admit_session_activity_receipt(_payload())["receipt"]
+        attached = attach_session_activity_evidence({"summary": {}}, receipt, "achievements")
+        self.assertEqual(attached["session_activity"]["consumer"], "achievements")
+
+
+class TheCommandLineValidatesWhatItIsHandedAndCollectsNothing(unittest.TestCase):
+    def test_ingest_records_once_projects_consumers_and_lists(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+            hermes_home = Path(tmp) / ".hermes"
+            input_path = Path(tmp) / "receipt.json"
+            input_path.write_text(json.dumps(_payload()), encoding="utf-8")
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "session-receipt"]
+
+            code, out, _ = run_cli(base + ["ingest", "--input", str(input_path), "--consumer", "workflow-learning", "--consumer", "context-budget-review"])
+            self.assertEqual(code, 0, out)
+            result = json.loads(out)
+            self.assertEqual(result["outcome"], "recorded")
+            self.assertEqual(result["evidence"]["workflow-learning"]["skill_exposure"]["exposed_unused_count"], 3)
+            self.assertEqual(result["evidence"]["context-budget-review"]["metrics"]["context_peak_tokens"]["value"], 91000)
+            self.assertIn("tokens_input", result["evidence"]["context-budget-review"]["unavailable_metrics"])
+
+            code, out, _ = run_cli(base + ["ingest", "--input", str(input_path)])
+            self.assertEqual(code, 0, out)
+            self.assertEqual(json.loads(out)["outcome"], "already_recorded")
+
+            code, out, _ = run_cli(base + ["list", "--session", "sess-9f2c4a"])
+            self.assertEqual(code, 0, out)
+            listing = json.loads(out)
+            self.assertEqual(len(listing["receipts"]), 1)
+            self.assertEqual(listing["quarantined"], [])
+            self.assertEqual(listing["claim_boundary"], CLAIM_BOUNDARY)
+
+    def test_dry_run_admits_without_writing_and_cross_profile_is_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            omh_home = Path(tmp) / ".omh"
+            hermes_home = Path(tmp) / ".hermes"
+            input_path = Path(tmp) / "receipt.json"
+            input_path.write_text(json.dumps(_payload()), encoding="utf-8")
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "runtime", "session-receipt"]
+
+            code, out, _ = run_cli(base + ["ingest", "--input", str(input_path), "--dry-run", "--consumer", "skill-health"])
+            self.assertEqual(code, 0, out)
+            result = json.loads(out)
+            self.assertEqual(result["outcome"], "accepted")
+            self.assertFalse(result["written"])
+            self.assertEqual(result["evidence"]["skill-health"]["consumer"], "skill-health")
+            self.assertFalse((omh_home / "runtime" / "session_activity_receipts.jsonl").exists())
+
+            code, out, _ = run_cli(base + ["ingest", "--input", str(input_path), "--expected-profile", "profile-zz", "--consumer", "achievements"])
+            self.assertEqual(code, 0, out)
+            result = json.loads(out)
+            self.assertEqual(result["outcome"], "quarantined")
+            self.assertEqual(result["reason"], REASON_CROSS_PROFILE)
+            self.assertIsNone(result["evidence"]["achievements"])
+
+    def test_an_invalid_payload_is_rejected_with_named_errors(self) -> None:
+        with TemporaryDirectory() as tmp:
+            input_path = Path(tmp) / "receipt.json"
+            input_path.write_text(json.dumps(_payload(transcript="user: hello")), encoding="utf-8")
+            code, out, _ = run_cli(
+                ["--omh-home", str(Path(tmp) / ".omh"), "--hermes-home", str(Path(tmp) / ".hermes"), "runtime", "session-receipt", "ingest", "--input", str(input_path)]
+            )
+            self.assertEqual(code, 0, out)
+            result = json.loads(out)
+            self.assertEqual(result["outcome"], "rejected")
+            self.assertTrue(result["errors"])
+            self.assertNotIn("user: hello", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- A versioned `session_activity_receipt/v1` contract and validator (`src/workflows/session_activity_receipts.py`): producer identity, profile/session handles, boundary kind with a `final` marker, observed interval with coverage, bounded per-counter readings carrying their own `availability` (`observed` / `heuristic` / `unavailable`) and `measurement` (`exact` / `floor`), bounded skill-name lists with truncation flags and a `plain` / `digest` name form, bounded model and evidence refs, privacy and claim-boundary constants.
- An adapter that validates supplied payloads only: `admit_session_activity_receipt` (pure) and `ingest_session_activity_receipt` (append-once under the store lock at `$OMH_HOME/runtime/session_activity_receipts.jsonl`). Identical re-sends answer `already_recorded`; cross-profile, stale (after a final receipt, behind a later boundary sequence, or older than an explicit `--max-age-seconds`), and identity-conflicting payloads are quarantined to a metadata-only sidecar; invalid payloads reach nothing on disk.
- Six named consumer projections (`session_activity_evidence`, `SESSION_ACTIVITY_CONSUMERS`): `workflow-learning`, `context-budget-review`, `run-efficiency`, `skill-health`, `achievements`, `agent-ops-review`, each reading its own counters off the same record with observed, heuristic, and unavailable lists kept apart, `terminal` only for a final receipt, `observation_floor` for partial coverage, and the exposed-but-unused derivation where skill counters are read.
- `omh runtime session-receipt ingest|list` (`src/commands/session_activity.py`), with `--expected-profile`, `--max-age-seconds`, `--redact-skill-names`, repeatable `--consumer`, and `--dry-run`.
- The six consumer skills name the supplied receipt as an input in their generated guidance; `docs/SESSION-ACTIVITY-RECEIPTS.md` documents the contract and states that the receipt is supplied observed evidence, not automatic host execution or proof of an unobserved interval.

### Why This Exists

- Issue #1404: OMH had `plugin_host_observation/v1` (plugin load/tool/hook events) and coding-unit telemetry (executor units), but no session-level observed summary that cross-workflow consumers could share. "The skill was not used" was ambiguous because nothing recorded whether the host exposed the skill in that session, and each workflow would otherwise have to parse observer-specific files or transcripts.

### User / Operator Impact

- An operator, wrapper, or observer plugin can hand OMH one approved, privacy-bounded receipt per session boundary and have it reused by six workflows without any transcript scanning.
- Reports distinguish exposed from activated skills, observed counters from heuristic and unavailable ones, floors from exact totals, and partial turn boundaries from a final session result.
- Nothing is collected automatically: no Hermes database is read, no hook is patched, no background collection starts.

### How It Works

- Normalization bounds arrays and folds unsafe skill names / refs into stable digest handles; strict validation then runs on the normalized shape (closed key sets at every level, raw-material keys refused by name, closed vocabularies, opaque references, ISO-8601 `Z` stamps, integer counters within `MAX_METRIC_VALUE`).
- `final: true` is only accepted on a `session_end` boundary; under `from_producer_load` or `unknown` coverage an `exact` reading is refused, so a mid-session producer can only report floors.
- `skill_exposure_summary` derives exposed-but-unused from complete name lists, falls back to counters when a list is truncated, and returns `unavailable` with a reason when either side was not observed or the counters disagree.
- Store placement: beside `plugin_host_observations.jsonl`, not in the run-scoped `journal/` registry, because a session receipt names no run.

### Files And Contracts Touched

- `src/workflows/session_activity_receipts.py` (new), `src/commands/session_activity.py` (new), `src/commands/runtime.py`, `src/system/paths.py`
- `src/skills/catalog_harnesses.py`, `src/skills/catalog_feature_surfaces.py`, `src/skills/native_capability_surfaces.py` and regenerated `skills/omh-achievements/SKILL.md`, `skills/omh-run-efficiency/SKILL.md`, `docs/WORKFLOWS.md`
- `src/maintenance/release.py`: `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` 914399 -> 914611 for the two bounded artifact-expectation lines, with the justification comment in the file
- `docs/SESSION-ACTIVITY-RECEIPTS.md` (new), `docs/README.md`
- `tests/test_session_activity_receipts.py` (new, 46 tests)

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `omh runtime session-receipt --help`; CLI ingest/list/dry-run/quarantine paths exercised through `run_cli` in the test file
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest tests/test_session_activity_receipts.py`: 46 tests OK, covering mid-session observation floor, heuristic error counters, partial vs final, deduplication, stale/cross-profile/identity quarantine, privacy redaction, six consumers on one fixture, store validation, and the CLI.
- Targeted shared-surface files (`test_router_content`, `test_skill_density`, `test_release_smoke`, `test_application_cases`, `test_runtime_artifacts`, `test_broad_exception_policy`, `test_interpreter_spawn_policy`): 275 tests OK.
- Full suite: 9833 tests, 28 failures/errors all in `test_cross_harness_adapters*` / `test_cross_harness_adapter_security` (known `.claude/worktrees` path artifact), 1 skipped; nothing else failed.
- `uv run python -m omh.cli release drift`: No drift, 18 checks passed (after the budget adjustment).
- All five `docs ... --check` gates, ruff, compileall, `git diff --check`: clean.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`: not run; no harness definitions or release channels changed beyond the regenerated catalog text covered by the byte gates.
- Manual Hermes/TUI check: not run; no TUI or plugin surface changed. No live host or observer plugin produces this receipt yet, so end-to-end supply was exercised only with the fixture payload.

## Risk

- Moderate scope: a new store, a new CLI group, and six catalog text lines. The contract is closed-key and versioned, so future fields require a version bump or an explicit key-set change with tests.
- Text-derived tool-error counts remain `heuristic` by contract; consumers must not promote them.

## Compatibility / Rollout

- Additive: no existing store, schema, or command changes shape. The runtime-store registry is untouched (session receipts are not run-scoped).
- Reaches a live machine through `omh update`; the new command is an agent/wrapper/operator surface, not a normal user step.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- A Hermes-side or observer-plugin producer that emits `session_activity_receipt/v1` is out of scope here (the issue defines shared ingestion semantics only).

Closes #1404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
