### PR TITLE
fix(doctor): a pack registered through the current pointer is registered

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -47,6 +47,7 @@ from ..config_adapter import (
     ensure_omh_skin,
     ensure_plugin_enabled,
     ensure_tui_interface,
+    external_dir_registered,
     external_dirs,
     maybe_set_memory_provider,
     memory_provider_selection,
@@ -590,8 +591,11 @@ def _registered_workflow_dir(paths: OmhPaths) -> Path:
 
 
 def _external_dir_registered(config: str, path: Path) -> bool:
+    entries = external_dirs(config)
     wanted = _external_dir_key(path)
-    return any(_external_dir_key(entry) == wanted for entry in external_dirs(config))
+    if any(_external_dir_key(entry) == wanted for entry in entries):
+        return True
+    return external_dir_registered(entries, path)
 
 
 def _external_dir_key(path: str | Path) -> str:
@@ -2743,7 +2747,7 @@ def _run_setup_wizard(args: argparse.Namespace, paths, language: str) -> None:
     print(f"{tr(language, 'hermes_home')}: {_color(str(paths.hermes_home), '36', use_color)}")
     if paths.hermes_config_path.exists():
         config_text = read_config(paths.hermes_config_path)
-        registered = paths.skills_dir.as_posix() in external_dirs(config_text)
+        registered = external_dir_registered(external_dirs(config_text), paths.skills_dir)
         status = tr(language, "status_already_registered") if registered else tr(language, "status_will_register")
         print(f"{tr(language, 'hermes_config')}: {_color(str(paths.hermes_config_path), '36', use_color)} ({status})")
     else:

--- a/src/install/config_adapter.py
+++ b/src/install/config_adapter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from dataclasses import dataclass
 from pathlib import Path
 import re
@@ -690,6 +692,30 @@ def _scalar_value(value: str) -> str:
     if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
         return stripped[1:-1]
     return stripped
+
+
+def external_dir_registered(dirs: list[str], skill_dir: str | Path) -> bool:
+    """Whether one registered entry names `skill_dir`, by text or by real path.
+
+    The installer registers the managed pack under the `current` pointer so the
+    entry survives generation switches, while a running command resolves its
+    own generation directory. Comparing the two as strings reported every
+    staged-update install as unregistered; the directories are the same one.
+    """
+    wanted_text = _normalize(skill_dir)
+    if wanted_text in dirs:
+        return True
+    try:
+        wanted_real = os.path.realpath(os.path.expanduser(str(skill_dir)))
+    except OSError:
+        return False
+    for entry in dirs:
+        try:
+            if os.path.realpath(os.path.expanduser(entry)) == wanted_real:
+                return True
+        except OSError:
+            continue
+    return False
 
 
 def ensure_external_dir(config_text: str, skill_dir: str | Path) -> ConfigChange:

--- a/src/maintenance/doctor.py
+++ b/src/maintenance/doctor.py
@@ -10,6 +10,7 @@ from .advisory import AdvisoryReport, run_config_advisories
 from .structural_search import inspect_structural_search
 from ..command_path import inspect_omh_command_path
 from ..config_adapter import (
+    external_dir_registered,
     external_dirs,
     memory_provider_selection,
     plugin_enablement,
@@ -140,8 +141,9 @@ def run_doctor(paths: OmhPaths) -> list[Check]:
     dirs = external_dirs(config_text)
     hermes_config_present = paths.hermes_config_path.exists()
     checks.append(Check("hermes_config", hermes_config_present, f"{paths.hermes_config_path}"))
-    # config.yaml stores external_dirs in POSIX form (config_adapter._normalize).
-    external_registered = paths.skills_dir.as_posix() in dirs
+    # By text or by real path: the installer registers the `current` pointer,
+    # the running command knows its generation, and both name this directory.
+    external_registered = external_dir_registered(dirs, paths.skills_dir)
     checks.append(Check("external_dir", external_registered, f"{paths.skills_dir} in skills.external_dirs"))
     # `None`, not `dirs`, when the config is absent: `read_config` returns "" for
     # a missing file, so an empty list there would read as "Hermes registers no

--- a/src/maintenance/probe.py
+++ b/src/maintenance/probe.py
@@ -13,7 +13,7 @@ except ImportError:  # pragma: no cover - absent on Windows.
     fcntl = None
 
 from ..capability_roadmap import build_capability_gap_roadmap
-from ..config_adapter import external_dirs, read_config
+from ..config_adapter import external_dir_registered, external_dirs, read_config
 from ..local_store import read_jsonl_objects
 from ..mcp.host_config import mcp_host_config_entry_present
 from ..parity import build_parity_matrix
@@ -480,8 +480,7 @@ def _structural_search_capability(*, which: Callable[[str], str | None] | None =
 def probe_capabilities(paths: OmhPaths, *, include_parity: bool = False, include_roadmap: bool = False) -> dict:
     config_text = read_config(paths.hermes_config_path)
     configured_dirs = external_dirs(config_text)
-    # config.yaml stores external_dirs in POSIX form (config_adapter._normalize).
-    skills_registered = paths.skills_dir.as_posix() in configured_dirs
+    skills_registered = external_dir_registered(configured_dirs, paths.skills_dir)
     capabilities: list[Capability] = []
     buzz = probe_buzz(paths)
     capabilities.append(

--- a/tests/test_config_adapter.py
+++ b/tests/test_config_adapter.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import os
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from _local_package import load_local_package
 
 load_local_package()
 from omh.config_adapter import (
+    external_dir_registered,
     activate_omh_skin,
     activate_tui_interface,
     display_interface_selection,
@@ -271,3 +275,26 @@ class ConfigAdapterTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ExternalDirRegistrationTests(unittest.TestCase):
+    """The installer registers `current/skills`; a running command knows only
+    its generation directory. Measured live 2026-09-08: doctor and probe
+    compared the two as strings and called every staged-update install
+    unregistered."""
+
+    def test_the_generation_directory_is_registered_through_the_current_pointer(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            generation = root / "generations" / "g1"
+            (generation / "skills").mkdir(parents=True)
+            os.symlink(generation, root / "current", target_is_directory=True)
+            dirs = [(root / "current" / "skills").as_posix()]
+            self.assertTrue(external_dir_registered(dirs, generation / "skills"))
+            self.assertTrue(external_dir_registered(dirs, root / "current" / "skills"))
+            self.assertFalse(external_dir_registered(dirs, root / "generations" / "g2" / "skills"))
+            self.assertFalse(external_dir_registered([], generation / "skills"))
+
+    def test_a_textual_match_needs_no_directory_on_disk(self) -> None:
+        self.assertTrue(external_dir_registered(["/nowhere/skills"], "/nowhere/skills"))
+        self.assertFalse(external_dir_registered(["/nowhere/skills"], "/elsewhere/skills"))

--- a/tests/test_doctor_advisory.py
+++ b/tests/test_doctor_advisory.py
@@ -5,9 +5,11 @@ import io
 import json
 import os
 import tempfile
+import dataclasses
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import mock
 
 from omh.maintenance import advisory
@@ -529,3 +531,25 @@ class PlacementTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RegistrationThroughCurrentPointerTests(unittest.TestCase):
+    def test_doctor_accepts_a_pack_registered_under_the_current_pointer(self) -> None:
+        # The staged-update layout: config.yaml names `current/skills`, the
+        # command running doctor resolves its own generation.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            generation = root / "generations" / "g1"
+            (generation / "skills").mkdir(parents=True)
+            os.symlink(generation, root / "current", target_is_directory=True)
+            hermes_home = root / ".hermes"
+            hermes_home.mkdir()
+            (hermes_home / "config.yaml").write_text(
+                f"skills:\n  external_dirs:\n    - {(root / 'current' / 'skills').as_posix()}\n", encoding="utf-8"
+            )
+            paths = dataclasses.replace(
+                resolve_paths(root / ".omh", hermes_home), managed_skills_dir=generation / "skills"
+            )
+            by_name = {check.name: check for check in run_doctor(paths)}
+            self.assertTrue(by_name["external_dir"].ok, by_name["external_dir"].message)
+            self.assertTrue(by_name["runtime_context"].ok, by_name["runtime_context"].message)


### PR DESCRIPTION
## Feature Report

### What Changed

- `external_dir_registered(dirs, skill_dir)` in the config adapter accepts a `skills.external_dirs` entry by normalized text or by real path.
- `omh doctor` (`external_dir`, `runtime_context`), `omh probe` (managed skill directory), and the `omh setup` wizard status line use it instead of string membership.

### Why This Exists

- The installer registers `<managed>/current/skills` so the entry survives generation switches; the running command resolves its generation directory. Compared as strings, every staged-update install reported two blocking doctor checks saying the skills directory is not registered while Hermes was loading it from that entry. Observed live on 2026-09-08 after `omh update`: `os.path.realpath` of both paths equal, doctor "needs attention: 2 blocking".

### User / Operator Impact

- Doctor and probe stop reporting a false registration failure on managed installs; the wizard no longer says it "will register" a directory that is already registered.

### How It Works

- Text match first (unchanged fast path), then `os.path.realpath` equality per entry; unreadable paths are skipped. `ensure_external_dir` keeps exact-text semantics because it decides what to write.

### Files And Contracts Touched

- `src/install/config_adapter.py`, `src/maintenance/doctor.py`, `src/maintenance/probe.py`, `src/commands/setup.py`
- `tests/test_config_adapter.py` (symlinked generation, textual match), `tests/test_doctor_advisory.py` (doctor accepts a pack registered under `current`)

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests/test_config_adapter.py tests/test_doctor_advisory.py tests/test_guidance_projection.py tests/test_hermes_readiness.py tests/test_identity_conflicts.py tests/test_cli.py tests/test_staged_self_update.py` → OK
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: live doctor re-check needs `omh update` after merge

### Observed Evidence

- New tests: generation dir registered via `current` symlink → both doctor checks ok; unrelated generation not registered; textual match without a directory on disk still works.
- Live before the fix: `omh doctor` → `external_dir` and `runtime_context` failing with the generation path while `config.yaml` lists `current/skills`; realpaths equal.

### Not Tested / Not Applicable

- Docs byte gates, harness, release checks: no catalog, generated artifact, or release surface changed; CI runs the full suite.

## Risk

- A registered entry that is a dangling symlink still counts only by text, as before. No behavior change for non-managed installs where the paths were already equal as text.

## Compatibility / Rollout

- No schema or config change. Preview channel picks it up on the next `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
