### PR TITLE
feat(memory): the dreaming brief reaches the turn, and the host says so

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -934,6 +934,35 @@ The ranking inputs do not expand eligibility or establish truth:
 Dreaming prepares a reminder and metadata-only evidence. It never invokes a
 model or performs consolidation, retirement, restore, or prune.
 
+### How a brief reaches the model and the user
+
+A brief on disk consolidates nothing by itself. While the newest brief is
+`due`, the provider serves it inside its prefetch pack as a bounded
+`<memory_consolidation>` section (trigger, reasons, Hermes memory headroom
+and duplicate-cluster counts, and what is requested), so the next
+non-trivial turn on any platform carries the request to the model. The
+section asks the model to consolidate through Hermes' own memory tool and
+then tell the user in one short line what changed. A brief is a request, not
+recalled memory: it never moves the recall count or the recall line.
+
+The section disappears once consolidation is observed: a `replace` or
+`remove` from Hermes' memory tool retires the brief when no standing reason
+remains. Where the host hands the provider a status callback (Hermes does
+this on the CLI surface), the provider also prints one line when a brief
+fires and one when it is honoured:
+
+```text
+💤 OMH — memory consolidation due (session_end: session_ending_with_unconsolidated_turns:1)
+🧹 OMH — memory consolidated (replace on memory)
+```
+
+Gateway platforms (TUI, Slack, Telegram, Discord) receive no provider status
+callback from Hermes; there the model's one-line report is the visible
+signal, and the tool calls it makes are shown by the platform as usual.
+`memory-sync` (reviewing existing Hermes memory against OMH records) stays
+an explicit workflow: nothing runs it automatically, and the brief only
+points at duplicate clusters for the model to resolve.
+
 ## Hermes Memory Tiering: Demotion (L1 → L2)
 
 Hermes-native memory files (`MEMORY.md`, `USER.md`) are L1: small,

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -91,6 +91,10 @@ PROVIDER_NAME = "omh"
 # speaks through -- CLI, TUI, and each gateway platform -- when a prefetch
 # actually put OMH memory into the turn.
 PROVIDER_LABEL = "OMH"
+# The brief rides in the prefetch pack, bounded so a long reason list or eviction
+# plan cannot crowd out the memory it is asking the model to keep.
+CONSOLIDATION_RENDER_BUDGET_CHARS = 1600
+CONSOLIDATION_MAX_ITEMS = 6
 WRITE_JOURNAL_SCHEMA_VERSION = "omh_memory_write_journal_entry/v1"
 JOURNAL_LIMIT = 32
 
@@ -135,6 +139,10 @@ class OmhMemoryProvider(_MemoryProviderBase):
         # base class asks that a stale prior count never be reported.
         self._served_pack = ""
         self._served_count = 0
+        # Hermes hands a status callback to providers on the CLI surface only;
+        # gateway platforms travel a different path and get the brief through
+        # the pack instead. None means "say nothing here", never "fail".
+        self._status_callback = None
 
     @property
     def name(self) -> str:
@@ -155,6 +163,8 @@ class OmhMemoryProvider(_MemoryProviderBase):
         self._hermes_home = Path(str(hermes_home)).expanduser() if hermes_home else None
         self._writes_enabled = str(kwargs.get("agent_context", "") or "") in _WRITING_CONTEXTS
         self._project_home = _project_omh_home(kwargs.get("cwd"))
+        callback = kwargs.get("status_callback")
+        self._status_callback = callback if callable(callback) else None
         self._pack = self.render_pack()
         # A session that died rather than ended -- a killed process, a closed
         # laptop, a lost gateway -- never reaches on_session_end, so nothing
@@ -280,6 +290,7 @@ class OmhMemoryProvider(_MemoryProviderBase):
             self._mutate_state(record_consolidation_observed)
             if not self._standing_reasons():
                 self._retire_stale_brief("memory_write")
+                self._say(f"🧹 {PROVIDER_LABEL} — memory consolidated ({action} on {target})")
 
     def on_session_end(self, messages: list[dict[str, Any]] | None = None) -> None:
         self._evaluate_if_due("session_end")
@@ -316,7 +327,10 @@ class OmhMemoryProvider(_MemoryProviderBase):
             rank_project_memory_records(read_project_memory_records(self._record_homes()), self._query)
         )
         self._pack_count = block_count + record_count
-        return "\n".join(part for part in (system, index, records) if part)
+        # The brief is a request, not a memory: it is served so the model can
+        # consolidate in this turn, and it never moves the recall count.
+        consolidation = render_consolidation_brief(read_latest_consolidation(self._omh_home))
+        return "\n".join(part for part in (system, index, records, consolidation) if part)
 
     def _record_homes(self) -> tuple[Path, ...]:
         """The project store first when there is one, then the user store."""
@@ -360,6 +374,7 @@ class OmhMemoryProvider(_MemoryProviderBase):
                 self._omh_home,
                 clear_after_consolidation(state, at=_utc_now(), reasons=reasons),
             )
+            self._say(consolidation_status_line(trigger, reasons))
         else:
             # Suppression keeps an unchanged `expiring_records:N` from re-firing,
             # which is right -- but the breakdown behind that N can still move
@@ -555,6 +570,20 @@ class OmhMemoryProvider(_MemoryProviderBase):
         path = self._omh_home / "memory" / "write_journal.jsonl"
         self._safely(lambda: _append_bounded_json_line(path, entry))
 
+    def _say(self, line: str) -> None:
+        """One status line through the host, where the host offered a channel.
+
+        Hermes passes `status_callback` to `initialize` on the CLI surface; it
+        prints there and forwards to the gateway status path. A failing
+        callback must not take down the hook that called it.
+        """
+        if self._status_callback is None or not line:
+            return
+        try:
+            self._status_callback(line)
+        except Exception:  # noqa: BLE001 - host callback; the memory hook must survive it
+            return
+
     @staticmethod
     def _safely(write) -> None:
         """A memory-provider write must never take down the turn that triggered it.
@@ -717,6 +746,57 @@ def _journal_record_identity(value: object) -> dict[str, object] | None:
 
 def _non_negative_int(value: object) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def render_consolidation_brief(brief: dict[str, Any] | None) -> str:
+    """The due brief as one bounded prompt section; "" when nothing is due.
+
+    Measured before this existed: 32 briefs in seven days on one machine,
+    every one written to disk, none ever read by a model -- the chat card
+    notice lives on the wrapper surface, and a Hermes turn saw nothing. So
+    `memory_writes_observed` stayed 0 at every consolidation. The section asks
+    for the consolidation and for one line to the user, which is the only
+    channel that reaches every platform Hermes speaks through.
+    """
+    if not brief or not brief.get("due"):
+        return ""
+    lines = [f'<memory_consolidation trigger="{_attr(brief.get("trigger", ""))}" raised_at="{_attr(brief.get("raised_at", ""))}">']
+    reasons = [str(item) for item in brief.get("reasons", []) if isinstance(item, str)]
+    for reason in reasons[:CONSOLIDATION_MAX_ITEMS]:
+        lines.append(f"  <reason>{_text(reason)}</reason>")
+    if len(reasons) > CONSOLIDATION_MAX_ITEMS:
+        lines.append(f'  <omitted reasons="{len(reasons) - CONSOLIDATION_MAX_ITEMS}" />')
+    plan = brief.get("eviction_plan") if isinstance(brief.get("eviction_plan"), dict) else {}
+    clusters = plan.get("duplicate_clusters") if isinstance(plan.get("duplicate_clusters"), list) else []
+    if clusters or plan.get("headroom_chars") is not None:
+        lines.append(
+            f'  <hermes_memory entries="{_attr(plan.get("entry_count", ""))}" headroom_chars="{_attr(plan.get("headroom_chars", ""))}"'
+            f' duplicate_clusters="{len(clusters)}" />'
+        )
+    requested = [str(item) for item in brief.get("requested_of_executor", []) if isinstance(item, str)]
+    for item in requested[:CONSOLIDATION_MAX_ITEMS]:
+        lines.append(f"  <do>{_text(item)}</do>")
+    lines.append("  <do>Then tell the user in one short line that OMH asked for memory consolidation and what you changed, or that nothing needed changing.</do>")
+    lines.append("</memory_consolidation>")
+    text = "\n".join(lines)
+    if len(text) > CONSOLIDATION_RENDER_BUDGET_CHARS:
+        text = text[: CONSOLIDATION_RENDER_BUDGET_CHARS - len("\n</memory_consolidation>")].rsplit("\n", 1)[0] + "\n</memory_consolidation>"
+    return text
+
+
+def consolidation_status_line(trigger: str, reasons: list[str]) -> str:
+    """The line a host prints when a brief fires: trigger and the first reason."""
+    first = reasons[0] if reasons else ""
+    more = f" +{len(reasons) - 1}" if len(reasons) > 1 else ""
+    return f"💤 {PROVIDER_LABEL} — memory consolidation due ({trigger}: {first}{more})"
+
+
+def _text(value: str) -> str:
+    return str(value).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _attr(value: object) -> str:
+    return _text(str(value if value is not None else "")).replace('"', "&quot;")
 
 
 def _default_omh_home() -> Path:

--- a/tests/test_broad_exception_policy.py
+++ b/tests/test_broad_exception_policy.py
@@ -68,6 +68,17 @@ class ClassifiedSite(NamedTuple):
 
 CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
     ClassifiedSite(
+        "src/plugin_bundle/omh/memory_provider.py",
+        "_say",
+        INTENTIONAL,
+        "The host's status callback prints one line for the user; it is Hermes' code, not "
+        "OMH's, and it runs inside a live memory hook (session end, memory write). A "
+        "callback that raises -- a closed terminal, a torn-down gateway adapter -- must "
+        "not fail the hook that was recording consolidation state; the line is dropped and "
+        "nothing else changes. The failure is classified by where it happens (host channel) "
+        "and surfaced nowhere because there is no channel left to surface it on.",
+    ),
+    ClassifiedSite(
         "src/coding/fanout_dispatch.py",
         "signal_safe_unit_runner",
         INTENTIONAL,
@@ -274,8 +285,8 @@ CLASSIFIED_SITES: tuple[ClassifiedSite, ...] = (
 # function. `_write_candidate_batch`, `_is_catalog_question`, `pre_llm_call`,
 # `_resume_unlocked`, and `_execute_cell` each hold two handlers, so the handler
 # count is five above the anchor count.
-EXPECTED_HANDLER_COUNT = 28
-EXPECTED_ANCHOR_COUNT = 23
+EXPECTED_HANDLER_COUNT = 29
+EXPECTED_ANCHOR_COUNT = 24
 
 
 class DerivedSite(NamedTuple):

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -61,7 +61,15 @@ from omh.plugin_bundle.omh.memory_dreaming import (
     write_dreaming_state,
 )
 from omh.plugin_bundle.omh.memory_eviction import build_eviction_plan, eviction_plan_summary
-from omh.plugin_bundle.omh.memory_provider import PROVIDER_LABEL, PROVIDER_NAME, OmhMemoryProvider, RecallStatus
+from omh.plugin_bundle.omh.memory_provider import (
+    CONSOLIDATION_RENDER_BUDGET_CHARS,
+    PROVIDER_LABEL,
+    PROVIDER_NAME,
+    OmhMemoryProvider,
+    RecallStatus,
+    consolidation_status_line,
+    render_consolidation_brief,
+)
 from omh.plugin_bundle.omh.memory_records import (
     rank_project_memory_records,
     read_project_memory_records,
@@ -2359,3 +2367,106 @@ class RecallIndicatorTests(unittest.TestCase):
             self.assertIsNone(provider.recall_status())
             provider.shutdown()
             self.assertIsNone(provider.recall_status())
+
+
+class DreamingReachesTheTurnTests(unittest.TestCase):
+    """Measured on one machine over seven days: 32 briefs written, 26 of them
+    `session_start_recovery`, and `memory_writes_observed` 0 at every one. The
+    scheduler ran; nothing carried its brief into a Hermes turn, so nothing
+    ever consolidated. The brief now rides in the prefetch pack -- the one
+    channel that reaches every platform -- and the host prints a line where
+    it offers a status callback."""
+
+    def _provider(self, root: Path, **kwargs: object) -> OmhMemoryProvider:
+        provider = OmhMemoryProvider(root / ".omh")
+        provider.initialize("s1", hermes_home=str(root / ".hermes"), agent_context="primary", cwd=str(root), **kwargs)
+        return provider
+
+    def test_a_due_brief_is_served_in_the_pack_and_never_counts_as_a_memory(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "one fact")
+            provider = self._provider(root)
+            provider.on_turn_start(1, "hi")
+            provider.on_session_end()  # a single unconsolidated turn is enough at a session end
+            self.assertTrue((root / ".omh" / "memory" / "consolidation.json").exists())
+            provider.queue_prefetch("")
+            pack = provider.prefetch("next turn")
+            self.assertIn("<memory_consolidation", pack)
+            self.assertIn("session_ending_with_unconsolidated_turns", pack)
+            self.assertIn("Hermes' own memory tool", pack)
+            self.assertIn("tell the user in one short line", pack)
+            # A brief is a request, not recalled memory: nothing to count, no
+            # indicator -- the pack is non-empty but Hermes renders count 0 generically.
+            self.assertEqual(provider.recall_status(), RecallStatus(provider_label="OMH", count=0))
+
+    def test_the_brief_leaves_the_pack_once_consolidation_is_observed(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "one fact")
+            provider = self._provider(root)
+            provider.on_turn_start(1, "hi")
+            provider.on_session_end()
+            provider.queue_prefetch("")
+            self.assertIn("<memory_consolidation", provider.prefetch("x"))
+            provider.on_memory_write("replace", "memory", "one fact, merged", {"write_origin": "assistant_tool"})
+            provider.queue_prefetch("")
+            self.assertNotIn("<memory_consolidation", provider.prefetch("x"))
+
+    def test_the_host_hears_a_line_when_a_brief_fires_and_when_it_is_honoured(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "one fact")
+            heard: list[str] = []
+            provider = self._provider(root, status_callback=heard.append)
+            provider.on_turn_start(1, "hi")
+            provider.on_session_end()
+            self.assertEqual(len(heard), 1)
+            self.assertTrue(heard[0].startswith("💤 OMH — memory consolidation due (session_end: "), heard[0])
+            provider.on_memory_write("remove", "memory", "", {"write_origin": "assistant_tool"})
+            self.assertEqual(heard[-1], "🧹 OMH — memory consolidated (remove on memory)")
+            # An 'add' is not consolidation and says nothing.
+            provider.on_memory_write("add", "memory", "new", {"write_origin": "assistant_tool"})
+            self.assertEqual(len(heard), 2)
+
+    def test_no_callback_and_a_failing_callback_both_leave_the_hook_alone(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_hermes_memory(root / ".hermes", "one fact")
+            quiet = self._provider(root)
+            quiet.on_turn_start(1, "hi")
+            quiet.on_session_end()  # no callback: nothing raised
+
+            def broken(_line: str) -> None:
+                raise RuntimeError("terminal went away")
+
+            provider = self._provider(root, status_callback=broken)
+            provider.on_turn_start(1, "hi")
+            provider.on_session_end()  # a failing host channel never fails the hook
+            self.assertTrue((root / ".omh" / "memory" / "consolidation.json").exists())
+
+    def test_the_status_line_names_the_trigger_and_the_first_reason(self) -> None:
+        self.assertEqual(
+            consolidation_status_line("turn", ["turn_interval_reached:5/5", "headroom_below_floor:120"]),
+            "💤 OMH — memory consolidation due (turn: turn_interval_reached:5/5 +1)",
+        )
+        self.assertEqual(consolidation_status_line("shutdown", []), "💤 OMH — memory consolidation due (shutdown: )")
+
+    def test_the_rendered_brief_is_bounded_escaped_and_silent_when_not_due(self) -> None:
+        self.assertEqual(render_consolidation_brief(None), "")
+        self.assertEqual(render_consolidation_brief({"due": False, "reasons": ["x"]}), "")
+        brief = {
+            "due": True,
+            "trigger": "turn",
+            "raised_at": "2026-09-08T00:00:00Z",
+            "reasons": [f"reason_{i} <{i}>" for i in range(20)],
+            "requested_of_executor": ["a & b"] * 20,
+            "eviction_plan": {"entry_count": 7, "headroom_chars": 1205, "duplicate_clusters": [{}, {}]},
+        }
+        text = render_consolidation_brief(brief)
+        self.assertLessEqual(len(text), CONSOLIDATION_RENDER_BUDGET_CHARS)
+        self.assertTrue(text.endswith("</memory_consolidation>"))
+        self.assertIn("reason_0 &lt;0&gt;", text)
+        self.assertIn('<omitted reasons="14" />', text)
+        self.assertIn('duplicate_clusters="2"', text)
+        self.assertNotIn("<0>", text)


### PR DESCRIPTION
## Feature Report

### What Changed

- While the newest consolidation brief is `due`, the OMH memory provider serves it inside its prefetch pack as a bounded `<memory_consolidation>` section: trigger, reasons, Hermes memory headroom and duplicate-cluster counts, the requested actions, and one added request — tell the user in one short line what was consolidated (or that nothing needed changing). The section leaves the pack when a `replace`/`remove` from Hermes' memory tool retires the brief. It never counts toward the recall line.
- Where Hermes hands the provider a `status_callback` at `initialize` (the CLI surface), the provider prints one line when a brief fires and one when it is honoured:
  `💤 OMH — memory consolidation due (session_end: session_ending_with_unconsolidated_turns:1)` / `🧹 OMH — memory consolidated (replace on memory)`. A missing or failing callback never affects the hook.
- `docs/MEMORY.md` Dreaming section gains "How a brief reaches the model and the user"; the broad-except policy inventory records the one new host-callback guard.

### Why This Exists

- Measured on the owner machine over seven days: 32 briefs written (26 `session_start_recovery`, 4 `session_end`, 2 `turn`), `memory_writes_observed` 0 at every one. The scheduler ran on time and nothing carried its brief into a Hermes turn — the only in-conversation consumer was the wrapper chat card, which a Hermes session never renders. Dreaming was invisible and inert. The owner asked for a "memory is being consolidated" signal on every surface (TUI, Slack, Discord, …).

### User / Operator Impact

- On every platform: the first non-trivial turn after a brief fires (turn interval, compaction, session end/shutdown, or a recovered dead session) carries the request; the model consolidates through Hermes' memory tool and reports in one line. Tool calls it makes are shown by the platform as usual.
- On the CLI surface additionally: the two deterministic status lines above.
- `memory-sync` remains explicit; nothing runs the interview automatically.

### How It Works

- `render_consolidation_brief(brief)` renders the due brief under `CONSOLIDATION_RENDER_BUDGET_CHARS` (1,600) with at most 6 reasons / 6 requested items, escapes text, and returns `""` when nothing is due. `render_pack` appends it after blocks, index, and records without touching `_pack_count`.
- `consolidation_status_line(trigger, reasons)` builds the fire line; `consolidation_due` calls `_say` after writing the brief; `on_memory_write` calls `_say` after retiring it. `_say` is a no-op without a callback and swallows a raising callback (classified in `tests/test_broad_exception_policy.py`).

### Files And Contracts Touched

- `src/plugin_bundle/omh/memory_provider.py`, `docs/MEMORY.md`
- `tests/test_memory_provider.py` (`DreamingReachesTheTurnTests`, 6 tests), `tests/test_broad_exception_policy.py` (one verdict, counts 28→29 / 23→24)

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (running; see CI for the clean-checkout result)
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check` (also `origin/main...HEAD`)
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests/test_memory_provider.py tests/test_hermes_memory_bridge.py tests/test_plugin_distribution.py tests/test_broad_exception_policy.py` → OK
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: needs `omh update` after merge; the owner machine has a pending recovery brief, so the next session start is the live check

### Observed Evidence

- New tests: a due brief is served and the recall status stays count 0; the section leaves the pack after an observed `replace`; the host hears the fire and honour lines and nothing on `add`; no callback and a raising callback both leave the hook intact; the rendered section is bounded, escaped, and empty when not due.
- Live measurement before the change: `consolidation.jsonl` 32 briefs / 7 days by trigger `{session_start_recovery: 26, session_end: 4, turn: 2}`; `dreaming.json` `memory_writes_observed: 0`.

### Not Tested / Not Applicable

- Harness/release checks: no catalog, generated artifact, or release surface changed.
- Live consolidation turn: after merge and `omh update`.

## Risk

- Prompt content grows by up to 1,600 chars on turns where a brief is due (bounded, disappears once honoured). A model that ignores the section leaves behaviour exactly as before this change.
- Gateway platforms depend on the model's one-line report; Hermes offers providers no status callback there. An upstream seam (a provider status line for gateway, like `recall_status`) would make the CLI lines universal; not filed.

## Compatibility / Rollout

- No schema or config change. Preview channel picks it up on the next `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Optional upstream proposal to Hermes: a provider `status_line()` seam for gateway platforms so the deterministic lines reach Slack/Discord/TUI too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
