### PR TITLE
fix(memory): a consolidation brief alone does not light the recall line

### DIFF
--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -135,10 +135,14 @@ class OmhMemoryProvider(_MemoryProviderBase):
         self._pack = ""
         self._query = ""
         self._pack_count = 0
+        # True when blocks, a reference index, or records are in the pack. A
+        # consolidation brief alone is a request, not recalled memory.
+        self._pack_has_memory = False
         # What the LAST prefetch handed Hermes, for the recall indicator: the
         # base class asks that a stale prior count never be reported.
         self._served_pack = ""
         self._served_count = 0
+        self._served_has_memory = False
         # Hermes hands a status callback to providers on the CLI surface only;
         # gateway platforms travel a different path and get the brief through
         # the pack instead. None means "say nothing here", never "fail".
@@ -178,6 +182,7 @@ class OmhMemoryProvider(_MemoryProviderBase):
 
     def prefetch(self, query: str = "", *, session_id: str = "") -> str:
         self._served_pack, self._served_count = self._pack, self._pack_count
+        self._served_has_memory = self._pack_has_memory
         return self._pack
 
     def queue_prefetch(
@@ -203,17 +208,18 @@ class OmhMemoryProvider(_MemoryProviderBase):
         prefetch that carried it, so the user sees memory was used even when
         the model says nothing about it. Nothing served, nothing said. A pack
         that is only a reference-block index counts as content without a
-        discrete count, which Hermes renders generically.
+        discrete count, which Hermes renders generically; a pack that is only
+        a consolidation brief is a request, not memory, and says nothing.
         """
-        if not self._served_pack:
+        if not self._served_pack or not self._served_has_memory:
             return None
         return RecallStatus(provider_label=PROVIDER_LABEL, count=self._served_count)
 
     def shutdown(self) -> None:
         """Hermes is closing. Last chance to leave a brief behind."""
         self._evaluate_if_due("shutdown")
-        self._pack, self._pack_count = "", 0
-        self._served_pack, self._served_count = "", 0
+        self._pack, self._pack_count, self._pack_has_memory = "", 0, False
+        self._served_pack, self._served_count, self._served_has_memory = "", 0, False
 
     # -- Optional hooks -----------------------------------------------------
 
@@ -327,6 +333,7 @@ class OmhMemoryProvider(_MemoryProviderBase):
             rank_project_memory_records(read_project_memory_records(self._record_homes()), self._query)
         )
         self._pack_count = block_count + record_count
+        self._pack_has_memory = bool(system or index or records)
         # The brief is a request, not a memory: it is served so the model can
         # consolidate in this turn, and it never moves the recall count.
         consolidation = render_consolidation_brief(read_latest_consolidation(self._omh_home))

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -2396,9 +2396,14 @@ class DreamingReachesTheTurnTests(unittest.TestCase):
             self.assertIn("session_ending_with_unconsolidated_turns", pack)
             self.assertIn("Hermes' own memory tool", pack)
             self.assertIn("tell the user in one short line", pack)
-            # A brief is a request, not recalled memory: nothing to count, no
-            # indicator -- the pack is non-empty but Hermes renders count 0 generically.
-            self.assertEqual(provider.recall_status(), RecallStatus(provider_label="OMH", count=0))
+            # A brief is a request, not recalled memory: no indicator at all.
+            self.assertIsNone(provider.recall_status())
+            # With one real memory beside it, the count is that memory alone.
+            write_memory_block(root / ".omh", approve_memory_block(build_memory_block("facts", "OMH wraps Hermes.")))
+            provider.queue_prefetch("")
+            pack = provider.prefetch("next turn")
+            self.assertIn("<memory_consolidation", pack)
+            self.assertEqual(provider.recall_status(), RecallStatus(provider_label="OMH", count=1))
 
     def test_the_brief_leaves_the_pack_once_consolidation_is_observed(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

### What Changed

- `recall_status()` answers only when the served pack carries memory (system blocks, a reference index, or records). A pack that holds only the `<memory_consolidation>` request returns `None`, so Hermes prints no recall line for it. With memory beside the brief, the count is the memory count as before.

### Why This Exists

- Observed live right after #1410, through Hermes' `MemoryManager` with the installed bundle and this machine's real pending compaction brief: the pack was 754 chars of brief only and `describe_recall()` returned `🧠 OMH — recalled relevant memory`. Nothing was recalled. The line's whole point (#1402) is that it is true.

### User / Operator Impact

- No false recall line on turns where only a consolidation request is served. Everything else unchanged.

### How It Works

- `render_pack` sets `_pack_has_memory = bool(system or index or records)`; `prefetch` copies it to `_served_has_memory`; `recall_status` requires it; `shutdown` clears it.

### Files And Contracts Touched

- `src/plugin_bundle/omh/memory_provider.py`, `tests/test_memory_provider.py` (brief-only → `None`; brief + one block → count 1)

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (CI)
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check` (`origin/main...HEAD`)
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `PYTHONPATH=tests uv run python -m unittest tests/test_memory_provider.py` → OK
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: re-run of the live MemoryManager check after merge + `omh update`

### Observed Evidence

- Live before: brief-only pack → `🧠 OMH — recalled relevant memory`. Test after: brief-only → `recall_status()` is `None`; brief plus one approved block → `RecallStatus("OMH", 1)`.

### Not Tested / Not Applicable

- Docs byte gates, harness, release: no catalog, generated artifact, or release surface changed.

## Risk

- None beyond the provider; a pack with memory behaves exactly as before.

## Compatibility / Rollout

- No schema or config change. Preview channel picks it up on the next `omh update`.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwmiYQFVYyiBf7cDp4vBJY
