### PR TITLE
fix: keep delegation route edits in the active Hermes home

### DIFF
--- a/src/plugin_bundle/omh/delegation_routing.py
+++ b/src/plugin_bundle/omh/delegation_routing.py
@@ -245,7 +245,15 @@ def write_delegation_route(
 
 
 def _config_path(hermes_home: str | Path | None) -> Path:
-    home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    if hermes_home:
+        return Path(hermes_home).expanduser() / "config.yaml"
+    try:
+        from hermes_constants import get_hermes_home
+    except ImportError:
+        # The bundled plugin is also importable without a Hermes runtime.
+        home = Path(os.environ.get("HERMES_HOME") or "~/.hermes").expanduser()
+    else:
+        home = get_hermes_home()
     return home / "config.yaml"
 
 

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -138,7 +138,7 @@ OMH_DELEGATE_ROUTE_SCHEMA = {
             },
             "hermes_home": {
                 "type": "string",
-                "description": "Optional HERMES_HOME override. Defaults to ~/.hermes.",
+                "description": "Optional Hermes home override. Defaults to the active Hermes home, or $HERMES_HOME / ~/.hermes without Hermes.",
             },
             "omh_home": {
                 "type": "string",

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -11,16 +11,103 @@ projection over the shipped mixture chains.
 import json
 import os
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
 
 from omh.plugin_bundle.omh.delegation_routing import (
     read_delegation_route,
+    read_session_provider,
     write_delegation_route,
 )
 from omh.plugin_bundle.omh.hermes_delegation import load_delegation_route_provenance
 from omh.plugin_bundle.omh.tools.delegate_route_tool import omh_delegate_route_handler
+
+
+class DelegationRouteHomeTest(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.default_home = self.root / ".hermes"
+        self.profile = self.default_home / "profiles" / "test-profile"
+        self.omh_home = self.root / ".omh"
+        self.enterContext(mock.patch.dict(os.environ, {
+            "HOME": str(self.root),
+            "USERPROFILE": str(self.root),
+            "HERMES_HOME": str(self.profile),
+            "OMH_HOME": str(self.omh_home),
+        }))
+        # Force the standalone boundary regardless of the developer's host.
+        self.enterContext(mock.patch.dict("sys.modules", {"hermes_constants": None}))
+
+    def _assert_tool_cycle(self, target, **args):
+        untouched = (
+            "# keep this comment\nmodel:\n  provider: test-parent\n"
+            "delegation:\n  max_concurrent_children: 4\n"
+            "display:\n  skin: test-skin\n"
+        )
+        other_homes = {self.default_home, self.profile, self.root / "native"} - {target}
+        for home in other_homes | {target}:
+            home.mkdir(parents=True, exist_ok=True)
+            (home / "config.yaml").write_text(untouched, encoding="utf-8")
+
+        config = target / "config.yaml"
+        target_text = untouched.replace("test-parent", "target-parent")
+        config.write_text(target_text, encoding="utf-8")
+
+        def call(action, **values):
+            return json.loads(omh_delegate_route_handler({
+                "action": action, "omh_home": str(self.omh_home), **args, **values,
+            }))
+
+        self.assertEqual(call("status")["route"], {})
+        result = call("set", model="test-child", reasoning_effort="high")
+        self.assertEqual(result["status"], "routed")
+        self.assertEqual(config.read_text(encoding="utf-8"), target_text.replace(
+            "delegation:\n",
+            "delegation:\n  model: 'test-child'\n  reasoning_effort: 'high'\n",
+        ))
+        self.assertEqual(call("status")["route"]["model"], "test-child")
+        self.assertEqual(read_session_provider(args.get("hermes_home")), "target-parent")
+        self.assertEqual(call("clear")["status"], "cleared")
+        self.assertEqual(call("status")["route"], {})
+        self.assertEqual(config.read_text(encoding="utf-8"), target_text)
+        for home in other_homes:
+            self.assertEqual((home / "config.yaml").read_text(encoding="utf-8"), untouched)
+
+    def test_standalone_tool_uses_environment_profile(self):
+        self._assert_tool_cycle(self.profile)
+
+    def test_standalone_tool_expands_environment_home(self):
+        os.environ["HERMES_HOME"] = "~/.hermes/profiles/test-profile"
+        self._assert_tool_cycle(self.profile)
+
+    def test_standalone_tool_defaults_when_environment_is_unset(self):
+        os.environ.pop("HERMES_HOME")
+        self._assert_tool_cycle(self.default_home)
+
+    def test_standalone_tool_defaults_when_environment_is_empty(self):
+        os.environ["HERMES_HOME"] = ""
+        self._assert_tool_cycle(self.default_home)
+
+    def test_explicit_home_outranks_environment(self):
+        self._assert_tool_cycle(self.root / "explicit", hermes_home="~/explicit")
+
+    def test_native_home_outranks_environment(self):
+        native = self.root / "native"
+        module = types.ModuleType("hermes_constants")
+        module.get_hermes_home = lambda: native
+        with mock.patch.dict("sys.modules", {"hermes_constants": module}):
+            self._assert_tool_cycle(native)
+
+    def test_explicit_home_does_not_consult_native_resolver(self):
+        module = types.ModuleType("hermes_constants")
+        module.get_hermes_home = mock.Mock(side_effect=AssertionError("must not resolve"))
+        with mock.patch.dict("sys.modules", {"hermes_constants": module}):
+            self._assert_tool_cycle(self.root / "explicit", hermes_home="~/explicit")
+        module.get_hermes_home.assert_not_called()
 
 
 class DelegationRouteWriterTest(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

Default delegation route reads and writes now resolve the active Hermes home, rather than always targeting `~/.hermes`. An explicitly supplied home keeps precedence.

### Why This Exists

In a profile session, setting, reading, or clearing a route without an explicit home ignored `HERMES_HOME` and could address the default profile configuration. The shared `_config_path` was the common cause for route and parent-provider reads.

### User / Operator Impact

The route tool targets the active profile. Other profile configurations, unrelated YAML settings, and comments remain unchanged. Callers can still explicitly address another home.

### How It Works

Resolve an explicit home first. Otherwise use Hermes `get_hermes_home` when importable. The standalone bundle falls back to nonempty `HERMES_HOME`, then `~/.hermes`, with tilde expansion. Reuse this shared resolver for existing callers; no route lifecycle or dispatch protocol is added.

### Files And Contracts Touched

`src/plugin_bundle/omh/delegation_routing.py`: shared configuration path. `src/plugin_bundle/omh/tools/delegate_route_tool.py`: accurate schema description. `tests/test_delegate_route_tool.py`: seven profile-resolution roundtrip regressions through the real tool handler.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

RED: 3 expected failures among 7 new tests before the fix. GREEN: 179 affected tests; parent reran all 48 route-tool tests. Tests cover set/status/clear, parent provider lookup, explicit precedence, native resolver, standalone environment, unset/empty environment, tilde expansion, and byte preservation of unrelated configs. Pinned Ruff and compileall passed. Full suite: 9,890 tests completed in 594.155s, OK with one skip. Independent review of `19054515646bbab144a6a3697aa7fc90a3df1906` found no blocking or medium issues and additionally exercised the real Hermes context-scoped resolver and standalone bundle with synthetic files.

### Not Tested / Not Applicable

No live Hermes/TUI or model dispatch was exercised, to preserve the productive setup. Generated catalog, harness, release, installer, and workflow-learning surfaces are unchanged; their checks remain unchecked, not implicitly passed. Native Linux/Windows execution is left to hosted CI.

## Risk

Only implicit configuration targeting changes. An explicit target still wins, including with Hermes installed. Native resolver errors are not silently redirected to another profile. Existing profile-wide persistent route semantics are unchanged: this patch does not claim session isolation, one-shot consumption, or restoration of prior routes.

## Compatibility / Rollout

No dependency, schema, installer, or release-channel changes. Native Hermes and standalone bundled imports remain supported. No actual child-model dispatch, production config changes, install, or restart was performed.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

None required for the bounded correction. Await maintainer review and exact-head hosted CI; no merge is requested by this automation.
