### PR TITLE
fix: keep consolidation status queries read-only

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -934,6 +934,16 @@ The ranking inputs do not expand eligibility or establish truth:
 Dreaming prepares a reminder and metadata-only evidence. It never invokes a
 model or performs consolidation, retirement, restore, or prune.
 
+For agents and operators, `omh_memory(action="consolidation")` reads the latest
+recorded brief and scheduler counters without starting a provider session or
+evaluating triggers. It returns `evaluated: false`; `due` and the brief's other
+fields are present only when a readable brief exists. No brief is not evidence
+that nothing is due. Repeated status queries leave counters, suppression state,
+and the pending brief unchanged. `omh memory dream` is likewise read-only;
+explicit `omh memory dream --evaluate` evaluates once under the `manual` trigger
+and may write a reminder. Provider lifecycle hooks retain their scheduled
+evaluation behavior.
+
 ### How a brief reaches the model and the user
 
 A brief on disk consolidates nothing by itself. While the newest brief is

--- a/src/plugin_bundle/omh/tools/memory_tool.py
+++ b/src/plugin_bundle/omh/tools/memory_tool.py
@@ -33,8 +33,7 @@ from ..degradation import safe_error_type as _safe_error_type
 from ..hermes_memory import build_hermes_memory_bridge
 from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
 from ..memory_blocks import read_memory_block, read_memory_blocks, select_memory_blocks
-from ..memory_dreaming import read_dreaming_state
-from ..memory_provider import OmhMemoryProvider
+from ..memory_dreaming import read_dreaming_state, read_latest_consolidation
 
 MEMORY_ACTIONS = ("status", "blocks", "read", "consolidation")
 
@@ -45,7 +44,8 @@ OMH_MEMORY_SCHEMA = {
         "compares Hermes' built-in memory (MEMORY.md, USER.md) against OMH's approved records "
         "and reports what fits under Hermes' character cap; 'blocks' is a review-readable status "
         "listing with admission and replay state; 'read' returns a value only for replay-eligible "
-        "OMH-reviewed blocks; 'consolidation' reports whether a reminder is due and why. Hermes "
+        "OMH-reviewed blocks; 'consolidation' reads the latest recorded reminder and counters "
+        "without evaluating or consuming them (no 'due' field when no brief is recorded). Hermes "
         "native, provider, and vector context is not_omh_reviewed and never grants OMH admission. "
         "Hermes memory entries are never returned, only counted and hashed. OMH cannot change Hermes memory."
     ),
@@ -183,17 +183,18 @@ def _public_replay(evaluation: dict[str, object]) -> dict[str, object]:
 
 
 def _consolidation() -> tuple[dict[str, object], str]:
-    """Whether dreaming is due, and on what evidence.
+    """Read the latest reminder and counters without entering a provider session.
 
-    This never runs consolidation. OMH cannot: the work needs a model, and the
-    only thing that consolidates Hermes memory is Hermes.
+    Like `omh memory dream` without `--evaluate`, this is a status query, not
+    a scheduler trigger. Keep a recorded due brief visible even when its
+    reasons are suppressed for the next evaluation. No brief means unknown,
+    not a fresh evaluation that found nothing due.
     """
     omh_home = _home("OMH_HOME", "~/.omh")
     try:
-        provider = OmhMemoryProvider(omh_home)
-        provider.initialize("", hermes_home=_home("HERMES_HOME", "~/.hermes"))
-        payload = dict(provider.consolidation_due())
+        payload = dict(read_latest_consolidation(omh_home) or {})
         payload["state"] = read_dreaming_state(omh_home)
+        payload["evaluated"] = False
         return payload, "bundle_memory"
     except Exception as exc:
         return _unavailable(_safe_error_type(type(exc).__name__)), "bundle_memory_error"

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -729,6 +729,62 @@ class MemoryToolActionTests(unittest.TestCase):
         with patch.dict(os.environ, {"OMH_HOME": str(root / ".omh"), "HERMES_HOME": str(root / ".hermes")}):
             return json.loads(omh_memory_handler(args))
 
+    def test_consolidation_status_preserves_pending_state_and_the_next_brief(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            home = root / ".omh"
+            _write_hermes_memory(root / ".hermes", "x" * 2100)
+            write_dreaming_state(home, record_compaction(record_turn(empty_dreaming_state())))
+            state_path = home / "memory" / "dreaming.json"
+            before = state_path.read_bytes()
+            for _ in range(2):
+                payload = self._call(root, action="consolidation")
+                self.assertEqual(state_path.read_bytes(), before)
+                self.assertFalse(payload["evaluated"])
+                self.assertNotIn("due", payload)
+                self.assertEqual(payload["state"], read_dreaming_state(home))
+                self.assertFalse((home / "memory" / "consolidation.json").exists())
+                self.assertFalse((home / "memory" / "consolidation.jsonl").exists())
+            brief = OmhMemoryProvider(home, hermes_home=root / ".hermes").consolidation_due()
+            self.assertTrue(brief["due"])
+            self.assertEqual(brief["trigger"], "manual")
+            self.assertIn("context_compaction_observed", brief["reasons"])
+            self.assertTrue(any(reason.startswith("headroom_below_floor") for reason in brief["reasons"]))
+
+    def test_consolidation_status_returns_the_due_brief_without_rewriting_it(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            home = root / ".omh"
+            _write_hermes_memory(root / ".hermes", "x" * 2100)
+            provider = OmhMemoryProvider(home, hermes_home=root / ".hermes")
+            brief = provider.consolidation_due()
+            self.assertTrue(brief["due"])
+            files = tuple((home / "memory").iterdir())
+            before = {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in files if path.is_file()}
+            for _ in range(2):
+                payload = self._call(root, action="consolidation")
+                self.assertTrue(payload["due"])
+                self.assertFalse(payload["evaluated"])
+                for key, value in brief.items():
+                    self.assertEqual(payload[key], value, key)
+                self.assertEqual({path: (path.read_bytes(), path.stat().st_mtime_ns) for path in before}, before)
+                self.assertEqual(tuple((home / "memory").iterdir()), files)
+            self.assertIn("<memory_consolidation", provider.render_pack())
+
+    def test_consolidation_status_never_enters_the_provider_lifecycle(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp).resolve()
+            _write_hermes_memory(root / ".hermes", "x" * 2100)
+            with patch.object(OmhMemoryProvider, "initialize") as initialize, patch.object(
+                OmhMemoryProvider, "consolidation_due", return_value={}
+            ) as evaluate:
+                payload = self._call(root, action="consolidation")
+            initialize.assert_not_called()
+            evaluate.assert_not_called()
+            self.assertFalse(payload["evaluated"])
+            self.assertNotIn("due", payload)
+            self.assertFalse((root / ".omh").exists())
+
     def test_the_default_action_is_still_the_bridge(self) -> None:
         with TemporaryDirectory() as tmp:
             payload = self._call(Path(tmp).resolve())


### PR DESCRIPTION
## Feature Report

### What Changed

The `omh_memory` consolidation action now reads the latest recorded reminder and scheduler counters without initializing a provider or evaluating triggers. It explicitly returns `evaluated: false`; `due` is absent if no readable brief exists.

### Why This Exists

The status handler initialized a provider session, consuming pending scheduler state, then evaluated a second time. A status request could therefore return `due: false` immediately after writing a due brief. This closes the plugin-side counterpart of the CLI status fix in #912.

### User / Operator Impact

Repeated status questions preserve pending counters, suppression state, and reminder bytes. Operators see the recorded brief rather than accidentally triggering or consuming another evaluation. A missing brief means no recorded result, not proof that no reminder is due.

### How It Works

Reuse the existing validated `read_latest_consolidation` and `read_dreaming_state` readers. Remove provider lifecycle calls from this read action. Explicit CLI `dream --evaluate`, provider lifecycle scheduling, reminder delivery from #1410, and normal tool-observation telemetry remain unchanged.

### Files And Contracts Touched

`src/plugin_bundle/omh/tools/memory_tool.py`: status behavior and schema description. `tests/test_memory_provider.py`: real handler regressions for pending state, repeated due-brief reads, and no provider lifecycle. `docs/MEMORY.md`: read-versus-evaluate contract.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — equivalent direct repository `.venv/bin/python` invocation, isolated HOME/HERMES_HOME/OMH_HOME.
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

RED: 3 expected failures among 10 handler tests before the fix. GREEN: 265 affected memory/provider/bridge/distribution/capability/policy tests; parent reran the 10 handler tests. Pinned Ruff and compileall passed. Isolated standalone bundle smoke passed: repeated reads preserve pending/due state and explicit evaluation and delivery remain functional. Independent review of `884e81b04c0be34ada931ef43617808f9dd88818` found no blocking or medium findings; 168 provider tests and six additional missing/corrupt/retired-state cases passed, including persisted bytes/mtimes. Exact-head full suite: 9,886 tests in 595.260s, OK with one skip; runner exit 0 on `884e81b04c0be34ada931ef43617808f9dd88818`. Combined local integration of all three independent fixes also passed 321 affected tests.

### Not Tested / Not Applicable

No live Hermes/TUI or model dispatch was exercised, to preserve the productive setup. Generated catalog, harness, release, installer, and workflow-learning surfaces are unchanged; their checks remain unchecked, not implicitly passed. Native Linux/Windows execution is left to hosted CI.

## Risk

Consumers that assumed every status query returned a fresh `due` boolean must instead inspect the recorded brief; the schema description documents that absent `due` means no readable brief. Readers retain existing validation and non-atomic snapshot behavior under concurrent scheduler writes. No memory admission or retirement logic changes.

## Compatibility / Rollout

No dependency, persistence schema, installer, or release-channel changes. This is a plugin status correction, not a new scheduler. No production installation, service restart, or live memory modification was performed. #1411 concerns the provider recall status signal and is separate from this tool handler.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

None required for the bounded correction. Await maintainer review and exact-head hosted CI; no merge is requested by this automation.
