### PR TITLE
fix(memory): bound complete record prefetch serialization

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -875,8 +875,13 @@ rendered off the hot path and re-ranked after each turn:
 3. `<memory_records>`: replay-eligible `project_memory_record/v2` records with
    a matching immutable review, ranked by token overlap with the conversation's
    latest message (tag hits weigh extra), then newest approval, cut to six
-   records and 2,400 characters. Each cut is named in place
-   (`render_budget_exhausted`, `record_limit_reached`), never dropped silently.
+   records and 2,400 characters including tags, separators, escaped text, and
+   omission reports. Cuts are aggregated by reason (`render_budget_exhausted`,
+   `record_limit_reached`) with exact counts instead of one line per record.
+   Space for both reports is reserved before selecting multiple records; record
+   ids and types are never shortened to fit, and the existing approval-date and
+   summary projections stay unchanged. A custom budget
+   too small for the omission report returns no section and a zero count.
 
 Records are read from the project store (`<repository>/.omh/memory/records/`
 for the nearest `.git` above the working directory) and then the user store

--- a/src/plugin_bundle/omh/memory_records.py
+++ b/src/plugin_bundle/omh/memory_records.py
@@ -72,24 +72,34 @@ def render_memory_records(
     budget_chars: int = DEFAULT_RECORD_RENDER_BUDGET_CHARS,
     limit: int = DEFAULT_RECORD_LIMIT,
 ) -> tuple[str, int]:
-    """The section text and how many records it carries in full."""
+    """Bound the entire section, including escaped text and aggregate omissions.
+
+    Return no section when even its omission report cannot fit. The count
+    includes only complete record elements, never omission metadata.
+    """
     if not records:
         return "", 0
-    lines, used, rendered = ["<memory_records>"], 0, 0
+    lines, rendered = ["<memory_records>"], 0
+    omissions = {"render_budget_exhausted": 0, "record_limit_reached": 0}
+    closing = "</memory_records>"
+    used = len(lines[0]) + 1 + len(closing)
+    # Reserve both possible reports once, not an unbounded line per record.
+    reserve = sum(len(f'\n  <omitted count="{len(records)}" reason="{reason}" />') for reason in omissions)
     for record in records:
-        record_id = _attribute(record.get("record_id", ""))
         if rendered >= max(limit, 0):
-            lines.append(f'  <omitted record_id="{record_id}" reason="record_limit_reached" />')
+            omissions["record_limit_reached"] += 1
             continue
         element = _render_record(record)
-        if used + len(element) > max(budget_chars, 0):
-            lines.append(f'  <omitted record_id="{record_id}" reason="render_budget_exhausted" />')
+        if used + 1 + len(element) + (reserve if len(records) > 1 else 0) > max(budget_chars, 0):
+            omissions["render_budget_exhausted"] += 1
             continue
-        used += len(element)
+        used += 1 + len(element)
         rendered += 1
         lines.append(element)
-    lines.append("</memory_records>")
-    return "\n".join(lines), rendered
+    lines.extend(f'  <omitted count="{count}" reason="{reason}" />' for reason, count in omissions.items() if count)
+    lines.append(closing)
+    text = "\n".join(lines)
+    return (text, rendered) if len(text) <= max(budget_chars, 0) else ("", 0)
 
 
 def _render_record(record: dict[str, Any]) -> str:

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -2225,6 +2225,22 @@ class RecordsReachPrefetchTests(unittest.TestCase):
             self.assertNotIn("nobody reviewed", pack)
             self.assertNotIn("reviewer said no", pack)
 
+    def test_many_admitted_records_stay_bounded_in_prefetch_and_status(self) -> None:
+        from xml.etree import ElementTree
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for index in range(40):
+                _approve_record(root, f"Approved local fact {index}.")
+            provider = self._provider(root)
+            text = provider.prefetch("")
+            self.assertLessEqual(len(text), 2400)
+            section = ElementTree.fromstring(text)
+            self.assertEqual(len(section.findall("record")), 6)
+            self.assertEqual(section.find("omitted").attrib,
+                             {"count": "34", "reason": "record_limit_reached"})
+            self.assertEqual(provider.recall_status().count, 6)
+
     def test_records_sit_after_blocks_in_one_pack(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -2265,10 +2281,11 @@ class RecordsReachPrefetchTests(unittest.TestCase):
             {"record_id": "mem_a", "record_type": "fact", "summary": "a < b & c", "approved_at": "2026-09-01T00:00:00Z"},
             {"record_id": "mem_b", "record_type": "fact", "summary": "x" * 400, "approved_at": "2026-09-02T00:00:00Z"},
         ]
-        text, count = render_memory_records(records, budget_chars=120)
+        text, count = render_memory_records(records, budget_chars=300)
         self.assertEqual(count, 1)
+        self.assertLessEqual(len(text), 300)
         self.assertIn("a &lt; b &amp; c", text)
-        self.assertIn('<omitted record_id="mem_b" reason="render_budget_exhausted" />', text)
+        self.assertIn('<omitted count="1" reason="render_budget_exhausted" />', text)
         text, count = render_memory_records(records, limit=1)
         self.assertEqual(count, 1)
         self.assertIn('reason="record_limit_reached"', text)

--- a/tests/test_memory_records.py
+++ b/tests/test_memory_records.py
@@ -1,0 +1,90 @@
+"""The provider's record budget covers the complete serialized section."""
+import subprocess
+import sys
+from pathlib import Path
+import unittest
+from xml.etree import ElementTree
+
+from omh.plugin_bundle.omh.memory_records import render_memory_records
+
+
+class MemoryRecordBudgetTests(unittest.TestCase):
+    def record(self, **values):
+        return {"record_id": "mem_a", "record_type": "fact", "summary": "a < b & c",
+                "approved_at": "2026-09-01T00:00:00Z", **values}
+
+    def check_section(self, records, budget=2400, limit=6):
+        text, count = render_memory_records(records, budget_chars=budget, limit=limit)
+        self.assertLessEqual(len(text), max(0, budget))
+        if not text:
+            self.assertEqual(count, 0)
+            return None
+        root = ElementTree.fromstring(text)
+        self.assertEqual(root.tag, "memory_records")
+        self.assertEqual(count, len(root.findall("record")))
+        self.assertLessEqual(count, max(0, limit))
+        omissions = root.findall("omitted")
+        self.assertLessEqual(len(omissions), 2)
+        self.assertEqual(count + sum(int(item.attrib["count"]) for item in omissions), len(records))
+        return root
+
+    def test_large_store_aggregates_every_omission(self):
+        root = self.check_section([self.record(record_id=f"mem_{i}") for i in range(10000)])
+        self.assertEqual(len(root.findall("record")), 6)
+        self.assertEqual(root.find("omitted").attrib,
+                         {"count": "9994", "reason": "record_limit_reached"})
+
+    def test_all_small_budgets_are_empty_or_complete_structures(self):
+        for budget in [-100, *range(350)]:
+            for limit in [-1, 0, 1, 6]:
+                with self.subTest(budget=budget, limit=limit):
+                    self.check_section([self.record()] * 10, budget, limit)
+        self.assertEqual(render_memory_records([], budget_chars=0), ("", 0))
+
+    def test_escaping_and_long_metadata_cannot_escape_the_budget(self):
+        records = [self.record(record_id='"<&' * 5000, record_type='"<&' * 5000),
+                   self.record(summary="&" * 500), self.record()]
+        root = self.check_section(records)
+        self.assertEqual(len(root.findall("record")), 1)
+        record = root.find("record")
+        self.assertEqual(record.attrib, {"id": "mem_a", "type": "fact", "approved": "2026-09-01"})
+        self.assertEqual(record.text, "a < b & c")
+        self.assertEqual(root.find("omitted").attrib,
+                         {"count": "2", "reason": "render_budget_exhausted"})
+
+    def test_one_record_fits_at_exact_serialized_boundary(self):
+        records = [self.record()]
+        text, count = render_memory_records(records)
+        self.assertEqual(count, 1)
+        self.assertEqual(render_memory_records(records, budget_chars=len(text)), (text, 1))
+        self.assertEqual(render_memory_records(records, budget_chars=len(text)-1)[1], 0)
+
+    def test_normal_records_preserve_order_and_escaped_provenance(self):
+        records = [self.record(record_id='mem_"<&', record_type='fact"<&'), self.record(record_id="mem_b")]
+        root = self.check_section(records)
+        self.assertEqual([r.attrib["id"] for r in root], ['mem_"<&', "mem_b"])
+        self.assertEqual(root[0].attrib["type"], 'fact"<&')
+        self.assertEqual(len(root.findall("omitted")), 0)
+
+    def test_standalone_bundle_uses_the_same_bounded_renderer(self):
+        bundle = Path(__file__).resolve().parents[1] / "src" / "plugin_bundle"
+        script = '''
+import sys
+sys.path.insert(0, sys.argv[1])
+from omh.memory_records import render_memory_records
+from xml.etree import ElementTree
+text, count = render_memory_records([{"record_id": "mem_a", "summary": "fact"}] * 10000)
+assert len(text) <= 2400
+assert count == len(ElementTree.fromstring(text).findall("record")) == 6
+assert "omh.workflows" not in sys.modules
+print("standalone bounded records: OK")
+'''
+        result = subprocess.run([sys.executable, "-I", "-S", "-c", script, str(bundle)],
+                                capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("standalone bounded records: OK", result.stdout)
+
+    def test_mixed_omission_reasons_are_counted_truthfully(self):
+        root = self.check_section([self.record(summary="&" * 500), self.record(), self.record()], limit=1)
+        self.assertEqual({e.attrib["reason"]: int(e.attrib["count"]) for e in root.findall("omitted")},
+                         {"render_budget_exhausted": 1, "record_limit_reached": 1})


### PR DESCRIPTION
## Feature Report

### What Changed

- Bound the complete `<memory_records>` prefetch section to its character budget, including wrapper tags, newlines, XML escaping, and omission reports.
- Replace unbounded per-record omission lines with at most two aggregate reports carrying exact counts. Return only the number of complete record elements actually rendered.

### Why This Exists

- The old renderer budgeted record bodies but not wrappers or omission metadata. A synthetic store of 10,000 records produced a 649,038-character section under the default 2,400-character budget. A single-record boundary test also showed that wrapper overhead could exceed the requested budget.
- Both regressions fail against the unchanged base implementation and pass against this patch.

### User / Operator Impact

- Large reviewed stores no longer expand the record prefetch section beyond its advertised budget. Recall status counts admitted records actually included, not omitted records.
- Review eligibility, ranking, executor selection, and existing summary/date projections remain unchanged. This is a language-independent serialization fix.

### How It Works

- Start accounting with the opening/closing tags and separators. For multiple records, reserve space for both possible omission reports using the input count as their maximum counter width.
- Select complete escaped records in existing order and aggregate cuts by `render_budget_exhausted` or `record_limit_reached`.
- Check final serialized length defensively. If the custom budget cannot hold the report, return an empty section and zero rendered records.

### Files And Contracts Touched

- `src/plugin_bundle/omh/memory_records.py`: bounded serialization and aggregate omission accounting.
- `tests/test_memory_records.py`: large stores, tiny/negative budgets and limits, escaping and long metadata, exact single-record boundaries, ordering/provenance, mixed omission reasons, and isolated standalone-bundle import coverage.
- `tests/test_memory_provider.py`: admitted-record integration coverage for prefetch length and recall status; update the omission format expectation.
- `docs/MEMORY.md`: complete-section budget, aggregate format, conservative reservation, and tiny-budget behavior.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

Check only commands that completed successfully. Leave non-applicable checks
unchecked and explain why under **Not Tested / Not Applicable**.

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — equivalent direct repository `.venv/bin/python` invocation, isolated HOME/HERMES_HOME/OMH_HOME.
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: isolated standalone-bundle renderer subprocess in `tests/test_memory_records.py`.
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: production installation and private runtime access were outside authorization.

### Observed Evidence

- Fresh recovery run: `PYTHONPATH=tests .venv/bin/python -m unittest tests/test_memory_records.py tests/test_memory_provider.py tests/test_hermes_memory_bridge.py tests/test_memory.py tests/test_plugin_distribution.py -v` completed with **340 tests, OK**, in 22.809 seconds. `HOME` and `HERMES_HOME` pointed to synthetic temporary homes.
- Prior baseline confirmation ran the final large-store and exact-boundary regression cases against the base renderer: **2 tests, 2 failures**. Final dedicated renderer run: **7 tests, OK**. Recovery reran these within the 340-test affected suite.
- Fresh pinned Ruff check passed using `uv run --offline --group lint`; full `src tests` compileall passed using `uv run --offline`.
- Fresh workflows, roles, capability-families, ulw-inventory, and ulw-site generated-output checks passed using the existing virtualenv. Earlier equivalent `uv run` checks also completed successfully.
- `git diff --check` passed. Public fixtures use synthetic data and repository-relative paths; local evidence logs are not part of the patch.
- Frozen-head full suite: **9,891 tests in 594.624s, OK (one skip), runner exit 0**, head `a383b7859279d6d69a153f667e089fd8c23afb15`.
- A local integration of this patch with independent consolidation-status and delegation-home fixes passed **321 affected tests**.

### Not Tested / Not Applicable

- No full-suite gap remains on the submitted head. The earlier run was superseded because discovery predated the final test additions; its lower test count was not accepted as exact-head evidence.
- Hosted CI and native Windows execution have not yet been observed. Independent review of `a383b7859279d6d69a153f667e089fd8c23afb15` found no blocking or medium findings; it additionally passed 15 focused cases, 221 broader provider/bridge/governance cases, and 2,000 deterministic randomized budget/count/structure checks.
- Harness validation, release checklist, CLI help, release/install smoke, and live Hermes/TUI smoke were not run in this bounded renderer recovery. No release, installation, CLI, or harness contracts changed; targeted distribution tests exercised temporary fixtures only.
- Workflow-learning smoke is not applicable: no learning contracts changed. No separate executor implementation changed, so Codex, Claude Code, and generic-executor checks are not claimed.

## Risk

- Aggregate omissions intentionally replace per-record omission IDs; consumers inspecting this section must use reason/count rather than expecting an omitted ID. Repository callers use the returned text and count, not per-record omission parsing.
- Reserving both possible reports is deliberately conservative and can leave spare space or include fewer records than an optimal packing algorithm. The section is bounded, not maximally packed.
- Very small custom budgets return no section rather than cutting a record or exceeding the budget. The budget is Python characters, not bytes or tokens, and covers only the record section, not the composed provider pack.
- Existing XML-illegal control handling is unchanged: arbitrary control characters can still make the XML-like section unparsable on both base and this patch. This change does not claim universal XML validity.

## Compatibility / Rollout

- Function signature, return type, default six-record/2,400-character limits, eligibility checks, ranking, and full record provenance remain unchanged. No runtime dependencies, migrations, private-memory writes, or Hermes core patches.
- Local full-suite verification and independent review completed on the submitted head. No production installation, release, merge, or stable/preview channel change was performed. This follows #1402 native record delivery; #724 addresses a separate recall-pack path.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Await maintainer review and exact-head hosted CI. No merge or production rollout is performed by this contribution workflow.
