### PR TITLE
fix(hud): keep native delegation activity in its conversation

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1020,30 +1020,34 @@ bound; nothing else in that directory is touched. `omh runtime todo set|clear|sh
 <id>` addresses one session's record from the command line.
 
 Records written without a session id — `omh runtime todo set` with no
-`--session`, or anything predating the field — are the home-wide
-`$OMH_HOME/runtime/todo.json`, scoped by write time instead: a plan written
-before the reading session started belongs to an earlier one and reads as
-stale. That fallback only applies where the host can answer it. With no
-`$HERMES_HOME/state.db`, an unreadable one, no live TUI session recorded in
-it, or a reading session it does not list as a TUI (a gateway session has no
-row to date the record against), the projection keeps the age-only behavior
-above and shows the plan, since hiding a legitimately current checklist on
-missing evidence is the worse failure. The widget's identity likewise needs
-a host that sets `HERMES_TUI_ACTIVE_SESSION_FILE` for the TUI process; on a
-Hermes that does not, the widget carries no identity and the panel answers
-for the most recently active live TUI session, as it did before.
+`--session`, or anything predating the field — remain home-wide
+`$OMH_HOME/runtime/todo.json` records. The operator/global reader and known
+live TUI sessions retain their existing age/write-time gates and explicit
+clear behavior. An unknown reading session cannot borrow an unstamped plan;
+it needs its own record.
 
-The widget's own identity has one known alias. After a resume or session
-switch the host's active-session file holds the durable session key; on a
-freshly created session it holds the gateway's transport id, which no record
-and no `state.db` row carries. The reader treats a widget reference that
-names no live TUI row and owns no record as that case and answers as an
-identity-less poll would — the most recently active live TUI session — so a
-fresh TUI still renders the plan it declares. Two TUIs both freshly created
-and not yet resumed therefore still share that answer — the pre-existing
-most-recently-active rule — until each is resumed or switched and the file
-carries its durable key; the plugin tools and the reminder are unaffected
-because Hermes dispatches them with the durable key.
+The widget also scopes native Hermes agent rows and their row-derived
+counts, token totals and costs to the reading conversation. Compression
+continuations remain one conversation; ordinary branches and delegated
+children are not continuation edges. Ownership filtering precedes the native
+reader's row limit, so unrelated busy sessions cannot hide this session's work.
+Calls to `omh hud` without a session reference retain the global operator view.
+
+The widget requires `HERMES_TUI_ACTIVE_SESSION_FILE` to name a durable session
+key. Older host paths write a transport id on a newly created session instead;
+missing, malformed or unmapped identities leave session-local agents and todos
+empty rather than selecting the most recently active chat. Resuming the exact
+conversation through a host path that writes its durable key restores that
+identity. OMH does not patch the host or guess an alias. Host-side durable-key
+work is tracked separately in NousResearch/hermes-agent#18476 and #66446.
+
+Ownership-less OMH executor/maestro rows and DAG projections remain available
+in the global view, but are not attributed to a session-local widget. Native
+manifest task labels and route-provenance records currently lack conversation
+ownership too: scoped rows omit those labels rather than pairing another
+conversation's task by timestamp. This is a display boundary only, not a stop,
+cancellation or change to delegation delivery. Other global diagnostic fields
+in the HUD payload are not redefined as session-scoped by this change.
 
 #### Status model: no-run, prepared-handoff, observed-run
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1020,34 +1020,41 @@ bound; nothing else in that directory is touched. `omh runtime todo set|clear|sh
 <id>` addresses one session's record from the command line.
 
 Records written without a session id — `omh runtime todo set` with no
-`--session`, or anything predating the field — remain home-wide
-`$OMH_HOME/runtime/todo.json` records. The operator/global reader and known
-live TUI sessions retain their existing age/write-time gates and explicit
-clear behavior. An unknown reading session cannot borrow an unstamped plan;
-it needs its own record.
+`--session`, or anything predating the field — are the home-wide
+`$OMH_HOME/runtime/todo.json`, scoped by write time instead: a plan written
+before the reading session started belongs to an earlier one and reads as
+stale. That fallback only applies where the host can answer it. With no
+`$HERMES_HOME/state.db`, an unreadable one, no live TUI session recorded in
+it, or a reading session it does not list as a TUI (a gateway session has no
+row to date the record against), the projection keeps the age-only behavior
+above and shows the plan, since hiding a legitimately current checklist on
+missing evidence is the worse failure. The widget's identity likewise needs
+a host that sets `HERMES_TUI_ACTIVE_SESSION_FILE` for the TUI process; on a
+Hermes that does not, the widget carries no identity and the panel answers
+for the most recently active live TUI session, as it did before.
 
-The widget also scopes native Hermes agent rows and their row-derived
-counts, token totals and costs to the reading conversation. Compression
-continuations remain one conversation; ordinary branches and delegated
-children are not continuation edges. Ownership filtering precedes the native
-reader's row limit, so unrelated busy sessions cannot hide this session's work.
-Calls to `omh hud` without a session reference retain the global operator view.
+The widget's own identity has one known alias. After a resume or session
+switch the host's active-session file holds the durable session key; on a
+freshly created session it holds the gateway's transport id, which no record
+and no `state.db` row carries. The reader treats a widget reference that
+names no live TUI row and owns no record as that case and answers as an
+identity-less poll would — the most recently active live TUI session — so a
+fresh TUI still renders the plan it declares. Two TUIs both freshly created
+and not yet resumed therefore still share that answer — the pre-existing
+most-recently-active rule — until each is resumed or switched and the file
+carries its durable key; the plugin tools and the reminder are unaffected
+because Hermes dispatches them with the durable key.
 
-The widget requires `HERMES_TUI_ACTIVE_SESSION_FILE` to name a durable session
-key. Older host paths write a transport id on a newly created session instead;
-missing, malformed or unmapped identities leave session-local agents and todos
-empty rather than selecting the most recently active chat. Resuming the exact
-conversation through a host path that writes its durable key restores that
-identity. OMH does not patch the host or guess an alias. Host-side durable-key
-work is tracked separately in NousResearch/hermes-agent#18476 and #66446.
-
-Ownership-less OMH executor/maestro rows and DAG projections remain available
-in the global view, but are not attributed to a session-local widget. Native
-manifest task labels and route-provenance records currently lack conversation
-ownership too: scoped rows omit those labels rather than pairing another
-conversation's task by timestamp. This is a display boundary only, not a stop,
-cancellation or change to delegation delivery. Other global diagnostic fields
-in the HUD payload are not redefined as session-scoped by this change.
+Native agent activity is a separate ownership policy from todos. A mapped
+valid durable identity selects native `state.db` children before row limits
+and totals, following only unambiguous compression continuations, never
+branches or delegated children. Missing, invalid or unmapped identities retain
+the previous global native fallback, including best-effort manifest context.
+Rows and aggregate scope explicitly say `global`; the widget renders those
+labels instead of attributing them to this chat. Mapped native rows omit
+unowned manifest/route labels. OMH executor, Maestro and DAG activity remains
+available in the widget, explicitly global; mixed totals say `this chat + global`.
+This changes display attribution only, not delegation or the todo policy above.
 
 #### Status model: no-run, prepared-handoff, observed-run
 

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -343,7 +343,8 @@ export default function register(sdk) {
     return { compact: Math.max(width.compact, cellWidth(routeCompact(text))), full: Math.max(width.full, cellWidth(text)) }
   }, { compact: 0, full: 0 })
 
-  const activityLayout = (row, columns, main, extraSeconds, tokensColumn, routeColumn) => {
+  const scopeLabel = row => row.scope === 'global' ? '[global] ' : row.scope === 'session' ? '[this chat] ' : ''
+  const activityLayout = (row, columns, main, extraSeconds, tokensColumn, routeColumn, scopeWidth) => {
     const state = safeText(row.state) || 'running'
     const stateText = columns < 100 ? ({ running: 'run', blocked: 'block', failed: 'fail' })[state] || state : state
     const taskId = truncateCells(safeText(row.task_id) || safeText(row.role) || 'agent', 8).padEnd(8)
@@ -403,7 +404,8 @@ export default function register(sdk) {
     // so they render as two pieces: same cells as before, split at the dot.
     const tailRest = ` · ${padCells(elapsedText(elapsed) || '0s', 7)}`
     const tailTokens = tokensColumn ? tokensPiece : ''
-    const prefix = `${taskId} `
+    const scope = padCells(scopeLabel(row), scopeWidth)
+    const prefix = `${scope}${taskId} `
     const separator = '  ·  '
     const budget = Math.max(24, columns - 4)
     // The route column exists per LIST, exactly like the tokens column: a
@@ -417,6 +419,9 @@ export default function register(sdk) {
     // title is what shrinks. `architect(claude-fable-5-1:xhigh)` still says
     // which lane, model and effort ran; `category:architect(claude-` does not.
     const routeRoom = budget - cellWidth(prefix) - tailWidth - cellWidth(separator) - 8 - 2
+    // If even the compact identity cannot fit beside a four-cell title,
+    // omit the whole shared route column rather than clipping the token tail.
+    if (routeColumn.compact > routeRoom + 4) routeColumn = { compact: 0, full: 0 }
     const routeShedPrefix = routeColumn.full > routeRoom
     const routeCap = routeShedPrefix ? routeColumn.compact : routeColumn.full
     const routeWidth = routeCap ? cellWidth(separator) + routeCap : 0
@@ -447,12 +452,13 @@ export default function register(sdk) {
       tailRest,
       tailState,
       tailTokens,
+      scope,
       taskId: main ? 'MAIN'.padEnd(8) : taskId,
     }
   }
 
-  function ActivityRow({ columns, extraSeconds, frame, main, row, routeColumn, t, tokensColumn }) {
-    const layout = activityLayout(row, columns, main, extraSeconds, tokensColumn, routeColumn)
+  function ActivityRow({ columns, extraSeconds, frame, main, row, routeColumn, scopeWidth, t, tokensColumn }) {
+    const layout = activityLayout(row, columns, main, extraSeconds, tokensColumn, routeColumn, scopeWidth)
     const blocked = row.state === 'blocked' || row.state === 'failed'
     const done = row.state === 'done'
     const marker = blocked ? '▲' : done ? '✓' : SPINNER_FRAMES[frame % SPINNER_FRAMES.length]
@@ -461,7 +467,7 @@ export default function register(sdk) {
       Text,
       { wrap: 'truncate-end' },
       h(Text, { color: blocked ? t.color.error : done ? t.color.ok : t.color.warn }, `${marker} `),
-      h(Text, { color: t.color.muted }, `${row.scope === 'global' ? '[global] ' : row.scope === 'session' ? '[this chat] ' : ''}${layout.taskId} `),
+      h(Text, { color: t.color.muted }, `${layout.scope}${layout.taskId} `),
       h(Text, { color: t.color.text }, layout.action),
       // Identity, then the measured block, then the rest. The route column
       // and the state/elapsed/tokens tail are fixed widths, so those figures
@@ -530,6 +536,8 @@ export default function register(sdk) {
     // it is what the fixed tail is anchored against, so every row reserves
     // it as soon as one row has a route to show.
     const routeColumn = routeColumnWidth([...mainRows, ...rows])
+    // Scope is a shared column too: mixed ownership must not shift the tail.
+    const scopeWidth = Math.max(0, ...[...mainRows, ...rows].map(row => cellWidth(scopeLabel(row))))
     return h(
       Box,
       { flexDirection: 'column', width: '100%' },
@@ -541,6 +549,7 @@ export default function register(sdk) {
           key: `main-${index}`,
           main: true,
           routeColumn,
+          scopeWidth,
           row,
           t,
           tokensColumn,
@@ -553,6 +562,7 @@ export default function register(sdk) {
           frame,
           key: `${safeText(row.task_id)}-${index}`,
           routeColumn,
+          scopeWidth,
           row,
           t,
           tokensColumn,

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -21,16 +21,16 @@ export default function register(sdk) {
     'import json,os,sys',
     "sys.path.insert(0, os.path.join(os.environ['HERMES_HOME'], 'plugins'))",
     'from omh.runtime_reader import read_omh_hud',
-    "print(json.dumps(read_omh_hud(os.environ.get('OMH_HOME'), os.environ.get('HERMES_HOME'), graph_preference=os.environ.get('OMH_SUBAGENT_GRAPH', 'auto'), tui_session_ref=os.environ.get('OMH_HUD_TUI_SESSION_REF', ''))))",
+    "print(json.dumps(read_omh_hud(os.environ.get('OMH_HOME'), os.environ.get('HERMES_HOME'), graph_preference=os.environ.get('OMH_SUBAGENT_GRAPH', 'auto'), tui_session_ref=os.environ.get('OMH_HUD_TUI_SESSION_REF', ''), session_scoped=True)))",
   ].join(';')
   // This TUI's own session id. The host writes it to the file named by
   // HERMES_TUI_ACTIVE_SESSION_FILE whenever it creates, resumes, or switches
   // a session, and this widget runs inside that same TUI process, so the
   // file is the one identity the poll can carry that no other TUI shares.
-  // The reader scopes the plan todo to it. After a resume or switch the
-  // file holds the durable session key; on a freshly created session it
-  // holds the gateway's transport id instead, which the reader detects
-  // (no live row, no record) and answers as an identity-less poll would.
+  // The reader scopes todos, agent rows and their derived metrics to it.
+  // A fresh host session may expose only an unmapped transport id: leave
+  // session-local activity empty until a durable id arrives, never use MRU.
+  // Even an identity-less widget poll explicitly requests session scope.
   // A missing, unreadable, or malformed value is passed as nothing rather
   // than as a mutated string that would select the wrong record.
   const ACTIVE_SESSION_FILE = process.env.HERMES_TUI_ACTIVE_SESSION_FILE || ''

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -27,10 +27,9 @@ export default function register(sdk) {
   // HERMES_TUI_ACTIVE_SESSION_FILE whenever it creates, resumes, or switches
   // a session, and this widget runs inside that same TUI process, so the
   // file is the one identity the poll can carry that no other TUI shares.
-  // The reader scopes todos, agent rows and their derived metrics to it.
-  // A fresh host session may expose only an unmapped transport id: leave
-  // session-local activity empty until a durable id arrives, never use MRU.
-  // Even an identity-less widget poll explicitly requests session scope.
+  // A mapped durable id scopes native rows and their derived metrics.
+  // Otherwise native activity remains visibly global, as does the OMH lane.
+  // The reader preserves the separate existing todo fallback policy.
   // A missing, unreadable, or malformed value is passed as nothing rather
   // than as a mutated string that would select the wrong record.
   const ACTIVE_SESSION_FILE = process.env.HERMES_TUI_ACTIVE_SESSION_FILE || ''
@@ -462,7 +461,7 @@ export default function register(sdk) {
       Text,
       { wrap: 'truncate-end' },
       h(Text, { color: blocked ? t.color.error : done ? t.color.ok : t.color.warn }, `${marker} `),
-      h(Text, { color: t.color.muted }, `${layout.taskId} `),
+      h(Text, { color: t.color.muted }, `${row.scope === 'global' ? '[global] ' : row.scope === 'session' ? '[this chat] ' : ''}${layout.taskId} `),
       h(Text, { color: t.color.text }, layout.action),
       // Identity, then the measured block, then the rest. The route column
       // and the state/elapsed/tokens tail are fixed widths, so those figures
@@ -605,7 +604,7 @@ export default function register(sdk) {
       h(
         Text,
         { color: t.color.label, key: 'graph-header', wrap: 'truncate-end' },
-        graphLine(`  DAG · ${frontier.length} ready · ${edgeCount} edges${hidden ? ` · +${hidden} more` : ''}`),
+        graphLine(`  ${graph.scope === 'global' ? '[global] ' : ''}DAG · ${frontier.length} ready · ${edgeCount} edges${hidden ? ` · +${hidden} more` : ''}`),
       ),
       ...nodes.map((node, index) => {
         const blockedBy = Array.isArray(node.blocked_by) ? node.blocked_by : []
@@ -691,7 +690,7 @@ export default function register(sdk) {
         h(Text, { bold: true, color: t.color.primary }, '⚚ [OMH]'),
         version ? h(Text, { color: t.color.muted }, ` v${version}`) : null,
         h(Text, { color: t.color.border }, SEPARATOR),
-        h(Text, { color: active ? t.color.warn : t.color.ok }, hudStateLabel(active, agents)),
+        h(Text, { color: active ? t.color.warn : t.color.ok }, `${agents.scope === 'global' ? '[global] ' : agents.scope === 'mixed' || maestro.rows?.some(row => row.scope === 'global') ? '[this chat + global] ' : agents.scope === 'session' ? '[this chat] ' : ''}${hudStateLabel(active, agents)}`),
         h(Text, { color: t.color.muted }, `${metrics.cost ? ` • ${metrics.cost}` : ''}${metrics.ctx ? ` • ${metrics.ctx}` : ''}`),
         // Exact in-flight liveness, paired from pre_tool_call/post_tool_call
         // by tool_call_id: the only honest answer to "is something actually

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -1289,7 +1289,7 @@ def _conversation_session_ids(connection: sqlite3.Connection, session_ref: str) 
 
 def _query_state_db(state_db: Path, *, now: float, session_ref: str | None = None) -> dict[str, Any]:
     """Read child sessions, usage tallies, and delegation states, read-only."""
-    result: dict[str, Any] = {"children": [], "delegation_states": {}, "parent_models": {}}
+    result: dict[str, Any] = {"children": [], "delegation_states": {}, "parent_models": {}, "scope": "global"}
     try:
         connection = sqlite3.connect(
             f"file:{state_db}?mode=ro", uri=True, timeout=0.25
@@ -1301,14 +1301,14 @@ def _query_state_db(state_db: Path, *, now: float, session_ref: str | None = Non
         parameters: list[Any] = [now - _SESSION_WINDOW_SECONDS]
         if session_ref is not None:
             owners = _conversation_session_ids(connection, session_ref)
-            if not owners:
-                return result
-            placeholders = ",".join("?" for _ in owners)
-            owner_filter = (
-                " AND CASE WHEN json_valid(model_config) THEN "
-                f"json_extract(model_config, '$._delegate_from') IN ({placeholders}) ELSE 0 END"
-            )
-            parameters.extend(sorted(owners))
+            if owners:
+                result["scope"] = "session"
+                placeholders = ",".join("?" for _ in owners)
+                owner_filter = (
+                    " AND CASE WHEN json_valid(model_config) THEN "
+                    f"json_extract(model_config, '$._delegate_from') IN ({placeholders}) ELSE 0 END"
+                )
+                parameters.extend(sorted(owners))
         cursor = connection.execute(
             "SELECT id, model, model_config, started_at FROM sessions "
             "WHERE model_config LIKE '%_delegate_from%' AND started_at >= ?"
@@ -1427,7 +1427,7 @@ def read_hermes_native_subagents(
     omh_home: str | Path | None = None,
     session_ref: str | None = None,
 ) -> dict[str, Any]:
-    """Project native children; None is global, an empty/unknown id is empty."""
+    """Project owned native children, or explicitly global fallback activity."""
     current = float(now) if now is not None else time.time()
     home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
     # Category labels honor the user's ~/.omh/routing/model-chains.json
@@ -1445,6 +1445,7 @@ def read_hermes_native_subagents(
         "completed": 0,
     }
     state = _query_state_db(home / "state.db", now=current, session_ref=session_ref)
+    payload["scope"] = state["scope"]
     children = state.get("children", [])
     if not children:
         return payload
@@ -1453,9 +1454,9 @@ def read_hermes_native_subagents(
     # overlap. Keep legacy global context, but never borrow it for a session.
     manifests = (
         _read_manifests(home / "cache" / "delegation" / "live", now=current)
-        if session_ref is None else []
+        if payload["scope"] == "global" else []
     )
-    if session_ref is not None:
+    if payload["scope"] == "session":
         # Prepared route records likewise carry no conversation ownership.
         route_provenance = []
 
@@ -1607,6 +1608,7 @@ def read_hermes_native_subagents(
         # lets the widget skip repaints so the dock stays drag-copyable.
         elapsed_until = last_activity if row_state != "running" else current
         row: dict[str, Any] = {
+            "scope": payload["scope"],
             "state": row_state,
             "task_id": session_tail,
             "role": "hermes-native",

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -1243,7 +1243,51 @@ def _parse_local_timestamp(value: str) -> float:
         return 0.0
 
 
-def _query_state_db(state_db: Path, *, now: float) -> dict[str, Any]:
+def _conversation_session_ids(connection: sqlite3.Connection, session_ref: str) -> set[str]:
+    """Exact durable identity plus unambiguous compression continuations only.
+
+    A transport id is not a durable id. Never substitute the latest session,
+    normalize an invalid reference, or follow ordinary branch/delegate parents.
+    Older schemas can still answer exact ownership without answering lineage.
+    """
+    if not isinstance(session_ref, str) or not (1 <= len(session_ref) <= 160) or any(
+        not (char.isalnum() or char in "_.:@-") for char in session_ref
+    ):
+        return set()
+    if not connection.execute("SELECT 1 FROM sessions WHERE id = ?", (session_ref,)).fetchone():
+        return set()
+    columns = {row[1] for row in connection.execute('PRAGMA table_info("sessions")')}
+    if not {"parent_session_id", "end_reason", "source"} <= columns:
+        return {session_ref}
+    rows = connection.execute(
+        """
+        WITH RECURSIVE candidates(parent, child) AS (
+            SELECT parent.id, child.id
+            FROM sessions parent JOIN sessions child ON child.parent_session_id = parent.id
+            WHERE parent.end_reason = 'compression'
+              AND COALESCE(child.source, '') != 'tool'
+              AND CASE WHEN child.model_config IS NULL OR child.model_config = '' THEN 1
+                  WHEN json_valid(child.model_config) THEN
+                      json_type(child.model_config) = 'object'
+                      AND json_extract(child.model_config, '$._delegate_from') IS NULL
+                      AND json_extract(child.model_config, '$._branched_from') IS NULL
+                  ELSE 0 END
+        ), edges(parent, child) AS (
+            SELECT parent, child FROM candidates c
+            WHERE (SELECT COUNT(*) FROM candidates WHERE parent = c.parent) = 1
+        ), conversation(id) AS (
+            SELECT ?
+            UNION SELECT edges.child FROM edges JOIN conversation ON edges.parent = conversation.id
+            UNION SELECT edges.parent FROM edges JOIN conversation ON edges.child = conversation.id
+        )
+        SELECT id FROM conversation
+        """,
+        (session_ref,),
+    )
+    return {row[0] for row in rows}
+
+
+def _query_state_db(state_db: Path, *, now: float, session_ref: str | None = None) -> dict[str, Any]:
     """Read child sessions, usage tallies, and delegation states, read-only."""
     result: dict[str, Any] = {"children": [], "delegation_states": {}, "parent_models": {}}
     try:
@@ -1253,14 +1297,23 @@ def _query_state_db(state_db: Path, *, now: float) -> dict[str, Any]:
     except sqlite3.Error:
         return result
     try:
+        owner_filter = ""
+        parameters: list[Any] = [now - _SESSION_WINDOW_SECONDS]
+        if session_ref is not None:
+            owners = _conversation_session_ids(connection, session_ref)
+            if not owners:
+                return result
+            placeholders = ",".join("?" for _ in owners)
+            owner_filter = (
+                " AND CASE WHEN json_valid(model_config) THEN "
+                f"json_extract(model_config, '$._delegate_from') IN ({placeholders}) ELSE 0 END"
+            )
+            parameters.extend(sorted(owners))
         cursor = connection.execute(
-            """
-            SELECT id, model, model_config, started_at
-            FROM sessions
-            WHERE model_config LIKE '%_delegate_from%' AND started_at >= ?
-            ORDER BY started_at DESC LIMIT 32
-            """,
-            (now - _SESSION_WINDOW_SECONDS,),
+            "SELECT id, model, model_config, started_at FROM sessions "
+            "WHERE model_config LIKE '%_delegate_from%' AND started_at >= ?"
+            + owner_filter + " ORDER BY started_at DESC LIMIT 32",
+            parameters,
         )
         rows = cursor.fetchall()
         parents_needed: set[str] = set()
@@ -1372,8 +1425,9 @@ def read_hermes_native_subagents(
     now: float | None = None,
     limit: int = _ROW_LIMIT,
     omh_home: str | Path | None = None,
+    session_ref: str | None = None,
 ) -> dict[str, Any]:
-    """Project live Hermes-native delegation children into HUD activity rows."""
+    """Project native children; None is global, an empty/unknown id is empty."""
     current = float(now) if now is not None else time.time()
     home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
     # Category labels honor the user's ~/.omh/routing/model-chains.json
@@ -1390,11 +1444,20 @@ def read_hermes_native_subagents(
         "blocked": 0,
         "completed": 0,
     }
-    state = _query_state_db(home / "state.db", now=current)
+    state = _query_state_db(home / "state.db", now=current, session_ref=session_ref)
     children = state.get("children", [])
     if not children:
         return payload
-    manifests = _read_manifests(home / "cache" / "delegation" / "live", now=current)
+    # The host manifests carry neither parent nor child session identity.
+    # Timestamp/task-order matching cannot establish ownership when dispatches
+    # overlap. Keep legacy global context, but never borrow it for a session.
+    manifests = (
+        _read_manifests(home / "cache" / "delegation" / "live", now=current)
+        if session_ref is None else []
+    )
+    if session_ref is not None:
+        # Prepared route records likewise carry no conversation ownership.
+        route_provenance = []
 
     # Children of one manifest, oldest-first, pair with the manifest's tasks
     # by dispatch order; the pairing is best-effort context (goal text and

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -763,22 +763,26 @@ def read_omh_hud(
     graph_preference: str = "auto",
     session_ref: str = "",
     tui_session_ref: str = "",
+    session_scoped: bool = False,
 ) -> dict[str, Any]:
     """The HUD payload for one reading session.
 
-    ``session_ref`` is the reader's own durable session id, as the host
-    dispatched it (plugin tool, hook, operator flag), and is trusted as-is.
-    ``tui_session_ref`` is what the host's active-session file reports for
-    the TUI a widget renders in; on a freshly created session that file
-    holds the gateway's transport id rather than the durable key, so a value
-    that neither names a live TUI row nor owns a record falls back to the
-    most recently active live TUI row instead of rendering nothing.
+    A supplied reference scopes activity to that durable conversation. Widgets
+    also set ``session_scoped`` so absent/malformed identities remain empty,
+    never global. Unmapped host transport ids cannot select a recent session.
+    Calls with no reference and no scoped flag retain the operator/global view.
     """
     safe_preset = preset if preset in HUD_PRESETS else "focused"
     home = _expand_path(omh_home) if omh_home else _default_omh_home()
     hermes = _expand_path(hermes_home) if hermes_home else _default_hermes_home()
     safe_limit = _safe_limit(limit, default=3)
-    status_payload = status if status is not None else _read_omh_hud_status(home, limit=safe_limit)
+    scoped = session_scoped or bool(session_ref or tui_session_ref)
+    reference = session_ref or tui_session_ref
+    # OMH run/binding projections identify executors and wrapper targets, not
+    # the originating Hermes conversation. Do not invent that relationship.
+    status_payload = {} if scoped else (
+        status if status is not None else _read_omh_hud_status(home, limit=safe_limit)
+    )
     state = _read_hud_json(home / "runtime" / "state.json", root=home)
     profile = _read_hud_json(home / "setup-profile.json", root=home)
     target_registry = _read_hud_json(home / "targets.json", root=home)
@@ -801,10 +805,7 @@ def read_omh_hud(
         "runtime": _hud_runtime_summary(status_payload, latest_run),
         "achievements": _achievements_summary(hermes),
         "tokens": _token_summary(token_metadata or {}),
-        # Scoped to the reading session: the widget names its own session
-        # (`session_ref`), and a caller that cannot falls back to the live
-        # TUI row, so one session's checklist never renders in another.
-        "todo": _todo_summary(home, hermes, session_ref, tui_session_ref),
+        "todo": _todo_summary(home, hermes, session_ref, tui_session_ref, session_scoped=scoped),
         # Concurrent tool-call batches observed by the pre_tool_call hook;
         # the [OMH] status line brands a fresh batch as a parallel shot.
         "parallel_shot": tool_calls["parallel_shot"],
@@ -845,7 +846,7 @@ def read_omh_hud(
     payload["subagents"]["rows"] = ordered[:ACTIVITY_ROW_LIMIT]
     # Hermes-native delegate_task children are work the HUD must show even
     # though they never touch the OMH runtime store; see hermes_delegation.
-    native = read_hermes_native_subagents(hermes, omh_home=home)
+    native = read_hermes_native_subagents(hermes, omh_home=home, session_ref=reference if scoped else None)
     if native["rows"]:
         merged = payload["subagents"]
         combined = _ordered_activity_rows(list(merged["rows"]) + list(native["rows"]))
@@ -861,10 +862,14 @@ def read_omh_hud(
         merged["completed"] = int(merged.get("completed", 0)) + int(native["completed"])
         if merged.get("status") == "idle":
             merged["status"] = "observed"
-    payload["graph"] = _hud_subagent_graph(
-        home,
-        native_rows_present=bool(native["rows"]),
-        preference=_hud_graph_preference(graph_preference),
+    payload["graph"] = (
+        project_subagent_graph(None, {"units": []}, preference=_hud_graph_preference(graph_preference),
+                               blockers=("session_ownership_unavailable",))
+        if scoped else _hud_subagent_graph(
+            home,
+            native_rows_present=bool(native["rows"]),
+            preference=_hud_graph_preference(graph_preference),
+        )
     )
     payload["active"] = bool(
         payload["runtime"]["workflow"] != "idle"
@@ -1766,6 +1771,8 @@ def _todo_summary(
     hermes: Path | None = None,
     session_ref: str = "",
     tui_session_ref: str = "",
+    *,
+    session_scoped: bool = False,
 ) -> dict[str, Any]:
     empty = {
         "status": "absent",
@@ -1778,19 +1785,21 @@ def _todo_summary(
         "display_phase": "",
         "more_count": 0,
     }
-    session_id, session = _reading_session(hermes, session_ref or tui_session_ref)
+    reference = session_ref or tui_session_ref
+    scoped = session_scoped or bool(reference)
+    if scoped and (
+        not isinstance(reference, str) or not (1 <= len(reference) <= MAX_TODO_SESSION_REF_CHARS)
+        or any(not (char.isalnum() or char in "_.:@-") for char in reference)
+    ):
+        return empty
+    session_id, session = _reading_session(hermes, reference)
     record, own_record = _own_todo_record(home, session_id)
-    if not own_record and not session_ref and tui_session_ref and session is None:
-        # The widget's reference places no TUI: it is neither a live row nor
-        # the owner of a record, which is what a fresh session's transport id
-        # looks like. Read as a widget with no identity would, rather than
-        # hiding the plan this TUI is most likely looking at.
-        session_id, session = _reading_session(hermes, "")
-        record, own_record = _own_todo_record(home, session_id)
     if not own_record:
         # No per-session record: the home-wide file answers, gated below by
         # the identity or write-time rule so another session's plan stays out.
         record = _read_hud_json(todo_path(home), root=home)
+    if scoped and session is None and not own_record and record.get("session_ref") != session_id:
+        return empty
     if record.get("schema_version") != TODO_SCHEMA_VERSION:
         return empty
     items: list[dict[str, Any]] = []

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -767,10 +767,9 @@ def read_omh_hud(
 ) -> dict[str, Any]:
     """The HUD payload for one reading session.
 
-    A supplied reference scopes activity to that durable conversation. Widgets
-    also set ``session_scoped`` so absent/malformed identities remain empty,
-    never global. Unmapped host transport ids cannot select a recent session.
-    Calls with no reference and no scoped flag retain the operator/global view.
+    A mapped durable reference scopes native activity to its conversation.
+    Missing/invalid/unmapped identities retain explicitly global native activity.
+    OMH activity remains global; the existing todo ownership policy is unchanged.
     """
     safe_preset = preset if preset in HUD_PRESETS else "focused"
     home = _expand_path(omh_home) if omh_home else _default_omh_home()
@@ -780,9 +779,7 @@ def read_omh_hud(
     reference = session_ref or tui_session_ref
     # OMH run/binding projections identify executors and wrapper targets, not
     # the originating Hermes conversation. Do not invent that relationship.
-    status_payload = {} if scoped else (
-        status if status is not None else _read_omh_hud_status(home, limit=safe_limit)
-    )
+    status_payload = status if status is not None else _read_omh_hud_status(home, limit=safe_limit)
     state = _read_hud_json(home / "runtime" / "state.json", root=home)
     profile = _read_hud_json(home / "setup-profile.json", root=home)
     target_registry = _read_hud_json(home / "targets.json", root=home)
@@ -805,7 +802,7 @@ def read_omh_hud(
         "runtime": _hud_runtime_summary(status_payload, latest_run),
         "achievements": _achievements_summary(hermes),
         "tokens": _token_summary(token_metadata or {}),
-        "todo": _todo_summary(home, hermes, session_ref, tui_session_ref, session_scoped=scoped),
+        "todo": _todo_summary(home, hermes, session_ref, tui_session_ref),
         # Concurrent tool-call batches observed by the pre_tool_call hook;
         # the [OMH] status line brands a fresh batch as a parallel shot.
         "parallel_shot": tool_calls["parallel_shot"],
@@ -835,6 +832,12 @@ def read_omh_hud(
         "status": "observed" if payload["subagents"]["maestro_rows"] else "idle",
         "rows": payload["subagents"].pop("maestro_rows"),
     }
+    payload["maestro"]["scope"] = "global"
+    payload["runtime"]["scope"] = "global"
+    payload["executor"]["scope"] = "global"
+    for row in payload["maestro"]["rows"] + payload["subagents"]["rows"]:
+        row["scope"] = "global"
+    omh_activity = bool(payload["subagents"]["active"] or payload["subagents"]["rows"])
     # Display-priority ordering applies to BOTH sources: the OMH-side rows
     # keep dispatch order at their producer and can put a blocked row ahead
     # of a running one, which the widget's running-exempt budget would then
@@ -847,6 +850,9 @@ def read_omh_hud(
     # Hermes-native delegate_task children are work the HUD must show even
     # though they never touch the OMH runtime store; see hermes_delegation.
     native = read_hermes_native_subagents(hermes, omh_home=home, session_ref=reference if scoped else None)
+    payload["subagents"]["scope"] = (
+        "mixed" if omh_activity and native["scope"] == "session" else native["scope"]
+    )
     if native["rows"]:
         merged = payload["subagents"]
         combined = _ordered_activity_rows(list(merged["rows"]) + list(native["rows"]))
@@ -862,15 +868,12 @@ def read_omh_hud(
         merged["completed"] = int(merged.get("completed", 0)) + int(native["completed"])
         if merged.get("status") == "idle":
             merged["status"] = "observed"
-    payload["graph"] = (
-        project_subagent_graph(None, {"units": []}, preference=_hud_graph_preference(graph_preference),
-                               blockers=("session_ownership_unavailable",))
-        if scoped else _hud_subagent_graph(
-            home,
-            native_rows_present=bool(native["rows"]),
-            preference=_hud_graph_preference(graph_preference),
-        )
+    payload["graph"] = _hud_subagent_graph(
+        home,
+        native_rows_present=bool(native["rows"]),
+        preference=_hud_graph_preference(graph_preference),
     )
+    payload["graph"]["scope"] = "global"
     payload["active"] = bool(
         payload["runtime"]["workflow"] != "idle"
         or payload["subagents"]["active"]
@@ -1771,8 +1774,6 @@ def _todo_summary(
     hermes: Path | None = None,
     session_ref: str = "",
     tui_session_ref: str = "",
-    *,
-    session_scoped: bool = False,
 ) -> dict[str, Any]:
     empty = {
         "status": "absent",
@@ -1785,21 +1786,19 @@ def _todo_summary(
         "display_phase": "",
         "more_count": 0,
     }
-    reference = session_ref or tui_session_ref
-    scoped = session_scoped or bool(reference)
-    if scoped and (
-        not isinstance(reference, str) or not (1 <= len(reference) <= MAX_TODO_SESSION_REF_CHARS)
-        or any(not (char.isalnum() or char in "_.:@-") for char in reference)
-    ):
-        return empty
-    session_id, session = _reading_session(hermes, reference)
+    session_id, session = _reading_session(hermes, session_ref or tui_session_ref)
     record, own_record = _own_todo_record(home, session_id)
+    if not own_record and not session_ref and tui_session_ref and session is None:
+        # The widget's reference places no TUI: it is neither a live row nor
+        # the owner of a record, which is what a fresh session's transport id
+        # looks like. Read as a widget with no identity would, rather than
+        # hiding the plan this TUI is most likely looking at.
+        session_id, session = _reading_session(hermes, "")
+        record, own_record = _own_todo_record(home, session_id)
     if not own_record:
         # No per-session record: the home-wide file answers, gated below by
         # the identity or write-time rule so another session's plan stays out.
         record = _read_hud_json(todo_path(home), root=home)
-    if scoped and session is None and not own_record and record.get("session_ref") != session_id:
-        return empty
     if record.get("schema_version") != TODO_SCHEMA_VERSION:
         return empty
     items: list[dict[str, Any]] = []

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -124,6 +124,7 @@ class HudCliTests(unittest.TestCase):
             payload["subagents"]["rows"],
             [
                 {
+                    "scope": "global",
                     "state": "running",
                     "task_id": "explore",
                     "role": "explore",
@@ -141,6 +142,7 @@ class HudCliTests(unittest.TestCase):
                     "tokens_per_second": 45,
                 },
                 {
+                    "scope": "global",
                     "state": "running",
                     "task_id": "libraria",
                     "role": "librarian",
@@ -158,6 +160,7 @@ class HudCliTests(unittest.TestCase):
                     "tokens_per_second": None,
                 },
                 {
+                    "scope": "global",
                     "state": "blocked",
                     "task_id": "architec",
                     "role": "architect",
@@ -176,7 +179,7 @@ class HudCliTests(unittest.TestCase):
                 },
             ],
         )
-        self.assertEqual(payload["maestro"], {"status": "idle", "rows": []})
+        self.assertEqual(payload["maestro"], {"status": "idle", "rows": [], "scope": "global"})
         widget_text = "\n".join(payload["display"]["widget_lines"])
         self.assertIn("[OMH]", widget_text)
         self.assertIn("ULW model routing review", widget_text)
@@ -1921,16 +1924,20 @@ class TodoSessionIsolationTests(_TodoSessionFixture, unittest.TestCase):
         # identity never falls through to the TUI's plan.
         self.assertEqual(self._todo_for("slack:C0123ABC:1725100000.000200")["status"], "absent")
 
-    def test_an_unmapped_widget_transport_id_never_borrows_the_latest_plan(self) -> None:
-        # An old host may write a transport ID instead of a durable key.
-        # There is no proof that the freshest DB session belongs to this TUI.
+    def test_a_fresh_tui_whose_widget_carries_the_transport_id_still_renders(self) -> None:
+        # On session.create the host's active-session file holds the gateway
+        # transport id (uuid4 hex[:8]), not the durable session key the tool
+        # stamps with; only resume/switch write the key. A widget reference
+        # that is neither a live TUI row nor the owner of a record is that
+        # case, and reads as an identity-less poll would -- the MRU live row
+        # -- so the plan the fresh TUI just declared is not hidden.
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
 
         self._build_state_db([(self.TUI_A, self._epoch(-60), self._epoch(-5))])
         self._declare(self.TUI_A, "Fresh")
 
         as_widget = read_omh_hud(self.omh_home, self.hermes_home, tui_session_ref="3f9a1c2b")["todo"]
-        self.assertEqual((as_widget["status"], as_widget["title"]), ("absent", ""))
+        self.assertEqual((as_widget["status"], as_widget["title"]), ("established", "Fresh"))
         # The durable key placed by the file after a resume reads directly.
         as_resumed = read_omh_hud(self.omh_home, self.hermes_home, tui_session_ref=self.TUI_A)["todo"]
         self.assertEqual(as_resumed["title"], "Fresh")
@@ -2034,8 +2041,9 @@ class TodoSessionIsolationTests(_TodoSessionFixture, unittest.TestCase):
         self._write_todo(self._record(source="cli", updated_at=self._stamp(-60)))
         self.assertEqual(self._todo_for(self.TUI_A)["status"], "established")
 
-        # A gateway with no owned record cannot borrow an unstamped global plan.
-        self.assertEqual(self._todo_for(self.SLACK)["status"], "absent")
+        # A reader state.db does not list (a gateway session) cannot date an
+        # unstamped record, so it keeps the age-only answer.
+        self.assertEqual(self._todo_for(self.SLACK)["status"], "established")
 
     def test_session_keys_are_filesystem_safe_and_distinct(self) -> None:
         from omh.plugin_bundle.omh.todo_store import todo_path, todo_session_key

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1921,20 +1921,16 @@ class TodoSessionIsolationTests(_TodoSessionFixture, unittest.TestCase):
         # identity never falls through to the TUI's plan.
         self.assertEqual(self._todo_for("slack:C0123ABC:1725100000.000200")["status"], "absent")
 
-    def test_a_fresh_tui_whose_widget_carries_the_transport_id_still_renders(self) -> None:
-        # On session.create the host's active-session file holds the gateway
-        # transport id (uuid4 hex[:8]), not the durable session key the tool
-        # stamps with; only resume/switch write the key. A widget reference
-        # that is neither a live TUI row nor the owner of a record is that
-        # case, and reads as an identity-less poll would -- the MRU live row
-        # -- so the plan the fresh TUI just declared is not hidden.
+    def test_an_unmapped_widget_transport_id_never_borrows_the_latest_plan(self) -> None:
+        # An old host may write a transport ID instead of a durable key.
+        # There is no proof that the freshest DB session belongs to this TUI.
         from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
 
         self._build_state_db([(self.TUI_A, self._epoch(-60), self._epoch(-5))])
         self._declare(self.TUI_A, "Fresh")
 
         as_widget = read_omh_hud(self.omh_home, self.hermes_home, tui_session_ref="3f9a1c2b")["todo"]
-        self.assertEqual((as_widget["status"], as_widget["title"]), ("established", "Fresh"))
+        self.assertEqual((as_widget["status"], as_widget["title"]), ("absent", ""))
         # The durable key placed by the file after a resume reads directly.
         as_resumed = read_omh_hud(self.omh_home, self.hermes_home, tui_session_ref=self.TUI_A)["todo"]
         self.assertEqual(as_resumed["title"], "Fresh")
@@ -2038,9 +2034,8 @@ class TodoSessionIsolationTests(_TodoSessionFixture, unittest.TestCase):
         self._write_todo(self._record(source="cli", updated_at=self._stamp(-60)))
         self.assertEqual(self._todo_for(self.TUI_A)["status"], "established")
 
-        # A reader state.db does not list (a gateway session) cannot date an
-        # unstamped record, so it keeps the age-only answer.
-        self.assertEqual(self._todo_for(self.SLACK)["status"], "established")
+        # A gateway with no owned record cannot borrow an unstamped global plan.
+        self.assertEqual(self._todo_for(self.SLACK)["status"], "absent")
 
     def test_session_keys_are_filesystem_safe_and_distinct(self) -> None:
         from omh.plugin_bundle.omh.todo_store import todo_path, todo_session_key

--- a/tests/test_hud_conversation_scope.py
+++ b/tests/test_hud_conversation_scope.py
@@ -179,7 +179,8 @@ for (const cols of [80, 100]) {
 console.log(JSON.stringify(results));
 """
         result = subprocess.run(['node', '--input-type=module', '-e', script], cwd=self.root,
-                                text=True, capture_output=True, check=True)
+                                encoding='utf-8', capture_output=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
         for case in json.loads(result.stdout):
             with self.subTest(columns=case['cols'], scopes=case['scopes']):
                 self.assertEqual(len(case['lines']), 2)
@@ -204,11 +205,12 @@ console.log(JSON.stringify(results));
         script = """
 import childProcess from 'node:child_process';
 import {syncBuiltinESMExports} from 'node:module';
+import {pathToFileURL} from 'node:url';
 childProcess.execFile = (exe, args, opts, cb) => {
   process.stdout.write(JSON.stringify({exe, args, env: opts.env})); cb(new Error('capture'));
 };
 syncBuiltinESMExports();
-const {default: register} = await import(process.argv[1]);
+const {default: register} = await import(pathToFileURL(process.argv[1]).href);
 register({Box: 'box', Text: 'text', h: () => null, defineWidgetApp: x => x,
           openWidget: () => null, updateWidget: () => null});
 """
@@ -217,9 +219,11 @@ register({Box: 'box', Text: 'text', h: () => null, defineWidgetApp: x => x,
             if reference is not None:
                 active.write_text(json.dumps({'session_id': reference}))
             env = {**os.environ, 'HERMES_TUI_ACTIVE_SESSION_FILE': str(active)}
-            capture = subprocess.run(['node', '--input-type=module', '-e', script, str(widget)], env=env, text=True, capture_output=True, check=True)
+            capture = subprocess.run(['node', '--input-type=module', '-e', script, str(widget)], env=env, encoding='utf-8', capture_output=True)
+            self.assertEqual(capture.returncode, 0, capture.stderr)
             invocation = json.loads(capture.stdout)
-            read = subprocess.run([invocation['exe'], *invocation['args']], env=invocation['env'], text=True, capture_output=True, check=True)
+            read = subprocess.run([invocation['exe'], *invocation['args']], env=invocation['env'], encoding='utf-8', capture_output=True)
+            self.assertEqual(read.returncode, 0, read.stderr)
             rows = json.loads(read.stdout)['subagents']['rows']
             expected = {PARENT_ID: ['own'], 'other-owner': ['other0']}.get(reference or '', ['own', 'other0'])
             self.assertEqual(sorted(row['task_id'] for row in rows), sorted(expected), reference)
@@ -238,7 +242,7 @@ const globalRow = {...payload.subagents.rows[0], scope:'global', task_id:'execut
 const omh = render({...payload, active:true, subagents:{...payload.subagents, scope:'global', rows:[globalRow]}, maestro:{scope:'global', rows:[globalRow]}, graph:{scope:'global', status:'active', nodes:[{node_id:'global-node', state:'running'}]}});
 console.log(JSON.stringify({native, omh}));
 """
-            render = subprocess.run(['node', '--input-type=module', '-e', render_script, read.stdout], cwd=self.root, env=env, text=True, capture_output=True)
+            render = subprocess.run(['node', '--input-type=module', '-e', render_script, read.stdout], cwd=self.root, env=env, encoding='utf-8', capture_output=True)
             self.assertEqual(render.returncode, 0, render.stderr)
             views = json.loads(render.stdout)
             self.assertIn('[global] MAIN', views['omh'])

--- a/tests/test_hud_conversation_scope.py
+++ b/tests/test_hud_conversation_scope.py
@@ -150,6 +150,46 @@ class HudConversationScopeTests(unittest.TestCase):
         self.assertEqual(result['todo']['title'], 'Private plan')
 
     @unittest.skipUnless(shutil.which('node'), 'Node is required for the widget boundary')
+    def test_scoped_activity_rows_fit_and_keep_token_columns(self):
+        widget = self.root / 'widget.mjs'
+        widget.write_bytes(widget_payload(Path(sys.executable)))
+        script = """
+import register from './widget.mjs';
+const apps = [], lines = [];
+const h = (tag, props, ...children) => {
+  if (typeof tag === 'function') {
+    const text = tag(props);
+    if (tag.name === 'ActivityRow') lines.push(text);
+    return text;
+  }
+  return children.flat(Infinity).filter(x => x != null).join('');
+};
+register({Box:'box', Text:'text', h, defineWidgetApp: app => {apps.push(app); return app}, openWidget:()=>{}, updateWidget:()=>{}});
+const app = apps.find(x => x.id === 'omh-status');
+const results = [];
+for (const cols of [80, 100]) {
+  for (const model of ['', 'gpt', 'claude-fable-5-1:xhigh'])
+  for (const scopes of [['global', 'global'], ['session', 'session'], ['global', 'session']]) {
+    lines.length = 0;
+    const rows = scopes.map((scope, i) => ({scope, model, task_id:`worker${i}`, action:'A long action title that must yield to the token column', state:'done', elapsed_seconds:12, tokens:12345}));
+    app.render({cols, rows:30, state:{payload:{privacy:'metadata_only', active:true, subagents:{rows}, maestro:{rows:[]}}}, t:{color:{}}});
+    results.push({cols, scopes, lines:[...lines]});
+  }
+}
+console.log(JSON.stringify(results));
+"""
+        result = subprocess.run(['node', '--input-type=module', '-e', script], cwd=self.root,
+                                text=True, capture_output=True, check=True)
+        for case in json.loads(result.stdout):
+            with self.subTest(columns=case['cols'], scopes=case['scopes']):
+                self.assertEqual(len(case['lines']), 2)
+                for scope, line in zip(case['scopes'], case['lines']):
+                    self.assertIn('[global]' if scope == 'global' else '[this chat]', line)
+                    self.assertIn('12.3k tokens', line[:case['cols']])
+                    self.assertLessEqual(len(line), case['cols'] - 2)
+                self.assertEqual(*[line.index('12.3k tokens') for line in case['lines']])
+
+    @unittest.skipUnless(shutil.which('node'), 'Node is required for the widget boundary')
     def test_widget_renders_owned_rows_and_explicit_global_fallback(self):
         # Run the shipped widget's actual Python reader, not a replica of its kwargs.
         self.build()

--- a/tests/test_hud_conversation_scope.py
+++ b/tests/test_hud_conversation_scope.py
@@ -56,6 +56,22 @@ class HudConversationScopeTests(unittest.TestCase):
         self.assertEqual([row['task_id'] for row in self.hud(session_ref='other-owner')['subagents']['rows']], ['other0'])
         self.assertEqual(len(self.hud()['subagents']['rows']), 2)
 
+    def test_mapped_empty_conversation_never_falls_back(self):
+        self.build()
+        with closing(sqlite3.connect(self.hermes / 'state.db')) as db, db:
+            db.execute('INSERT INTO sessions VALUES (?, ?, ?, ?)', ('empty-owner', '', '{}', NOW))
+        result = self.hud(session_ref='empty-owner')['subagents']
+        self.assertEqual(result['rows'], [])
+        self.assertEqual(result['active'], 0)
+        self.assertEqual(result['scope'], 'session')
+
+    def test_global_fallback_preserves_manifest_context(self):
+        self.build()
+        _write_manifest(self.hermes, 'global-dispatch', ['Global work'], started=NOW - 32, log_mtime=NOW)
+        result = self.hud(tui_session_ref='unmapped')['subagents']
+        self.assertTrue(any(row['action'] == 'Global work' for row in result['rows']))
+        self.assertTrue(all(row['scope'] == 'global' for row in result['rows']))
+
     def test_ownership_is_applied_before_the_native_row_cap(self):
         self.build(other_count=40)
         result = self.hud(session_ref=PARENT_ID)['subagents']
@@ -69,8 +85,9 @@ class HudConversationScopeTests(unittest.TestCase):
             for argument in ('session_ref', 'tui_session_ref'):
                 with self.subTest(argument=argument, reference=reference):
                     result = self.hud(**{argument: reference})
-                    self.assertEqual(result['subagents']['rows'], [])
-                    self.assertEqual(result['subagents']['active'], 0)
+                    self.assertEqual(len(result['subagents']['rows']), 2)
+                    self.assertEqual(result['subagents']['scope'], 'global')
+                    self.assertTrue(all(row['scope'] == 'global' for row in result['subagents']['rows']))
 
     def test_compression_edges_keep_own_history_but_not_delegates_or_branches(self):
         self.build()
@@ -102,20 +119,22 @@ class HudConversationScopeTests(unittest.TestCase):
         self.assertEqual(result['delegation_id'], '')
         self.assertLessEqual(result['elapsed_seconds'], 30)
 
-    def test_unowned_omh_and_maestro_rows_do_not_reenter_scoped_hud(self):
+    def test_unowned_omh_and_maestro_rows_remain_explicitly_global(self):
         self.build()
         status = {'active_executors': [
             {'target_id': 'foreign-run', 'executor_profile': profile, 'tokens_total': 9999, 'cost_usd': 55}
             for profile in ('hermes_local', 'maestro')],
             'latest_progress_events': [{'event_type': 'executor_completed'}], 'runs': []}
         result = self.hud(session_ref=PARENT_ID, status=status)
-        self.assertEqual(result['maestro']['rows'], [])
-        self.assertEqual([row['task_id'] for row in result['subagents']['rows']], ['own'])
-        self.assertEqual(result['subagents']['active'], 1)
-        self.assertEqual(result['subagents']['completed'], 0)
-        self.assertEqual(result['graph'].get('nodes', []), [])
+        self.assertTrue(result['maestro']['rows'])
+        self.assertEqual(result['maestro']['scope'], 'global')
+        self.assertEqual(result['maestro']['rows'][0]['scope'], 'global')
+        self.assertEqual(result['subagents']['active'], 3)
+        self.assertEqual(result['subagents']['scope'], 'mixed')
+        self.assertEqual(result['runtime']['scope'], 'global')
+        self.assertNotEqual(result['graph'].get('reason'), 'session_ownership_unavailable')
 
-    def test_widget_unknown_identity_does_not_borrow_the_latest_todo(self):
+    def test_widget_unknown_identity_preserves_existing_todo_fallback(self):
         self.build()
         from omh.plugin_bundle.omh.todo_store import TODO_SCHEMA_VERSION, todo_path
         record = {'schema_version': TODO_SCHEMA_VERSION, 'session_ref': PARENT_ID,
@@ -128,10 +147,10 @@ class HudConversationScopeTests(unittest.TestCase):
             {'id': PARENT_ID, 'activity': NOW, 'started_at': NOW - 50}]), mock.patch(
                 'omh.plugin_bundle.omh.runtime_reader._utc_epoch_now', return_value=NOW):
             result = self.hud(tui_session_ref='unmapped-transport')
-        self.assertEqual(result['todo']['items'], [])
+        self.assertEqual(result['todo']['title'], 'Private plan')
 
     @unittest.skipUnless(shutil.which('node'), 'Node is required for the widget boundary')
-    def test_widget_missing_malformed_and_unknown_ids_never_request_global_rows(self):
+    def test_widget_renders_owned_rows_and_explicit_global_fallback(self):
         # Run the shipped widget's actual Python reader, not a replica of its kwargs.
         self.build()
         with closing(sqlite3.connect(self.hermes / 'state.db')) as db, db:
@@ -162,5 +181,33 @@ register({Box: 'box', Text: 'text', h: () => null, defineWidgetApp: x => x,
             invocation = json.loads(capture.stdout)
             read = subprocess.run([invocation['exe'], *invocation['args']], env=invocation['env'], text=True, capture_output=True, check=True)
             rows = json.loads(read.stdout)['subagents']['rows']
-            expected = {PARENT_ID: ['own'], 'other-owner': ['other0']}.get(reference or '', [])
-            self.assertEqual([row['task_id'] for row in rows], expected, reference)
+            expected = {PARENT_ID: ['own'], 'other-owner': ['other0']}.get(reference or '', ['own', 'other0'])
+            self.assertEqual(sorted(row['task_id'] for row in rows), sorted(expected), reference)
+            scope = 'session' if reference in (PARENT_ID, 'other-owner') else 'global'
+            self.assertTrue(all(row['scope'] == scope for row in rows))
+            render_script = """
+import register from './widget.mjs';
+const payload = JSON.parse(process.argv[1]);
+const apps = [];
+const h = (tag, props, ...children) => typeof tag === 'function' ? tag(props) : children.flat(Infinity).filter(x => x != null).join('');
+register({Box:'box', Text:'text', h, defineWidgetApp: app => {apps.push(app); return app}, openWidget:()=>{}, updateWidget:()=>{}});
+const app = apps.find(x => x.id === 'omh-status');
+const render = value => app.render({cols:160, rows:30, state:{payload:value}, t:{color:{}}});
+const native = render(payload);
+const globalRow = {...payload.subagents.rows[0], scope:'global', task_id:'executor', dispatch_lane:'maestro', executor_profile:'codex'};
+const omh = render({...payload, active:true, subagents:{...payload.subagents, scope:'global', rows:[globalRow]}, maestro:{scope:'global', rows:[globalRow]}, graph:{scope:'global', status:'active', nodes:[{node_id:'global-node', state:'running'}]}});
+console.log(JSON.stringify({native, omh}));
+"""
+            render = subprocess.run(['node', '--input-type=module', '-e', render_script, read.stdout], cwd=self.root, env=env, text=True, capture_output=True)
+            self.assertEqual(render.returncode, 0, render.stderr)
+            views = json.loads(render.stdout)
+            self.assertIn('[global] MAIN', views['omh'])
+            self.assertIn('[global] executor', views['omh'])
+            self.assertIn('[global] DAG', views['omh'])
+            self.assertIn('global-node', views['omh'])
+            self.assertIn('codex/maestro', views['omh'])
+            rendered = views['native']
+            self.assertIn('[global]' if scope == 'global' else '[this chat]', rendered)
+            if scope == 'global':
+                self.assertNotIn('[this chat]', rendered)
+                self.assertGreaterEqual(rendered.count('[global]'), len(rows) + 1)

--- a/tests/test_hud_conversation_scope.py
+++ b/tests/test_hud_conversation_scope.py
@@ -1,0 +1,166 @@
+"""Session-local HUD rows must never borrow another conversation's work."""
+from contextlib import closing
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from omh.plugin_bundle.omh.runtime_reader import read_omh_hud
+from omh.tui_widget_pack import widget_payload
+from test_plugin_hermes_delegation import NOW, PARENT_ID, _build_state_db, _write_manifest
+
+
+class HudConversationScopeTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.hermes = self.root / '.hermes'
+        self.hermes.mkdir()
+        self.omh = self.root / '.omh'
+        self.env = mock.patch.dict(os.environ, {'HOME': str(self.root), 'OMH_HOME': str(self.omh), 'HERMES_HOME': str(self.hermes)})
+        self.env.start()
+        self.addCleanup(self.env.stop)
+        self.clock = mock.patch('omh.plugin_bundle.omh.hermes_delegation.time.time', return_value=NOW)
+        self.clock.start()
+        self.addCleanup(self.clock.stop)
+
+    def build(self, other_count=1):
+        children = [{'id': 'child_own', 'model': 'gpt-5.6-sol', 'started_at': NOW - 30,
+                     'usage': {'input_tokens': 100, 'output_tokens': 20, 'actual_cost_usd': 0.25, 'last_seen': NOW - 1}}]
+        children += [{'id': f'child_other{i}', 'model': 'other-model', 'started_at': NOW - 10,
+                      'usage': {'input_tokens': 9000, 'actual_cost_usd': 9, 'last_seen': NOW - 1}} for i in range(other_count)]
+        _build_state_db(self.hermes, children)
+        with closing(sqlite3.connect(self.hermes / 'state.db')) as db, db:
+            db.execute('INSERT INTO sessions VALUES (?, ?, ?, ?)', ('other-owner', 'other-model', '{}', NOW - 50))
+            for i in range(other_count):
+                db.execute('UPDATE sessions SET model_config=? WHERE id=?', (json.dumps({'_delegate_from': 'other-owner'}), f'child_other{i}'))
+
+    def hud(self, **kwargs):
+        return read_omh_hud(self.omh, self.hermes, **kwargs)
+
+    def test_rows_and_derived_totals_are_owned_by_the_reading_conversation(self):
+        self.build()
+        own = self.hud(session_ref=PARENT_ID)['subagents']
+        self.assertEqual([row['task_id'] for row in own['rows']], ['own'])
+        self.assertEqual((own['active'], own['running'], own['blocked'], own['completed']), (1, 1, 0, 0))
+        self.assertEqual(sum(row['tokens'] for row in own['rows']), 120)
+        self.assertEqual(sum(row['cost_usd'] for row in own['rows']), 0.25)
+        self.assertEqual([row['task_id'] for row in self.hud(session_ref='other-owner')['subagents']['rows']], ['other0'])
+        self.assertEqual(len(self.hud()['subagents']['rows']), 2)
+
+    def test_ownership_is_applied_before_the_native_row_cap(self):
+        self.build(other_count=40)
+        result = self.hud(session_ref=PARENT_ID)['subagents']
+        self.assertEqual([row['task_id'] for row in result['rows']], ['own'])
+        self.assertEqual(result['hidden_rows'], 0)
+        self.assertEqual(result['active'], 1)
+
+    def test_unknown_or_malformed_identity_does_not_select_an_owner(self):
+        self.build()
+        for reference in ('not-a-session', PARENT_ID + '\n', ' ' + PARENT_ID, PARENT_ID + '/' , 'x' * 161):
+            for argument in ('session_ref', 'tui_session_ref'):
+                with self.subTest(argument=argument, reference=reference):
+                    result = self.hud(**{argument: reference})
+                    self.assertEqual(result['subagents']['rows'], [])
+                    self.assertEqual(result['subagents']['active'], 0)
+
+    def test_compression_edges_keep_own_history_but_not_delegates_or_branches(self):
+        self.build()
+        with closing(sqlite3.connect(self.hermes / 'state.db')) as db, db:
+            for column in ('parent_session_id TEXT', 'end_reason TEXT', 'source TEXT'):
+                db.execute('ALTER TABLE sessions ADD COLUMN ' + column)
+            db.execute("UPDATE sessions SET end_reason='compression', source='tui' WHERE id=?", (PARENT_ID,))
+            for sid, parent, config, source in (
+                ('continued', PARENT_ID, {}, 'tui'),
+                ('branch', PARENT_ID, {'_branched_from': PARENT_ID}, 'tui'),
+                ('tool-child', PARENT_ID, {}, 'tool'),
+                ('real-child', PARENT_ID, {'_delegate_from': PARENT_ID}, 'tool'),
+            ):
+                db.execute('INSERT INTO sessions (id, model, model_config, started_at, parent_session_id, source) VALUES (?, ?, ?, ?, ?, ?)',
+                           (sid, 'gpt-5.6-sol', json.dumps(config), NOW - 400, parent, source))
+            for suffix, parent in (('continued', 'continued'), ('branch', 'branch'), ('nested', 'real-child'), ('tool', 'tool-child')):
+                db.execute('INSERT INTO sessions (id, model, model_config, started_at) VALUES (?, ?, ?, ?)',
+                           ('worker_' + suffix, 'gpt-5.6-sol', json.dumps({'_delegate_from': parent}), NOW - 3))
+        for reference in (PARENT_ID, 'continued'):
+            result = self.hud(session_ref=reference)
+            self.assertEqual({row['task_id'] for row in result['subagents']['rows']}, {'own', 'continue', 'real-chi'})
+        self.assertEqual({row['task_id'] for row in self.hud(session_ref='real-child')['subagents']['rows']}, {'nested'})
+
+    def test_unowned_manifests_cannot_supply_labels_or_liveness(self):
+        self.build()
+        _write_manifest(self.hermes, 'unrelated-dispatch', ['Unrelated work'], started=NOW - 32, log_mtime=NOW + 50)
+        result = next(row for row in self.hud(session_ref=PARENT_ID)['subagents']['rows'] if row['task_id'] == 'own')
+        self.assertEqual(result['action'], '')
+        self.assertEqual(result['delegation_id'], '')
+        self.assertLessEqual(result['elapsed_seconds'], 30)
+
+    def test_unowned_omh_and_maestro_rows_do_not_reenter_scoped_hud(self):
+        self.build()
+        status = {'active_executors': [
+            {'target_id': 'foreign-run', 'executor_profile': profile, 'tokens_total': 9999, 'cost_usd': 55}
+            for profile in ('hermes_local', 'maestro')],
+            'latest_progress_events': [{'event_type': 'executor_completed'}], 'runs': []}
+        result = self.hud(session_ref=PARENT_ID, status=status)
+        self.assertEqual(result['maestro']['rows'], [])
+        self.assertEqual([row['task_id'] for row in result['subagents']['rows']], ['own'])
+        self.assertEqual(result['subagents']['active'], 1)
+        self.assertEqual(result['subagents']['completed'], 0)
+        self.assertEqual(result['graph'].get('nodes', []), [])
+
+    def test_widget_unknown_identity_does_not_borrow_the_latest_todo(self):
+        self.build()
+        from omh.plugin_bundle.omh.todo_store import TODO_SCHEMA_VERSION, todo_path
+        record = {'schema_version': TODO_SCHEMA_VERSION, 'session_ref': PARENT_ID,
+                  'updated_at': '2027-01-15T08:00:00Z', 'title': 'Private plan',
+                  'items': [{'text': 'Own task', 'state': 'active'}]}
+        path = todo_path(self.omh, PARENT_ID)
+        path.parent.mkdir(parents=True)
+        path.write_text(json.dumps(record))
+        with mock.patch('omh.plugin_bundle.omh.runtime_reader.live_tui_session_rows', return_value=[
+            {'id': PARENT_ID, 'activity': NOW, 'started_at': NOW - 50}]), mock.patch(
+                'omh.plugin_bundle.omh.runtime_reader._utc_epoch_now', return_value=NOW):
+            result = self.hud(tui_session_ref='unmapped-transport')
+        self.assertEqual(result['todo']['items'], [])
+
+    @unittest.skipUnless(shutil.which('node'), 'Node is required for the widget boundary')
+    def test_widget_missing_malformed_and_unknown_ids_never_request_global_rows(self):
+        # Run the shipped widget's actual Python reader, not a replica of its kwargs.
+        self.build()
+        with closing(sqlite3.connect(self.hermes / 'state.db')) as db, db:
+            db.execute('UPDATE sessions SET started_at=? WHERE id LIKE ?', (time.time() - 2, 'child_%'))
+        plugins = self.hermes / 'plugins'
+        plugins.mkdir()
+        source = Path(__file__).resolve().parents[1] / 'src/plugin_bundle/omh'
+        shutil.copytree(source, plugins / 'omh')
+        widget = self.root / 'widget.mjs'
+        widget.write_bytes(widget_payload(Path(sys.executable)))
+        script = """
+import childProcess from 'node:child_process';
+import {syncBuiltinESMExports} from 'node:module';
+childProcess.execFile = (exe, args, opts, cb) => {
+  process.stdout.write(JSON.stringify({exe, args, env: opts.env})); cb(new Error('capture'));
+};
+syncBuiltinESMExports();
+const {default: register} = await import(process.argv[1]);
+register({Box: 'box', Text: 'text', h: () => null, defineWidgetApp: x => x,
+          openWidget: () => null, updateWidget: () => null});
+"""
+        active = self.root / 'active.json'
+        for reference in (None, 'bad/id', 'unmapped-transport', PARENT_ID, 'other-owner'):
+            if reference is not None:
+                active.write_text(json.dumps({'session_id': reference}))
+            env = {**os.environ, 'HERMES_TUI_ACTIVE_SESSION_FILE': str(active)}
+            capture = subprocess.run(['node', '--input-type=module', '-e', script, str(widget)], env=env, text=True, capture_output=True, check=True)
+            invocation = json.loads(capture.stdout)
+            read = subprocess.run([invocation['exe'], *invocation['args']], env=invocation['env'], text=True, capture_output=True, check=True)
+            rows = json.loads(read.stdout)['subagents']['rows']
+            expected = {PARENT_ID: ['own'], 'other-owner': ['other0']}.get(reference or '', [])
+            self.assertEqual([row['task_id'] for row in rows], expected, reference)

--- a/tests/test_tui_subagent_dag_mode.py
+++ b/tests/test_tui_subagent_dag_mode.py
@@ -223,7 +223,8 @@ class TuiSubagentDagModeTests(unittest.TestCase):
 
         native = {
             "status": "observed",
-            "rows": [{"task_id": "native-1", "state": "running"}],
+            "scope": "global",
+            "rows": [{"task_id": "native-1", "state": "running", "scope": "global"}],
             "active": 1,
             "running": 1,
             "blocked": 0,


### PR DESCRIPTION
## Feature Report

### What Changed

Attribute native delegation activity to the reading conversation when Hermes supplies a mapped durable identity. Preserve global activity when ownership is unavailable, and render its scope explicitly instead of implying it belongs to this chat. Preserve the existing OMH/Maestro, graph and todo behavior.

### Why This Exists

The native HUD reader queried recent children across the profile even when called for a specific conversation. Synthetic SQLite records reproduce a chat receiving another chat's agents. The original scope fix overreached by hiding the global OMH lane and changing todo fallback. The review corrections remove those regressions rather than requiring an unreleased host update.

### User / Operator Impact

- Mapped conversations see only their own native children, filtered before the database cap and derived totals.
- Unambiguous compression continuations are the same conversation; branches and delegated children are not.
- Missing, malformed and unmapped references retain native global fallback, including its existing manifest context. Rows and aggregates explicitly carry their scope.
- The actual widget labels local rows `[this chat]`, global rows `[global]`, and mixed aggregates `[this chat + global]`.
- OMH executor/Maestro activity, workflow state and graph remain available and globally attributed.
- Existing todo selection, write-time and clear behavior is unchanged. No agents are stopped and dispatch/delivery is unchanged.

### How It Works

The widget passes its own active-session-file reference. The native reader resolves the durable conversation and compression lineage and applies `_delegate_from` ownership before `LIMIT`. Successful resolution remains session-scoped even when the conversation has no children. Unavailable identity uses the prior global native read with `scope: global`; it does not substitute another durable conversation as the owner.

Timestamp-only manifests and route metadata do not prove ownership, so mapped native reads still omit that optional context. Global reads retain it. OMH status and graph projections remain intact and marked global. The original `_todo_summary` policy is restored, removing the extra duplicated validation introduced by the earlier version.

### Files And Contracts Touched

- `src/plugin_bundle/omh/hermes_delegation.py`: native ownership resolution/filtering, scope metadata and explicit global fallback.
- `src/plugin_bundle/omh/runtime_reader.py`: reference plumbing, retained global lanes and scope attribution.
- `src/omh/tui_widgets/omh-status.mjs`: real reader invocation and visible scope labels.
- `tests/test_tui_subagent_dag_mode.py`: align existing mock with native scope; no assertion removed.
- `tests/test_hud_conversation_scope.py`: ownership/lineage/caps, empty mapped conversations, fallback and actual shipped-widget regressions.
- `docs/INSTALLATION.md`: native scope and host compatibility. Original todo policy retained.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [ ] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke
- [x] Relevant dry-run or smoke command (synthetic host/reader and managed installer dry-run)
- [ ] Manual Hermes/TUI check

### Observed Evidence

- Final head `d11a5f1fb6e6db58436b7527273e9b4861488a6e`: 175 HUD/native/widget/DAG/todo regressions passed. Original native isolation, restored global lanes, explicit fallback and real JS scope labels remain covered.
- Final-head static shard plan: **9,887 unique tests accounted for: 9,885 passed, one failed, one Windows-only skip, zero errors**. Failure: `test_fanout_confinement.FanoutFilesystemConfinementTests.test_verification_command_is_confined_when_it_has_no_owner_receipt`. The identical failure was reproduced on unchanged base `4058bad5` with the same unaffected shard ordering (only the new HUD test IDs omitted). No sandbox policy or assertion was weakened. This is NOT an all-green full-suite claim.
- Before final width correction/fixture alignment, monolithic discovery ran 9,893 tests on `dcbbf137` and 10,142 on current main `5c8e024c` plus all four PRs (`ac3eebfd`). Both had only the outdated DAG mock missing scope (one error, one skip). The mock now matches the real native reader. These earlier runs are not final-head passes.
- Final current-main integration `4aa446af`: 351 focused HUD/DAG/native/widget/todo/memory tests passed together after the last corrections. The local portfolio also passed its combined focused checks. #1413–#1415 are unchanged.
- Independent full-diff review confirmed the functional obligations, then found a scope-label width regression. Post-fix review cleared it and exercised 48 renderer cases at 80/100 columns with mixed/no scope and heterogeneous routes; 11 previously fitting legacy cases were byte-identical. This is real widget JS with a test SDK, not live terminal UI.
- Ruff, compileall, Node syntax, docs workflows/roles/capability-families byte gates, harness validation and `git diff --check` passed.
- Synthetic integration uses actual Hermes create-session RPC results, SQLite and the OMH reader: mapped conversations remain distinct; unknown/missing references retain explicitly global rows. No LLM or private live session data involved.
- Hosted CI is separate; prior fork CI required maintainer authorization. Updated exact-head state is reported in the correction reply.


### Not Tested / Not Applicable

No manual live two-chat GUI acceptance or live release smoke is claimed; the reader and actual JS renderer are exercised with isolated synthetic state. No release, installer or workflow-learning contracts change. Their broad release/checklist/workflow-learning commands are not the acceptance surface for this PR. Local installer verification, where performed, is separate from production process activation.

## Risk

Mapped native rows still omit optional manifest/task labels lacking ownership. Global fallback intentionally remains visible and is not a privacy boundary between profiles: labels disclose attribution, not authorization. Activity recency is not proof that a process is alive. Other profile-global metadata is not transformed into per-conversation data by this patch.

## Compatibility / Rollout

Existing Hermes create-session paths may publish a transport ID. This now remains usable with explicitly global native activity, not an empty widget. Once a durable ID arrives, native rows become conversation-scoped. Existing host fixes NousResearch/hermes-agent#18476 and #66446 are complementary improvements, not prerequisites. NousResearch/hermes-agent#105065 independently fixes the built-in delegation counter, not this database-backed panel.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including the live release-smoke gap

## Follow-Up

Only a producer-supplied trustworthy owner may make OMH/manifest activity conversation-scoped; timestamps do not establish it. The approved fixes #1413, #1414 and #1415 remain separate and unchanged.
