### PR TITLE
docs: what a routing case costs on rebase, and what a phrase's tokens cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,9 @@ PR without the chat history.
   `ROUTING_INTERVENTION_CASES` and `ROUTING_PRECISION_CASES`.
 - Treat exact-count fixtures as contracts. Update affected assertions in the
   same change, but do not copy mutable counts or source line numbers into
-  prose.
+  prose. When a rebase conflicts on those counts, re-derive them from the
+  producer instead of choosing a side: upstream's baseline moved and your
+  delta still has to land on top of it.
 
 ## Generated Artifact Discipline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,13 @@ Rules:
   (`normalized_phrase`, `routing_tokens`, `contains_cue_phrase`) — do not add
   raw substring checks. Phrase triggers for multi-word intents; token triggers
   only when a single token is unambiguous.
+- A multi-word trigger is also scored as its separate tokens, so a phrase
+  built from everyday words widens the skill far beyond the phrase. Before
+  shipping one, route a sentence that contains the generic word in an
+  unrelated sense and compare the score against `origin/main`; if it moved a
+  clarify into a dispatch, hold the word back in
+  `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` (`src/routing/recommend.py`) so only the
+  complete phrase scores, and pin it with a negative case.
 - Guard patterns: routing and policy changes ship with negative cases
   alongside positive cases. Adding a trigger without a negative case is
   incomplete. Both corpora live in `src/quality/routing_precision.py` and each
@@ -130,8 +137,30 @@ Rules:
   `render.py` instead.
 - Adding a routing fixture or skill without updating exact-count assertions —
   breaks `tests/test_routing_precision.py`, `tests/test_cli.py`,
-  `tests/test_hermes_ux_quality.py`, and `tests/test_release_smoke.py`. Grep
-  those four for the old count when totals change.
+  `tests/test_hermes_ux_quality.py`, and `tests/test_release_smoke.py`, plus
+  the expected values in `src/maintenance/drift.py`. Grep those five for the
+  old count when totals change, and remember each test file pins the totals
+  twice: once in the payload assertions and once in the rendered CLI strings
+  (`NNN/NNN negative-control cases`, `Interventions: NNN/NNN ...`).
+- Resolving a routing-count rebase conflict by picking a side. Those same five
+  files conflict whenever main added a case while your branch was open, and
+  neither side is right: upstream's baseline moved and your delta still has to
+  land on top of it. Keep whichever side carries your reason comments, then
+  re-derive every number from the producer rather than doing the arithmetic by
+  hand:
+
+  ```py
+  from omh.quality.routing_precision import build_routing_precision_demo, routing_precision_errors
+  payload = build_routing_precision_demo(source="discord")
+  print(payload["summary"])          # case_count, intervention_case_count, total_case_count
+  print(routing_precision_errors(payload))  # must be []
+  ```
+
+  Confirm with `drift_report()["ok"]` before continuing the rebase. Two
+  adjacent budgets can fire in the same change and are raised the same way,
+  with the reason written at the entry: the per-skill Hangul freeze in
+  `tests/test_routing_language_policy.py` and
+  `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` in `src/maintenance/release.py`.
 - Grepping the repo and matching stale strings under `build/lib/` — it is a
   gitignored copy of old sources. Scope searches to `src/`, `tests/`, `docs/`,
   `skills/`.


### PR DESCRIPTION
## Feature Report

### What Changed

Documentation only. Two rules that #1412 learned the expensive way and that
were written nowhere a later agent would look:

- `CLAUDE.md` Common Pitfalls: the exact-count bullet now names five sites, not
  four, and says each test file pins the totals twice. A new bullet covers the
  rebase case with the re-derivation recipe and the two budgets that fire
  alongside it.
- `CLAUDE.md` Code Conventions: a new bullet on a multi-word trigger also being
  scored as its separate tokens, with the check and the existing remedy.
- `AGENTS.md`: one sentence on the same rebase rule, executor-neutral, beside
  the exact-count clause it belongs to.

### Why This Exists

Two concrete failures on #1412, neither of which the docs warned about.

**The count sites were undercounted, and the rebase case was missing.** The
pitfall listed four test files. `src/maintenance/drift.py` carries the same
totals as `expected=` values and is a fifth, and each test file pins them twice
over — once in the payload assertions, once in the rendered CLI strings
(`NNN/NNN negative-control cases`). A branch that greps only the four, and only
for the payload form, ships red.

Worse, nothing described what happens on rebase. Those five files conflict
whenever main lands a routing case while a branch is open, and the instinct —
pick a side — is wrong in both directions: upstream's baseline moved and the
branch's delta still has to land on top of it. On #1412 that meant hand
arithmetic across five files, twice, once per commit.

**A phrase trigger is also its tokens.** Code Conventions already says "phrase
triggers for multi-word intents; token triggers only when a single token is
unambiguous". It does not say that shipping a phrase *hands the skill its
tokens anyway*. `smooth scroll` gave `frontend` both `smooth` and `scroll`, and
"the mouse wheel scroll is broken in my terminal emulator" moved from clarify
(score 7) to a high-confidence `frontend` dispatch (score 10). That is a real
overroute, it survived the first review round, and it was only caught by
measuring the same sentence against `origin/main`.

### User / Operator Impact

Operator-facing in the sense that matters here: the next agent or maintainer
adding a routing case finds the five sites, the rebase recipe, and the token
check in the file they already read, instead of rediscovering each one from a
red CI run or a missed overroute.

### How It Works

Prose only. The rebase bullet carries a runnable snippet
(`build_routing_precision_demo` + `routing_precision_errors`, then
`drift_report()["ok"]`) so the reader re-derives the numbers rather than
computing them; the trigger bullet names
`_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS` in `src/routing/recommend.py`, which
already existed and is what #1412 used.

No counts are written into prose, per CLAUDE.md's own rule two bullets above
the text being edited — the new text names producers, metrics, and file paths
only.

### Files And Contracts Touched

- `CLAUDE.md` (Code Conventions, Common Pitfalls)
- `AGENTS.md` (Coding Style, exact-count clause)

No source, no test, no generated artifact.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [ ] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] Relevant workflow-learning review queue smoke:
- [x] Relevant dry-run or smoke command: every command the new text tells a
      reader to run, executed in this worktree
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite: `Ran 10152 tests`, `OK (skipped=1)`.
- Every documented command executed here, not asserted from memory:
  `build_routing_precision_demo(source="discord")["summary"]` returns the three
  keys the snippet prints, `routing_precision_errors(payload)` returns `[]`,
  `drift_report()["ok"]` is `True`, and
  `_WHOLE_PHRASE_ONLY_TRIGGER_TOKENS["frontend"]` holds the five tokens the
  bullet points at.
- `ruff` clean, `git diff --check` clean.

### Not Tested / Not Applicable

- Generated-artifact gates (`docs workflows/roles/capability-families/
  ulw-inventory/ulw-site --check`) not re-run: this change touches no catalog
  source and no projection, so none of them can move.
- `compileall`, `harness validate`, `release checklist`, and the install smoke
  not run: no Python, packaging, or install surface changes.
- No manual Hermes/TUI check: the diff changes no runtime behavior.

## Risk

Effectively none — two markdown files, no behavior. The one thing to keep true
is the five-site list; if it grows again, the sentence to update is in Common
Pitfalls rather than buried in a test comment, which is stated in the commit's
`Directive:` trailer.

## Compatibility / Rollout

Additive prose. Nothing reads these files programmatically.

## Release / Claims

- [x] Release-channel impact considered (`stable`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

- The token-leak check is manual (route the generic word, compare against
  `origin/main`). It could become a gate — a corpus of "generic word in an
  unrelated sense" sentences scored per skill — but that is a real quality
  surface with its own design, not a docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qdyhgjgcprxN8QcuPncC4
