### PR TITLE
fix(install): handle symlinked plugin dirs in _copy_plugin_bundle

### DIFF
--- a/src/install/plugin_pack.py
+++ b/src/install/plugin_pack.py
@@ -251,23 +251,44 @@ def _collect_resource_records(root: Any, rel: Path, records: list[PluginFileReco
             records.append(PluginFileRecord(str(item_rel), sha256_text(item.read_text(encoding="utf-8"))))
 
 
+def _discard_path(path: Path) -> None:
+    """Remove *path* whether it is a symlink, a regular file, or a directory.
+
+    ``shutil.rmtree`` alone cannot remove a symbolic link — it errors (or
+    silently no-ops with ``ignore_errors=True``) and leaves the link behind.
+    A stale ``.omh.previous`` symlink from an older layout then causes the
+    subsequent ``target.rename(backup)`` to fail with ``ENOTDIR``, because
+    Linux ``rename(2)`` refuses to rename a directory over an existing
+    non-directory.  Every temporary/backup path in ``_copy_plugin_bundle``
+    goes through this helper so the install is robust against leftovers from
+    any prior layout.
+    """
+    if path.is_symlink():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path, ignore_errors=True)
+    elif path.exists():
+        path.unlink()
+
+
 def _copy_plugin_bundle(target: Path, file_records: list[dict[str, str]]) -> None:
     root = resources.files("omh.plugin_bundle.omh")
     parent = target.parent
     tmp = parent / f".{target.name}.installing"
     backup = parent / f".{target.name}.previous"
     ensure_dir(parent)
-    shutil.rmtree(tmp, ignore_errors=True)
-    shutil.rmtree(backup, ignore_errors=True)
+    _discard_path(tmp)
+    _discard_path(backup)
     try:
         _copy_resource_tree(root, tmp)
         atomic_write_json(tmp / PLUGIN_MANAGED_MANIFEST, _new_plugin_manifest(target, file_records))
-        if target.exists():
+        if target.exists() or target.is_symlink():
+            _discard_path(backup)
             target.rename(backup)
         tmp.rename(target)
-        shutil.rmtree(backup, ignore_errors=True)
+        _discard_path(backup)
     except OSError:
-        shutil.rmtree(tmp, ignore_errors=True)
+        _discard_path(tmp)
         if backup.exists() and not target.exists():
             backup.rename(target)
         raise

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -5,6 +5,7 @@ import importlib.resources as resources
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -1312,6 +1313,35 @@ class UpdateRefreshesTheBundleTests(unittest.TestCase):
             status, _, stderr = run_cli(base + ["update"])
             self.assertEqual(status, 0, stderr)
             self.assertEqual(marker.read_text(encoding="utf-8"), "# edited outside OMH\n")
+
+    def test_update_replaces_a_symlinked_bundle_without_crashing(self) -> None:
+        # Older OMH installs sometimes left the plugin directory as a symlink
+        # to a shared location.  A subsequent `omh update` renamed that symlink
+        # to ``.omh.previous``, but ``shutil.rmtree`` cannot unlink a symlink,
+        # so the stale backup survived.  The next update then hit
+        # ``rename(dir, symlink)`` → ``ENOTDIR`` and crashed.  The fix
+        # (``_discard_path``) removes symlink/file/directory leftovers before
+        # every rename, so two consecutive updates on a symlinked bundle both
+        # succeed and leave a real directory.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            run_cli(base + ["setup"])
+            bundle = self._bundle_dir(root / ".hermes")
+            shared = root / ".hermes" / "shared-omh"
+            shutil.move(str(bundle), str(shared))
+            bundle.symlink_to(shared)
+
+            status, _, stderr = run_cli(base + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(bundle.is_symlink())
+            self.assertTrue((bundle / "memory_provider.py").is_file())
+
+            # Second update proves the stale-symlink path is gone — no ENOTDIR.
+            status, _, stderr = run_cli(base + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue((bundle / "memory_provider.py").is_file())
+            self.assertFalse((bundle.parent / ".omh.previous").is_symlink())
 
 
 class UpdateCarriesRegistrationTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

### What Changed

- Added `_discard_path()` helper in `src/install/plugin_pack.py` that removes symlinks, regular files, and directories uniformly (unlink for symlinks/files, rmtree for dirs).
- Replaced all four `shutil.rmtree(..., ignore_errors=True)` calls in `_copy_plugin_bundle` with `_discard_path()`.
- Added `target.is_symlink()` to the target-exists check so a symlinked plugin directory is properly backed up and replaced with a real directory.
- Added regression test `test_update_replaces_a_symlinked_bundle_without_crashing` in `tests/test_plugin_distribution.py`.

### Why This Exists

`omh update` crashed with `NotADirectoryError: [Errno 20]` when a bot-profile plugin directory was a symlink — a leftover from an older OMH layout where profiles symlinked `plugins/omh` to a shared location.

The crash sequence was:
1. `target.rename(backup)` renamed the symlink to `.omh.previous` (this works — rename on a symlink just moves it).
2. `shutil.rmtree(backup, ignore_errors=True)` silently failed to remove the symlink (rmtree cannot unlink symlinks; it descends into the target and fails, then swallows the error).
3. The stale `.omh.previous` symlink survived across updates.
4. On the next update, `target.rename(backup)` tried to rename a real directory over the existing symlink. Linux `rename(2)` refuses `rename(dir, symlink)` with `ENOTDIR`, crashing the entire `omh update` for every bot profile.

This affected any multi-profile setup where the `law` (or other bot) profile's plugin dir was originally a symlink, which is the case on this machine.

### User / Operator Impact

- `omh update` no longer crashes on profiles with symlinked plugin directories.
- `omh update` is now idempotent across consecutive runs even when a stale `.omh.previous` symlink exists from a prior layout.
- Operators no longer need to manually remove stale symlinks before running `omh update`.

### How It Works

`_discard_path(path)` checks the filesystem entry type:
- **Symlink** → `path.unlink()` (removes the link itself, not the target)
- **Directory** → `shutil.rmtree(path, ignore_errors=True)`
- **Regular file** → `path.unlink()`

Every temporary and backup path in `_copy_plugin_bundle` (`tmp`, `backup`, and the post-rename cleanup) now goes through `_discard_path`, so no stale leftover — regardless of type — can block a subsequent rename. The `target.exists()` guard also gains `target.is_symlink()` so a symlinked plugin dir enters the backup path instead of being skipped.

### Files And Contracts Touched

- `src/install/plugin_pack.py` — new `_discard_path()` helper + updated `_copy_plugin_bundle()`
- `tests/test_plugin_distribution.py` — new test + `import shutil`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [ ] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (plugin distribution suite: 52/52 pass)
- [ ] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [ ] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [x] Manual Hermes/TUI check, or explicit reason it was not run: `omh update` and `omh doctor` run clean on a machine with a real stale `.omh.previous` symlink on the `law` profile.

### Observed Evidence

- Targeted tests: `PYTHONPATH=tests uv run python -m unittest tests.test_plugin_distribution -v` → 52/52 pass, including the new `test_update_replaces_a_symlinked_bundle_without_crashing`.
- Manual: `omh update` on the affected machine (law profile had a stale `.omh.previous` symlink → `/home/senor/.hermes/plugins/omh`). Before fix: `NotADirectoryError [Errno 20]`. After fix: exit 0, "Bot profiles: law (refreshed)".
- Manual: `omh doctor` → "Hermes targets: ok (2/2)".

### Not Tested / Not Applicable

- Full test suite (`unittest discover -s tests`): the CLI test module timed out (180s) due to subprocess-heavy tests unrelated to this change. The targeted plugin distribution suite (52 tests) fully exercises the changed code paths.
- `ruff check`: not run (ruff not available in this environment).
- `compileall`, `docs --check`, `harness validate`, `release` smoke: not run — this change touches only the plugin install path, not docs, skills catalog, generated artifacts, or release tooling.
- Windows: `rename(2)` semantics differ, but the symlink code path is POSIX-specific.

## Risk

Low. The change is scoped to `_copy_plugin_bundle` internals. The atomic-rename contract is preserved — the backup is still created via rename, and the rollback path still restores it on error. The only behavioral change is that symlinks/files in the tmp/backup paths are now correctly removed instead of silently surviving.

## Compatibility / Rollout

No compatibility concerns. Older layouts that used symlinks will now be transparently replaced with real directories on the next `omh update` — which is the intended behavior. No config or schema changes.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — this is a bugfix for `preview` channel; no release-channel change.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed — plugin install smoke is local only; Hermes runtime load not claimed.
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence — N/A (no handoffs in this PR).
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data.
- [x] Known manual Hermes checks are listed — `omh update` and `omh doctor` run manually; `omh release hermes-smoke --live` gap noted.

## Follow-Up

- Consider adding a Windows-specific path in `_discard_path` if OMH ever supports Windows plugin dirs (currently POSIX-only for symlinks).