### PR TITLE
feat(memory): one offline command proves project-memory recall still selects correctly

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1024,6 +1024,74 @@ this surface is `prepared_not_observed` until that happens. The reverse move
 — promoting an approved OMH record up into L1 — remains the memory bridge's
 `promotable` surface (`omh memory status`).
 
+## Retrieval Regression Suite
+
+Record validity and retrieval quality are different questions. `omh memory
+evaluate` answers the first: admission, lifecycle, replay, and store
+compaction against a generated corpus. A change to relevance ranking, pins,
+age decay, attention tiers, the scope or perspective lens, budget cuts, or
+stale-record handling can leave every one of those verdicts green and still
+hand the executor the wrong context. `omh memory recall-suite` answers the
+second.
+
+```sh
+omh memory recall-suite --revision "$(git rev-parse HEAD)"
+```
+
+The command runs a retained fixture corpus through
+`build_project_memory_recall_pack` — the same builder handoff preparation
+uses — and exits non-zero when the pack it gets back disagrees with the
+corpus. It copies no ranking, eligibility, or budget logic: every verdict is a
+comparison of retained record ids and production reason codes against what the
+builder returned. Add `--output` to keep the JSON report.
+
+Each fixture declares its own records, pins, delivery counters, query, scope
+and perspective lens, record and character budgets, and the expected
+disposition of every record: included in this order, excluded for this named
+reason, or absent because a lens filtered it before the pack could name it.
+The corpus covers exact and partial relevance, no-match behavior, same-topic
+disagreement, correction and supersession, expiry, stale review and the
+`--include-stale` inspection path, scope and perspective isolation, pin and
+attention interactions, age ties, both archive directions, and record and
+character budget truncation.
+
+The clock is part of the fixture. Every timestamp is absolute and the corpus
+declares its own `now`, so a case that turns on expiry, review deadlines, or
+age tiers reads the same on any host on any day, and no fixture goes red
+because a day passed. Records are written straight into a per-case temporary
+store rather than captured and approved, because approval stamps the real
+clock and mints a random record id.
+
+The report separates what broke. Ordering failures, missing expected hits, and
+unexpected inclusions are counted apart from budget violations, so a pack that
+returns the right records but overruns its budget is never reported as a
+relevance miss. A record that a lens, a deadline, or a tier was supposed to
+keep out carries a contamination class, and an unexpected inclusion increments
+that class's own counter — `foreign_scope_contamination`,
+`foreign_perspective_contamination`, `stale_contamination`,
+`expired_contamination`, `archived_contamination` — so a leak is reported
+under its own name. Every finding names the fixture, the record id, the
+expected disposition, the observed disposition, and the production reason code
+when the pack carried one.
+
+Two reports are comparable only when their identities match. The report binds
+itself to the fixture digest, the evaluator version, the corpus version, a
+digest of the effective retrieval configuration
+(`effective_recall_configuration` reads the live ranking constants, so
+retuning a weight moves the digest), the fixture clock, and the target
+revision passed to `--revision`. `compare_retrieval_reports` refuses a
+comparison whose identities differ and names the mismatched fields, rather
+than attributing a corpus edit or a weight change to a retrieval regression.
+
+Reports carry `schema_version: omh_memory_retrieval_evaluation/v1`. This is a
+sibling of `omh_memory_evaluation/v1`, not a widening of it: existing
+evaluation reports parse exactly as before, and a reader dispatches on
+`schema_version`. Neither runner makes a model call, a provider call, a
+network request, or a credential read, and neither writes outside its own
+temporary store. A model-judge or external memory-provider result may enter
+only through a separate observed-evidence contract; this suite never produces
+one.
+
 ## Prepared Context Boundary
 
 A prepared recall or handoff pack is OMH-local context, not proof that an

--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -60,7 +60,7 @@ from ..memory import (
     build_rejected_decision_recall,
 )
 from ..system.local_store import read_json_object_result
-from ..workflows.memory_evaluation import run_memory_evaluation
+from ..workflows.memory_evaluation import run_memory_evaluation, run_memory_retrieval_evaluation
 from ..workflows.memory_lifecycle import (
     apply_memory_correction,
     apply_memory_prune,
@@ -599,6 +599,25 @@ def cmd_memory_evaluate(args: argparse.Namespace) -> int:
         raise OmhError(str(exc)) from exc
     _print_json(payload)
     return 0
+
+
+def cmd_memory_recall_suite(args: argparse.Namespace) -> int:
+    """One offline command that decides whether recall still selects correctly.
+
+    The exit status is the gate: a retrieval regression makes this command
+    fail, so it can stand in CI ahead of a ranking, pin, decay, tier, lens,
+    budget, or staleness change without anyone having to read the report first.
+    """
+    try:
+        payload = run_memory_retrieval_evaluation(target_revision=str(args.revision or ""))
+        if args.output:
+            output = Path(args.output).expanduser()
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
+    except (OSError, ValueError) as exc:
+        raise OmhError(str(exc)) from exc
+    _print_json(payload)
+    return 0 if bool(payload.get("passed")) else 1
 
 
 def cmd_memory_blocks(args: argparse.Namespace) -> int:

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -320,6 +320,14 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     evaluate.add_argument("--output", default=None, help="Write the exact JSON evidence object to this path.")
     evaluate.set_defaults(func=memory.cmd_memory_evaluate)
 
+    recall_suite = memory_sub.add_parser(
+        "recall-suite",
+        help="Run the retained retrieval-quality corpus through the production recall-pack builder; exits non-zero on a regression.",
+    )
+    recall_suite.add_argument("--revision", default="", help="Target revision this report is bound to; two reports compare only when it matches.")
+    recall_suite.add_argument("--output", default=None, help="Write the exact JSON regression report to this path.")
+    recall_suite.set_defaults(func=memory.cmd_memory_recall_suite)
+
     blocks = memory_sub.add_parser("blocks", help="List OMH memory blocks by label, without their values.")
     blocks.add_argument("--tier", choices=("system", "reference"), default=None, help="Limit the listing to one tier.")
     blocks.set_defaults(func=memory.cmd_memory_blocks)

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -1221,6 +1221,34 @@ def reject_project_memory_candidate(
     }
 
 
+def effective_recall_configuration() -> dict[str, object]:
+    """Every constant the recall ladder ranks, decays, and cuts with.
+
+    A retrieval regression report is only comparable against another report
+    built under the same retrieval configuration, so the configuration has to
+    be readable rather than inferred from the sorted output. Reading the live
+    constants here -- not a copy of their values -- is the point: retuning a
+    weight changes this projection, which changes the report's configuration
+    digest, which is what makes two reports refuse to be compared.
+    """
+    return {
+        "recall_pack_schema_version": PROJECT_MEMORY_RECALL_PACK_SCHEMA_VERSION,
+        "rrf_k": _RECALL_RRF_K,
+        "rrf_weights": dict(sorted(_RECALL_RRF_WEIGHTS.items())),
+        "temporal_recency_weight": 2.0,
+        "age_tier_bounds_days": list(_AGE_TIER_BOUNDS_DAYS),
+        "age_tier_weights": list(_AGE_TIER_WEIGHTS),
+        "attention_rank": dict(sorted(_MEMORY_ATTENTION_RANK.items())),
+        "admission_veracity_weight_pct": dict(sorted(_ADMISSION_VERACITY_WEIGHT_PCT.items())),
+        "admission_veracity_default_pct": _ADMISSION_VERACITY_DEFAULT_PCT,
+        "pins_limit": _MEMORY_PINS_LIMIT,
+        "inspectable_stale_reasons": sorted(_INSPECTABLE_STALE_REASONS),
+        "expires_soon_days": _EXPIRES_SOON_DAYS,
+        "review_due_soon_days": _REVIEW_DUE_SOON_DAYS,
+        "cadence_defaults": dict(sorted(_MEMORY_CADENCE_DEFAULTS.items())),
+    }
+
+
 def build_project_memory_recall_pack(
     paths: OmhPaths,
     query: str = "",

--- a/src/workflows/memory_evaluation.py
+++ b/src/workflows/memory_evaluation.py
@@ -1,10 +1,27 @@
-"""Deterministic, host-normalized evidence for OMH-owned memory fixtures."""
+"""Deterministic, host-normalized evidence for OMH-owned memory fixtures.
+
+Two report families live here, each with its own schema version:
+
+- ``omh_memory_evaluation/v1`` (``run_memory_evaluation``) evaluates record
+  admission, lifecycle, replay, and store compaction against a generated
+  corpus. Unchanged; reports written by earlier builds stay readable.
+- ``omh_memory_retrieval_evaluation/v1``
+  (``run_memory_retrieval_evaluation``) runs a retained fixture corpus through
+  the production recall-pack builder and reports what it selected, ordered,
+  excluded, and explained.
+
+The retrieval report is a new schema rather than a widening of the first, so
+no existing consumer has to migrate: a reader dispatches on
+``schema_version``, and a v1 evaluation report parses exactly as it always
+did. Neither runner makes a model call, a provider call, a network request,
+or a credential read, and neither writes outside its own temporary store.
+"""
 
 from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 import math
 import os
 import platform
@@ -18,9 +35,37 @@ from pathlib import Path
 from ..paths import OmhPaths
 from ..plugin_bundle.omh.memory_governance import canonical_payload_digest, evaluate_memory_replay, stable_artifact_identity
 from ..version import __version__
+from .memory import (
+    MEMORY_PINS_SCHEMA_VERSION,
+    MEMORY_RECALL_USAGE_SCHEMA_VERSION,
+    build_project_memory_recall_pack,
+    effective_recall_configuration,
+)
+from .memory_retrieval_fixtures import (
+    CONTAMINATION_CLASSES,
+    FIXTURE_CLOCK,
+    FIXTURE_CLOCK_ISO,
+    FIXTURE_CORPUS_VERSION,
+    RETRIEVAL_CASES,
+    fixture_digest,
+    materialize_fixture_record,
+)
 from .memory_store import prune_expired_memory_evidence
 
 EVALUATION_SCHEMA_VERSION = "omh_memory_evaluation/v1"
+RETRIEVAL_EVALUATION_SCHEMA_VERSION = "omh_memory_retrieval_evaluation/v1"
+RETRIEVAL_EVALUATOR_VERSION = "omh-memory-retrieval-evaluator/v1"
+# Two retrieval reports are comparable only when every one of these agrees.
+# A difference in any of them means the two runs answered different questions.
+RETRIEVAL_IDENTITY_FIELDS = (
+    "schema_version",
+    "evaluator_version",
+    "corpus_version",
+    "fixture_digest",
+    "retrieval_config_digest",
+    "clock",
+    "target_revision",
+)
 CORPUS_GENERATOR_VERSION = "omh-memory-evaluation-generator/v1"
 FROZEN_TIME = datetime(2031, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
 PROFILE_SPECS: dict[str, dict[str, int]] = {
@@ -71,6 +116,337 @@ def run_memory_evaluation(profile: str, *, repetitions: int = 3, seed: int | Non
         "vps_artifact": {"recorded": False, "claim": "No VPS result is claimed; a VPS result exists only when an actual VPS artifact is produced."},
         "claim_boundary": "OMH-owned synthetic fixture evidence only. Correctness gates are exact ids, reason-code counts, and persisted bytes, never elapsed time. No fixed latency threshold or cross-host absolute comparison is asserted; ratios are same-host only. LongMemEval, LoCoMo, MemoryAgentBench, and vendor scores are not pass criteria. No VPS result is claimed without an actual VPS artifact.",
     }
+
+
+def run_memory_retrieval_evaluation(
+    *,
+    target_revision: str = "",
+    cases: tuple[dict[str, object], ...] = RETRIEVAL_CASES,
+    pack_builder: Callable[..., dict[str, object]] = build_project_memory_recall_pack,
+) -> dict[str, object]:
+    """Run the retained retrieval corpus through the production recall builder.
+
+    Every case gets its own temporary store, is seeded with exactly the records,
+    pins, and delivery counters the fixture declares, and is queried at the
+    fixture's own clock. Nothing here re-implements ranking, eligibility, or
+    budget selection: the suite compares retained ids and reason codes against
+    what ``pack_builder`` returned, and that is the whole of its judgement.
+
+    ``pack_builder`` exists so the suite's own tests can seed a retrieval
+    regression -- a reordering, a leak, a budget overrun -- and prove the
+    report catches it. Production callers never pass it.
+    """
+    revision = str(target_revision or "")
+    case_results = [_run_retrieval_case(case, pack_builder) for case in cases]
+    configuration = effective_recall_configuration()
+    totals = _retrieval_totals(case_results)
+    return {
+        "schema_version": RETRIEVAL_EVALUATION_SCHEMA_VERSION,
+        "evaluator_version": RETRIEVAL_EVALUATOR_VERSION,
+        "corpus_version": FIXTURE_CORPUS_VERSION,
+        "fixture_digest": fixture_digest(cases),
+        "retrieval_configuration": configuration,
+        "retrieval_config_digest": _canonical_digest(configuration),
+        "clock": FIXTURE_CLOCK_ISO,
+        "target_revision": revision,
+        "command": {"name": "omh memory recall-suite", "version": __version__, "arguments": {"revision": revision}},
+        "case_count": len(case_results),
+        "cases": case_results,
+        "summary": totals,
+        "passed": bool(totals["failed_cases"] == 0),
+        "execution_boundary": (
+            "Offline OMH-local evaluation: no model call, provider call, network request, or credential "
+            "read, and no write outside each case's own temporary fixture store."
+        ),
+        "claim_boundary": (
+            "Retrieval agreement against a synthetic OMH-owned fixture corpus only. It is prepared "
+            "regression evidence, never execution, review, CI, merge, provider-quality, or Hermes "
+            "internal-memory evidence. A model-judge or external memory-provider result may only enter "
+            "through a separate observed-evidence contract and is never produced here."
+        ),
+    }
+
+
+def retrieval_report_identity(report: dict[str, object]) -> dict[str, object]:
+    """The fields two retrieval reports must share before they can be compared."""
+    return {field: report.get(field) for field in RETRIEVAL_IDENTITY_FIELDS}
+
+
+def compare_retrieval_reports(left: dict[str, object], right: dict[str, object]) -> dict[str, object]:
+    """Refuse a comparison whose two sides do not answer the same question.
+
+    A retrieval report is only meaningful against another report built from the
+    same fixtures, the same retrieval configuration, the same clock, and the
+    same target revision. Comparing across any of those silently attributes a
+    corpus edit or a weight change to a retrieval regression, so the mismatched
+    identity fields are named and no verdict is offered.
+    """
+    left_identity, right_identity = retrieval_report_identity(left), retrieval_report_identity(right)
+    mismatched = sorted(field for field in RETRIEVAL_IDENTITY_FIELDS if left_identity[field] != right_identity[field])
+    if mismatched:
+        return {
+            "schema_version": "omh_memory_retrieval_comparison/v1",
+            "comparable": False,
+            "mismatched_identity_fields": mismatched,
+            "left_identity": left_identity,
+            "right_identity": right_identity,
+            "reason": "retrieval reports are comparable only when every identity field matches",
+        }
+    previously_passing = {case_id for case_id, case in _case_by_id(left).items() if bool(case.get("passed", False))}
+    return {
+        "schema_version": "omh_memory_retrieval_comparison/v1",
+        "comparable": True,
+        "mismatched_identity_fields": [],
+        "left_identity": left_identity,
+        "right_identity": right_identity,
+        "identical_results": left.get("cases") == right.get("cases"),
+        "regressed_cases": sorted(
+            str(case.get("case_id", ""))
+            for case in _case_rows(right)
+            if not bool(case.get("passed", False)) and str(case.get("case_id", "")) in previously_passing
+        ),
+    }
+
+
+def _case_rows(report: dict[str, object]) -> list[dict[str, object]]:
+    rows = report.get("cases")
+    return [row for row in rows if isinstance(row, dict)] if isinstance(rows, list) else []
+
+
+def _case_by_id(report: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {str(row.get("case_id", "")): row for row in _case_rows(report)}
+
+
+def _run_retrieval_case(case: dict[str, object], pack_builder: Callable[..., dict[str, object]]) -> dict[str, object]:
+    lens = case["lens"] if isinstance(case.get("lens"), dict) else {}
+    budget = case["budget"] if isinstance(case.get("budget"), dict) else {}
+    flags = case["flags"] if isinstance(case.get("flags"), dict) else {}
+    with tempfile.TemporaryDirectory(prefix="omh-memory-retrieval-") as temporary:
+        paths = OmhPaths(Path(temporary) / "omh", Path(temporary) / "hermes")
+        _seed_retrieval_store(paths, case)
+        pack = pack_builder(
+            paths,
+            str(case["query"]),
+            scope_kind=lens.get("scope_kind"),
+            scope_ref=lens.get("scope_ref"),
+            observer=lens.get("observer"),
+            observed=lens.get("observed"),
+            limit=int(budget["limit"]),
+            max_chars=budget.get("max_chars"),
+            include_stale=bool(flags.get("include_stale", False)),
+            include_archived=bool(flags.get("include_archived", False)),
+            now=FIXTURE_CLOCK,
+        )
+    return _score_retrieval_case(case, pack)
+
+
+def _seed_retrieval_store(paths: OmhPaths, case: dict[str, object]) -> None:
+    """Write exactly the fixture's records, reviews, pins, and usage counters."""
+    specs = [spec for spec in case["records"] if isinstance(spec, dict)] if isinstance(case.get("records"), list) else []
+    for spec in specs:
+        record, review = materialize_fixture_record(spec)
+        _write(paths.memory_dir / "records" / f"{record['record_id']}.json", record)
+        _write(paths.memory_dir / "reviews" / f"{review['review_id']}.json", review)
+    pins = [str(value) for value in case["pins"]] if isinstance(case.get("pins"), list) else []
+    if pins:
+        _write(
+            paths.memory_dir / "pins.json",
+            {"schema_version": MEMORY_PINS_SCHEMA_VERSION, "updated_at": FIXTURE_CLOCK_ISO, "record_ids": sorted(pins)},
+        )
+    usage = case["usage"] if isinstance(case.get("usage"), dict) else {}
+    if usage:
+        _write(
+            paths.memory_dir / "usage.json",
+            {
+                "schema_version": MEMORY_RECALL_USAGE_SCHEMA_VERSION,
+                "records": {
+                    str(record_id): {"times_recalled": int(times), "last_recalled_at": FIXTURE_CLOCK_ISO}
+                    for record_id, times in sorted(usage.items())
+                },
+            },
+        )
+
+
+def _score_retrieval_case(case: dict[str, object], pack: dict[str, object]) -> dict[str, object]:
+    case_id = str(case["case_id"])
+    expected = case["expected"] if isinstance(case.get("expected"), dict) else {}
+    expected_order = [str(value) for value in expected.get("included_order", [])]
+    expected_excluded = {str(key): str(value) for key, value in dict(expected.get("excluded_reasons", {})).items()}
+    expected_absent = {str(value) for value in expected.get("absent", [])}
+    expected_siblings = {str(key): str(value) for key, value in dict(expected.get("sibling_hints", {})).items()}
+    expected_ineligible = {str(value) for value in expected.get("ineligible_included", [])}
+    contamination_class = {
+        str(spec["record_id"]): str(spec.get("contamination_class", ""))
+        for spec in case["records"]
+        if isinstance(spec, dict)
+    }
+
+    included = [item for item in pack.get("included_records", []) if isinstance(item, dict)]
+    excluded = [item for item in pack.get("excluded_records", []) if isinstance(item, dict)]
+    observed_order = [str(item.get("record_id", "")) for item in included]
+    observed_excluded = {str(item.get("record_id", "")): item for item in excluded}
+    observed_included = {str(item.get("record_id", "")): item for item in included}
+
+    def _disposition(record_id: str) -> str:
+        if record_id in expected_order:
+            return "included"
+        if record_id in expected_excluded:
+            return f"excluded:{expected_excluded[record_id]}"
+        if record_id in expected_absent:
+            return "absent"
+        return "unspecified"
+
+    def _finding(record_id: str, observed: str, reason_code: str) -> dict[str, object]:
+        return {
+            "case_id": case_id,
+            "record_id": record_id,
+            "expected_disposition": _disposition(record_id),
+            "observed_disposition": observed,
+            "reason_code": reason_code,
+            "contamination_class": contamination_class.get(record_id, ""),
+        }
+
+    unexpected_inclusions = [
+        _finding(record_id, "included", str(observed_included[record_id].get("eligibility_reason", "")))
+        for record_id in observed_order
+        if record_id not in expected_order
+    ]
+    missing_inclusions = [
+        _finding(
+            record_id,
+            "excluded" if record_id in observed_excluded else "absent",
+            str(observed_excluded.get(record_id, {}).get("reason", "")),
+        )
+        for record_id in expected_order
+        if record_id not in observed_order
+    ]
+    exclusion_reason_drift = [
+        _finding(
+            record_id,
+            f"excluded:{observed_excluded[record_id].get('reason', '')}" if record_id in observed_excluded else ("included" if record_id in observed_included else "absent"),
+            str(observed_excluded.get(record_id, {}).get("eligibility_reason", "")),
+        )
+        for record_id, reason in sorted(expected_excluded.items())
+        if str(observed_excluded.get(record_id, {}).get("reason", "")) != reason
+    ]
+    exclusion_reason_drift += [
+        _finding(record_id, f"excluded:{entry.get('reason', '')}", str(entry.get("eligibility_reason", "")))
+        for record_id, entry in sorted(observed_excluded.items())
+        if record_id not in expected_excluded and record_id not in expected_order
+    ]
+    contamination = {f"{name}_contamination": 0 for name in CONTAMINATION_CLASSES}
+    for finding in unexpected_inclusions:
+        name = str(finding["contamination_class"])
+        if name:
+            contamination[f"{name}_contamination"] += 1
+
+    sibling_hint_drift = [
+        _finding(record_id, str(observed_excluded.get(record_id, {}).get("sibling_included", "")), "sibling_included")
+        for record_id, sibling in sorted(expected_siblings.items())
+        if str(observed_excluded.get(record_id, {}).get("sibling_included", "")) != sibling
+    ]
+    ineligible_evidence_drift = [
+        _finding(record_id, "included", str(observed_included.get(record_id, {}).get("eligibility_reason", "")))
+        for record_id in sorted(expected_ineligible)
+        if bool(_replay_eligible(observed_included.get(record_id, {})))
+    ]
+    budget_violations = _retrieval_budget_violations(case_id, case, pack, included)
+
+    exact_order = observed_order == expected_order
+    failures = (
+        len(unexpected_inclusions)
+        + len(missing_inclusions)
+        + len(exclusion_reason_drift)
+        + len(sibling_hint_drift)
+        + len(ineligible_evidence_drift)
+        + len(budget_violations)
+        + (0 if exact_order else 1)
+    )
+    return {
+        "case_id": case_id,
+        "intent": str(case["intent"]),
+        "query": str(case["query"]),
+        "clock": str(case["clock"]),
+        "lens": case["lens"],
+        "budget": case["budget"],
+        "flags": case["flags"],
+        "expected_included_order": expected_order,
+        "observed_included_order": observed_order,
+        "exact_order": exact_order,
+        "expected_hit_count": len([record_id for record_id in expected_order if record_id in observed_order]),
+        "expected_included_count": len(expected_order),
+        "unexpected_inclusions": unexpected_inclusions,
+        "missing_inclusions": missing_inclusions,
+        "exclusion_reason_drift": exclusion_reason_drift,
+        "sibling_hint_drift": sibling_hint_drift,
+        "ineligible_evidence_drift": ineligible_evidence_drift,
+        "contamination": contamination,
+        "budget_violations": budget_violations,
+        "passed": failures == 0,
+    }
+
+
+def _replay_eligible(item: dict[str, object]) -> bool:
+    evaluation = item.get("replay_evaluation")
+    return bool(evaluation.get("eligible", False)) if isinstance(evaluation, dict) else False
+
+
+def _retrieval_budget_violations(
+    case_id: str,
+    case: dict[str, object],
+    pack: dict[str, object],
+    included: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Budget failures, reported apart from relevance and ordering failures.
+
+    A pack that returns the right records in the right order but overruns its
+    record or character budget has a budget bug, not a ranking bug, and the two
+    must never be reported as one number.
+    """
+    budget = case["budget"] if isinstance(case.get("budget"), dict) else {}
+    expected = case["expected"] if isinstance(case.get("expected"), dict) else {}
+    limit = int(budget["limit"])
+    max_chars = budget.get("max_chars")
+    violations: list[dict[str, object]] = []
+    if len(included) > limit:
+        violations.append({"case_id": case_id, "violation": "record_limit_exceeded", "limit": limit, "observed": len(included)})
+    if isinstance(max_chars, int) and not isinstance(max_chars, bool):
+        observed_chars = sum(len(str(item.get("summary", ""))) for item in included)
+        if observed_chars > max_chars:
+            violations.append({"case_id": case_id, "violation": "char_budget_exceeded", "limit": max_chars, "observed": observed_chars})
+    expected_truncated = bool(expected.get("truncated", False))
+    observed_truncated = bool(pack.get("truncated", False))
+    if observed_truncated != expected_truncated:
+        violations.append(
+            {"case_id": case_id, "violation": "truncation_flag_drift", "limit": expected_truncated, "observed": observed_truncated}
+        )
+    return violations
+
+
+def _retrieval_totals(cases: list[dict[str, object]]) -> dict[str, object]:
+    contamination = {f"{name}_contamination": 0 for name in CONTAMINATION_CLASSES}
+    for case in cases:
+        for key, value in dict(case["contamination"]).items():
+            contamination[str(key)] += int(value)
+    return {
+        "case_count": len(cases),
+        "passed_cases": sum(1 for case in cases if bool(case["passed"])),
+        "failed_cases": sum(1 for case in cases if not bool(case["passed"])),
+        "exact_order_cases": sum(1 for case in cases if bool(case["exact_order"])),
+        "expected_hit_count": sum(int(case["expected_hit_count"]) for case in cases),
+        "expected_included_count": sum(int(case["expected_included_count"]) for case in cases),
+        "unexpected_inclusion_count": sum(len(list(case["unexpected_inclusions"])) for case in cases),
+        "missing_inclusion_count": sum(len(list(case["missing_inclusions"])) for case in cases),
+        "exclusion_reason_drift_count": sum(len(list(case["exclusion_reason_drift"])) for case in cases),
+        "sibling_hint_drift_count": sum(len(list(case["sibling_hint_drift"])) for case in cases),
+        "ineligible_evidence_drift_count": sum(len(list(case["ineligible_evidence_drift"])) for case in cases),
+        "budget_violation_count": sum(len(list(case["budget_violations"])) for case in cases),
+        **contamination,
+    }
+
+
+def _canonical_digest(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
 def build_evaluation_corpus(profile: str, *, seed: int | None = None, frozen_at: datetime = FROZEN_TIME) -> dict[str, object]:

--- a/src/workflows/memory_retrieval_fixtures.py
+++ b/src/workflows/memory_retrieval_fixtures.py
@@ -1,0 +1,499 @@
+"""Retained retrieval fixtures for the project-memory recall regression suite.
+
+This module is data plus one materializer. It holds no ranking, eligibility, or
+budget logic: every expectation below is a recorded verdict about what the
+production recall-pack builder must return, never a second implementation of
+how it decides.
+
+Two properties make the corpus a regression gate rather than a snapshot:
+
+- The clock is part of the fixture. Every timestamp is absolute and the case
+  clock is ``FIXTURE_CLOCK``, so a case that depends on expiry, review
+  deadlines, or age tiers reads the same on any host on any day. No fixture
+  here reads the wall clock, directly or through a default argument.
+- Record order is the order written here, and the store reader sorts by file
+  name, so neither dict iteration nor filesystem order can reorder a pack.
+
+Each case declares the records, the pins, the delivery counters, the query,
+the scope and perspective lens, the budgets, and the expected disposition of
+every record: included in this order, excluded for this named reason, or
+absent because a lens filtered it before the pack could name it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+
+from ..plugin_bundle.omh.memory_governance import (
+    MEMORY_GOVERNANCE_POLICY_VERSION,
+    PROJECT_MEMORY_RECORD_SCHEMA_VERSION,
+    PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION,
+    canonical_payload_digest,
+    stable_artifact_identity,
+)
+
+FIXTURE_CORPUS_VERSION = "omh-memory-retrieval-fixtures/v1"
+# The corpus clock. Absolute, declared once, never derived from the host.
+FIXTURE_CLOCK = datetime(2031, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+FIXTURE_CLOCK_ISO = "2031-01-02T03:04:05Z"
+
+_RECORD_CLAIM_BOUNDARY = (
+    "Reviewed OMH project memory is prepared context only; it is not execution, "
+    "review, CI, merge, or Hermes internal-memory evidence."
+)
+_REVIEW_CLAIM_BOUNDARY = (
+    "Project memory review decisions are prepared governance only, never executor-use evidence."
+)
+# Contamination classes label a record that a lens, a deadline, or a tier is
+# supposed to keep out of the pack. A labelled record appearing in a pack that
+# did not expect it increments the counter named here, so a leak is reported
+# under its own name instead of as a generic relevance miss.
+CONTAMINATION_CLASSES = ("foreign_scope", "foreign_perspective", "stale", "expired", "archived")
+
+
+def _record(
+    record_id: str,
+    summary: str,
+    *,
+    approved_at: str,
+    tags: tuple[str, ...] = (),
+    record_type: str = "fact",
+    scope_kind: str = "project",
+    scope_ref: str = "default",
+    observer: str = "",
+    observed: str = "",
+    retention_class: str = "standard",
+    expires_at: str = "",
+    review_due_at: str = "",
+    superseded_by: str = "",
+    attention_tier: str = "active",
+    admission_state: str = "approved_manual",
+    contamination_class: str = "",
+) -> dict[str, object]:
+    """One fixture record specification, in the retained corpus's own shape."""
+    if contamination_class and contamination_class not in CONTAMINATION_CLASSES:
+        raise ValueError(f"unsupported contamination class: {contamination_class}")
+    return {
+        "record_id": record_id,
+        "summary": summary,
+        "approved_at": approved_at,
+        "tags": list(tags),
+        "record_type": record_type,
+        "scope_kind": scope_kind,
+        "scope_ref": scope_ref,
+        "observer": observer,
+        "observed": observed,
+        "retention_class": retention_class,
+        "expires_at": expires_at,
+        "review_due_at": review_due_at,
+        "superseded_by": superseded_by,
+        "attention_tier": attention_tier,
+        "admission_state": admission_state,
+        "contamination_class": contamination_class,
+    }
+
+
+def materialize_fixture_record(spec: dict[str, object]) -> tuple[dict[str, object], dict[str, object]]:
+    """Turn one fixture specification into a stored record and its review.
+
+    The pair is written straight into an isolated fixture store rather than
+    produced through capture and approval, because approval stamps the record
+    with ``utc_now()`` and mints a random record id. Both would make the pack
+    depend on the day the suite ran and on the bytes of ``os.urandom``.
+    """
+    approved_at = str(spec["approved_at"])
+    record_id = str(spec["record_id"])
+    review_id = f"review_{record_id}"
+    retention: dict[str, object] = {"class": str(spec["retention_class"]), "admitted_at": approved_at}
+    expires_at = str(spec["expires_at"])
+    if expires_at:
+        retention["expires_at"] = expires_at
+    review_due_at = str(spec["review_due_at"])
+    tags = spec["tags"] if isinstance(spec.get("tags"), list) else []
+    record: dict[str, object] = {
+        "schema_version": PROJECT_MEMORY_RECORD_SCHEMA_VERSION,
+        "record_id": record_id,
+        "candidate_id": f"cand_{record_id}",
+        "revision": 1,
+        "record_type": str(spec["record_type"]),
+        "summary": str(spec["summary"]),
+        "scope": {"kind": str(spec["scope_kind"]), "ref": str(spec["scope_ref"])},
+        "tags": [str(tag) for tag in tags],
+        "source": "retrieval_fixture",
+        "source_class": "omh_local",
+        "source_ref": "",
+        "derived_from": [],
+        "admission": {
+            "state": str(spec["admission_state"]),
+            "review_id": review_id,
+            "reviewer_claim": "operator",
+            "admitted_at": approved_at,
+            "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION,
+        },
+        "retention": retention,
+        "revalidation": {"deadline": review_due_at} if review_due_at else {},
+        "approved_at": approved_at,
+        "created_at": approved_at,
+        "updated_at": approved_at,
+        "ttl": {"expires_at": expires_at, "ttl_days": None},
+        "staleness": {"stale_after": review_due_at, "review_due_at": review_due_at, "stale_after_days": None},
+        "attention": {
+            "schema_version": "omh_memory_attention/v1",
+            "tier": str(spec["attention_tier"]),
+            "reason": "retrieval_fixture",
+            "previous_tier": "",
+            "changed_at": approved_at,
+        },
+        "safety": {},
+        "redaction_policy": "metadata_only",
+        "claim_boundary": _RECORD_CLAIM_BOUNDARY,
+    }
+    if str(spec["observed"]):
+        record["perspective"] = {"observer": str(spec["observer"]), "observed": str(spec["observed"])}
+    if str(spec["superseded_by"]):
+        record["superseded_by"] = str(spec["superseded_by"])
+    digest = canonical_payload_digest(record)
+    admission = record["admission"]
+    if isinstance(admission, dict):
+        admission["payload_digest"] = digest
+    review = {
+        "schema_version": PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION,
+        "review_id": review_id,
+        "artifact_identity": stable_artifact_identity(record),
+        "decision": str(spec["admission_state"]),
+        "reviewer_claim": "operator",
+        "payload_digest": digest,
+        "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION,
+        "reviewed_at": approved_at,
+        "claim_boundary": _REVIEW_CLAIM_BOUNDARY,
+    }
+    return record, review
+
+
+def _case(
+    case_id: str,
+    intent: str,
+    *,
+    records: tuple[dict[str, object], ...],
+    query: str = "",
+    scope_kind: str | None = None,
+    scope_ref: str | None = None,
+    observer: str | None = None,
+    observed: str | None = None,
+    limit: int = 6,
+    max_chars: int | None = None,
+    include_stale: bool = False,
+    include_archived: bool = False,
+    pins: tuple[str, ...] = (),
+    usage: tuple[tuple[str, int], ...] = (),
+    included_order: tuple[str, ...] = (),
+    excluded_reasons: tuple[tuple[str, str], ...] = (),
+    absent: tuple[str, ...] = (),
+    truncated: bool = False,
+    sibling_hints: tuple[tuple[str, str], ...] = (),
+    ineligible_included: tuple[str, ...] = (),
+) -> dict[str, object]:
+    return {
+        "case_id": case_id,
+        "intent": intent,
+        "clock": FIXTURE_CLOCK_ISO,
+        "query": query,
+        "lens": {"scope_kind": scope_kind, "scope_ref": scope_ref, "observer": observer, "observed": observed},
+        "budget": {"limit": limit, "max_chars": max_chars},
+        "flags": {"include_stale": include_stale, "include_archived": include_archived},
+        "pins": list(pins),
+        "usage": {record_id: times for record_id, times in usage},
+        "records": list(records),
+        "expected": {
+            "included_order": list(included_order),
+            "excluded_reasons": dict(excluded_reasons),
+            "absent": list(absent),
+            "truncated": truncated,
+            "sibling_hints": dict(sibling_hints),
+            "ineligible_included": list(ineligible_included),
+        },
+    }
+
+
+# Timestamps used across the corpus. Named so a case reads as a statement about
+# freshness rather than as a date arithmetic puzzle.
+_YOUNG = "2030-12-20T00:00:00Z"
+_YOUNGER = "2030-12-28T00:00:00Z"
+_AGING = "2030-10-01T00:00:00Z"
+_OLD = "2029-06-01T00:00:00Z"
+_PAST_DEADLINE = "2030-11-15T00:00:00Z"
+_FUTURE_DEADLINE = "2032-06-01T00:00:00Z"
+
+
+RETRIEVAL_CASES: tuple[dict[str, object], ...] = (
+    _case(
+        "exact_and_partial_relevance",
+        "An exact multi-token match leads a partial one, and a record with no overlap is named, not dropped.",
+        records=(
+            _record("mem_r01_exact", "Staging deploys run canary batches before promotion", approved_at=_YOUNG, tags=("deploy", "staging")),
+            _record("mem_r02_partial", "Deploys are announced in the release channel", approved_at=_YOUNG, tags=("deploy",)),
+            _record("mem_r03_unrelated", "The parser owner is the platform team", approved_at=_YOUNG, tags=("parser",)),
+        ),
+        query="staging deploys canary",
+        included_order=("mem_r01_exact", "mem_r02_partial"),
+        excluded_reasons=(("mem_r03_unrelated", "no_query_overlap"),),
+    ),
+    _case(
+        "no_match_yields_an_empty_pack_with_named_reasons",
+        "A query nothing answers returns an empty pack in which every record still carries its exclusion reason.",
+        records=(
+            _record("mem_r01_exact", "Staging deploys run canary batches before promotion", approved_at=_YOUNG, tags=("deploy", "staging")),
+            _record("mem_r02_partial", "Deploys are announced in the release channel", approved_at=_YOUNG, tags=("deploy",)),
+            _record("mem_r03_unrelated", "The parser owner is the platform team", approved_at=_YOUNG, tags=("parser",)),
+        ),
+        query="quantum ledger reconciliation",
+        excluded_reasons=(
+            ("mem_r01_exact", "no_query_overlap"),
+            ("mem_r02_partial", "no_query_overlap"),
+            ("mem_r03_unrelated", "no_query_overlap"),
+        ),
+    ),
+    _case(
+        "same_topic_disagreement_names_the_cut_sibling",
+        "Two records disagree on one topic and the budget keeps one: the cut side names the sibling that survived.",
+        records=(
+            _record("mem_r10_keeps", "Deploys wait for a green nightly run", approved_at=_YOUNGER, tags=("deploy",)),
+            _record("mem_r11_cut", "Deploys ship without waiting for the nightly run", approved_at=_OLD, tags=("deploy",)),
+        ),
+        query="deploys nightly",
+        limit=1,
+        included_order=("mem_r10_keeps",),
+        excluded_reasons=(("mem_r11_cut", "over_budget"),),
+        truncated=True,
+        sibling_hints=(("mem_r11_cut", "mem_r10_keeps"),),
+    ),
+    _case(
+        "supersession_removes_the_corrected_revision",
+        "A corrected record points at its replacement and leaves the pack as superseded, not as a relevance miss.",
+        records=(
+            _record("mem_r20_current", "Release notes are written before the tag is pushed", approved_at=_YOUNG, tags=("release",)),
+            _record(
+                "mem_r21_superseded",
+                "Release notes are written after the tag is pushed",
+                approved_at=_AGING,
+                tags=("release",),
+                superseded_by="mem_r20_current",
+            ),
+        ),
+        query="release notes tag",
+        included_order=("mem_r20_current",),
+        excluded_reasons=(("mem_r21_superseded", "superseded"),),
+    ),
+    _case(
+        "expired_volatile_record_leaves_the_pack",
+        "A volatile record whose retention deadline has passed is excluded under its retention class, not silently.",
+        records=(
+            _record("mem_r30_live", "The staging database runs postgres 17", approved_at=_YOUNG, tags=("staging",)),
+            _record(
+                "mem_r31_expired",
+                "The staging database runs postgres 16",
+                approved_at=_AGING,
+                tags=("staging",),
+                retention_class="volatile",
+                expires_at=_PAST_DEADLINE,
+                contamination_class="expired",
+            ),
+        ),
+        query="staging database postgres",
+        included_order=("mem_r30_live",),
+        excluded_reasons=(("mem_r31_expired", "expired_volatile"),),
+    ),
+    _case(
+        "stale_review_is_excluded_by_default",
+        "A passed revalidation deadline holds the record out of the default pack under its own reason code.",
+        records=(
+            _record("mem_r40_fresh", "The nightly job runs on the ubuntu runner", approved_at=_YOUNG, tags=("nightly",), review_due_at=_FUTURE_DEADLINE),
+            _record(
+                "mem_r41_stale",
+                "The nightly job runs on the macos runner",
+                approved_at=_AGING,
+                tags=("nightly",),
+                review_due_at=_PAST_DEADLINE,
+                contamination_class="stale",
+            ),
+        ),
+        query="nightly job runner",
+        included_order=("mem_r40_fresh",),
+        excluded_reasons=(("mem_r41_stale", "stale_review_required"),),
+    ),
+    _case(
+        "include_stale_surfaces_the_record_carrying_ineligible_evidence",
+        "The inspection affordance returns the stale record, and it arrives still marked ineligible.",
+        records=(
+            _record("mem_r40_fresh", "The nightly job runs on the ubuntu runner", approved_at=_YOUNG, tags=("nightly",), review_due_at=_FUTURE_DEADLINE),
+            _record(
+                "mem_r41_stale",
+                "The nightly job runs on the macos runner",
+                approved_at=_AGING,
+                tags=("nightly",),
+                review_due_at=_PAST_DEADLINE,
+                contamination_class="stale",
+            ),
+        ),
+        query="nightly job runner",
+        include_stale=True,
+        included_order=("mem_r40_fresh", "mem_r41_stale"),
+        ineligible_included=("mem_r41_stale",),
+    ),
+    _case(
+        "scope_lens_isolates_a_foreign_scope",
+        "A record filed under another scope never reaches the pack the lens asked for.",
+        records=(
+            _record("mem_r50_in_scope", "The default scope owns the release checklist", approved_at=_YOUNG, tags=("release",)),
+            _record(
+                "mem_r51_other_scope",
+                "The other scope owns the release checklist",
+                approved_at=_YOUNG,
+                tags=("release",),
+                scope_ref="other",
+                contamination_class="foreign_scope",
+            ),
+        ),
+        query="release checklist",
+        scope_kind="project",
+        scope_ref="default",
+        included_order=("mem_r50_in_scope",),
+        absent=("mem_r51_other_scope",),
+    ),
+    _case(
+        "perspective_lens_isolates_another_actors_record",
+        "An unscoped record and this actor's record pass; a record observed for another actor does not.",
+        records=(
+            _record("mem_r60_unscoped", "Handoffs cite the branch name", approved_at=_YOUNG, tags=("handoff",)),
+            _record("mem_r61_mine", "Handoffs cite the branch name and the base revision", approved_at=_YOUNG, tags=("handoff",), observer="omh", observed="claude-code"),
+            _record(
+                "mem_r62_theirs",
+                "Handoffs cite the branch name and the ticket id",
+                approved_at=_YOUNG,
+                tags=("handoff",),
+                observer="omh",
+                observed="codex",
+                contamination_class="foreign_perspective",
+            ),
+        ),
+        query="handoffs branch name",
+        observer="omh",
+        observed="claude-code",
+        included_order=("mem_r60_unscoped", "mem_r61_mine"),
+        absent=("mem_r62_theirs",),
+    ),
+    _case(
+        "pins_lead_without_owning_the_whole_budget",
+        "A pinned anchor with no query overlap leads the pack, and the strongest match still takes a slot.",
+        records=(
+            _record("mem_r70_pinned", "The team reviews architecture decisions on friday", approved_at=_OLD, tags=("process",)),
+            _record("mem_r71_strong", "Cache invalidation runs on every deploy", approved_at=_YOUNG, tags=("cache", "deploy")),
+            _record("mem_r72_weak", "Cache warmers are optional", approved_at=_YOUNG, tags=("cache",)),
+        ),
+        query="cache invalidation deploy",
+        limit=2,
+        pins=("mem_r70_pinned",),
+        included_order=("mem_r70_pinned", "mem_r71_strong"),
+        excluded_reasons=(("mem_r72_weak", "over_budget"),),
+        truncated=True,
+    ),
+    _case(
+        "attention_tier_outranks_relevance",
+        "An active record leads a reference record that matches the query more strongly.",
+        records=(
+            _record("mem_r80_active", "Migrations are applied by the release job", approved_at=_YOUNG, tags=("migration",)),
+            _record(
+                "mem_r81_reference",
+                "Migrations are applied by the release job during the release window",
+                approved_at=_YOUNG,
+                tags=("migration", "release"),
+                attention_tier="reference",
+            ),
+        ),
+        query="migrations release job window",
+        included_order=("mem_r80_active", "mem_r81_reference"),
+    ),
+    _case(
+        "archive_tier_leaves_the_default_pack_named",
+        "An archived record is held back under its own reason code while it stays in the store.",
+        records=(
+            _record("mem_r90_active", "Feature flags are removed after two releases", approved_at=_YOUNG, tags=("flags",)),
+            _record(
+                "mem_r91_archived",
+                "Feature flags are removed after five releases",
+                approved_at=_AGING,
+                tags=("flags",),
+                attention_tier="archive",
+                contamination_class="archived",
+            ),
+        ),
+        query="feature flags releases",
+        included_order=("mem_r90_active",),
+        excluded_reasons=(("mem_r91_archived", "archived_tier"),),
+    ),
+    _case(
+        "archive_tier_returns_on_an_explicit_archived_query",
+        "The archived record comes back when the operator asks for it, behind its active peer.",
+        records=(
+            _record("mem_r90_active", "Feature flags are removed after two releases", approved_at=_YOUNG, tags=("flags",)),
+            _record(
+                "mem_r91_archived",
+                "Feature flags are removed after five releases",
+                approved_at=_AGING,
+                tags=("flags",),
+                attention_tier="archive",
+                contamination_class="archived",
+            ),
+        ),
+        query="feature flags releases",
+        include_archived=True,
+        included_order=("mem_r90_active", "mem_r91_archived"),
+    ),
+    _case(
+        "age_tie_breaks_deterministically_by_record_id",
+        "Two records of equal relevance, equal age, and equal usage order by record id, never by store order.",
+        records=(
+            _record("mem_ra1_first", "Backups run every night", approved_at=_YOUNG, tags=("backup",)),
+            _record("mem_ra2_second", "Backups run every night", approved_at=_YOUNG, tags=("backup",)),
+        ),
+        query="backups night",
+        included_order=("mem_ra1_first", "mem_ra2_second"),
+    ),
+    _case(
+        "record_limit_truncation_reports_over_budget",
+        "A record-count budget cuts the tail and says so, rather than returning a short pack silently.",
+        records=(
+            _record("mem_rb1", "Queue workers retry failed jobs twice", approved_at=_YOUNGER, tags=("queue",)),
+            _record("mem_rb2", "Queue workers log every retry", approved_at=_YOUNG, tags=("queue",)),
+            _record("mem_rb3", "Queue depth alerts fire at one thousand", approved_at=_AGING, tags=("queue",)),
+            _record("mem_rb4", "Queue names are prefixed by the service", approved_at=_OLD, tags=("queue",)),
+        ),
+        query="queue workers retry",
+        limit=2,
+        included_order=("mem_rb1", "mem_rb2"),
+        excluded_reasons=(("mem_rb3", "over_budget"), ("mem_rb4", "over_budget")),
+        truncated=True,
+    ),
+    _case(
+        "character_budget_truncation_is_reported_separately",
+        "A character budget cuts the pack under the same over_budget reason with the record limit left slack.",
+        records=(
+            _record("mem_rc1", "Queue workers retry failed jobs twice", approved_at=_YOUNGER, tags=("queue",)),
+            _record("mem_rc2", "Queue workers log every retry attempt for audit", approved_at=_YOUNG, tags=("queue",)),
+            _record("mem_rc3", "Queue depth alerts fire at one thousand messages", approved_at=_AGING, tags=("queue",)),
+        ),
+        query="queue workers retry",
+        limit=6,
+        max_chars=40,
+        included_order=("mem_rc1",),
+        excluded_reasons=(("mem_rc2", "over_budget"), ("mem_rc3", "over_budget")),
+        truncated=True,
+    ),
+)
+
+
+def fixture_digest(cases: tuple[dict[str, object], ...] = RETRIEVAL_CASES) -> str:
+    """One digest over the retained corpus, keys sorted, separators fixed."""
+    return hashlib.sha256(json.dumps(cases, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()

--- a/tests/test_memory_retrieval_suite.py
+++ b/tests/test_memory_retrieval_suite.py
@@ -1,0 +1,442 @@
+"""Retrieval-quality regression suite for project memory (issue #1427).
+
+These tests hold three lines:
+
+- the suite is a gate, not a snapshot: a seeded ranking, lens, freshness,
+  archive, or budget regression has to make it fail, and each has to fail under
+  its own name rather than as one undifferentiated count;
+- the report is deterministic and identity-bound: the same inputs produce the
+  same bytes, and two reports built from different fixtures, configuration,
+  clock, or revision refuse to be compared at all;
+- the corpus stays offline and self-contained: no clock read, no network or
+  model import, and no write outside each case's own temporary store.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest import mock
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+from omh.workflows.memory_evaluation import (
+    RETRIEVAL_EVALUATION_SCHEMA_VERSION,
+    RETRIEVAL_IDENTITY_FIELDS,
+    compare_retrieval_reports,
+    retrieval_report_identity,
+    run_memory_evaluation,
+    run_memory_retrieval_evaluation,
+)
+from omh.workflows.memory_retrieval_fixtures import (
+    CONTAMINATION_CLASSES,
+    RETRIEVAL_CASES,
+    fixture_digest,
+    materialize_fixture_record,
+)
+
+_SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src" / "workflows"
+
+
+def _case(case_id: str) -> dict:
+    return next(case for case in RETRIEVAL_CASES if case["case_id"] == case_id)
+
+
+def _serialize(report: dict) -> str:
+    return json.dumps(report, sort_keys=True, separators=(",", ":"))
+
+
+def _case_result(report: dict, case_id: str) -> dict:
+    return next(case for case in report["cases"] if case["case_id"] == case_id)
+
+
+def _leak_builder(record_id: str, source_case_id: str):
+    """A recall builder that leaks one fixture record back into its pack.
+
+    The leaked entry is built from the fixture record itself, so the seeded
+    fault is exactly "this record reached the pack", which is what a broken
+    lens, a broken expiry check, or a broken tier gate would produce.
+    """
+    from omh.memory import build_project_memory_recall_pack
+
+    spec = next(item for item in _case(source_case_id)["records"] if item["record_id"] == record_id)
+    record, _review = materialize_fixture_record(spec)
+
+    def _builder(paths, query="", **kwargs):
+        pack = build_project_memory_recall_pack(paths, query, **kwargs)
+        leaked = {
+            "record_id": record_id,
+            "record_type": record["record_type"],
+            "summary": record["summary"],
+            "scope": record["scope"],
+            "tags": record["tags"],
+            "source": record["source"],
+            "approved_at": record["approved_at"],
+            "staleness": {"state": "not_checked"},
+            "score": 0,
+            "attention_tier": "active",
+            "derived_from": [],
+            "perspective": {},
+            "eligibility_reason": "eligible",
+            "replay_evaluation": {"eligible": True, "reason_code": "eligible"},
+        }
+        included = [item for item in pack["included_records"] if str(item["record_id"]) != record_id]
+        excluded = [item for item in pack["excluded_records"] if str(item["record_id"]) != record_id]
+        return {**pack, "included_records": [*included, leaked], "excluded_records": excluded}
+
+    return _builder
+
+
+class RetrievalSuiteDeterminismTests(unittest.TestCase):
+    def test_identical_inputs_produce_identical_report_bytes(self) -> None:
+        first = run_memory_retrieval_evaluation(target_revision="rev-a")
+        second = run_memory_retrieval_evaluation(target_revision="rev-a")
+
+        self.assertEqual(_serialize(first), _serialize(second))
+        self.assertEqual(first["schema_version"], RETRIEVAL_EVALUATION_SCHEMA_VERSION)
+
+    def test_the_retained_corpus_passes_against_the_production_recall_builder(self) -> None:
+        report = run_memory_retrieval_evaluation()
+
+        self.assertTrue(report["passed"], report["summary"])
+        self.assertEqual(report["summary"]["failed_cases"], 0)
+        self.assertEqual(report["summary"]["exact_order_cases"], report["case_count"])
+        self.assertEqual(report["summary"]["expected_hit_count"], report["summary"]["expected_included_count"])
+
+    def test_a_corpus_edit_moves_the_fixture_digest(self) -> None:
+        changed = copy.deepcopy(list(RETRIEVAL_CASES))
+        changed[0]["records"][0]["summary"] = "a different synthetic fixture summary"
+
+        self.assertNotEqual(fixture_digest(RETRIEVAL_CASES), fixture_digest(tuple(changed)))
+
+    def test_the_report_is_bound_to_fixture_configuration_clock_and_revision(self) -> None:
+        report = run_memory_retrieval_evaluation(target_revision="rev-a")
+        identity = retrieval_report_identity(report)
+
+        self.assertEqual(set(identity), set(RETRIEVAL_IDENTITY_FIELDS))
+        self.assertEqual(identity["fixture_digest"], fixture_digest())
+        self.assertEqual(identity["clock"], "2031-01-02T03:04:05Z")
+        self.assertEqual(identity["target_revision"], "rev-a")
+        self.assertEqual(len(str(identity["retrieval_config_digest"])), 64)
+
+
+class RetrievalCorpusCoverageTests(unittest.TestCase):
+    def test_case_ids_and_record_ids_are_unique_within_the_corpus(self) -> None:
+        case_ids = [case["case_id"] for case in RETRIEVAL_CASES]
+        self.assertEqual(len(case_ids), len(set(case_ids)))
+        for case in RETRIEVAL_CASES:
+            record_ids = [record["record_id"] for record in case["records"]]
+            self.assertEqual(len(record_ids), len(set(record_ids)), case["case_id"])
+
+    def test_every_fixture_record_has_exactly_one_expected_disposition(self) -> None:
+        """A record with no declared disposition would score as a silent pass."""
+        for case in RETRIEVAL_CASES:
+            expected = case["expected"]
+            buckets = {
+                "included": set(expected["included_order"]),
+                "excluded": set(expected["excluded_reasons"]),
+                "absent": set(expected["absent"]),
+            }
+            for record in case["records"]:
+                record_id = record["record_id"]
+                declared = [name for name, ids in buckets.items() if record_id in ids]
+                self.assertEqual(len(declared), 1, f"{case['case_id']}/{record_id}: {declared}")
+
+    def test_the_corpus_covers_every_named_retrieval_interaction(self) -> None:
+        required = {
+            "exact_and_partial_relevance",
+            "no_match_yields_an_empty_pack_with_named_reasons",
+            "same_topic_disagreement_names_the_cut_sibling",
+            "supersession_removes_the_corrected_revision",
+            "expired_volatile_record_leaves_the_pack",
+            "stale_review_is_excluded_by_default",
+            "include_stale_surfaces_the_record_carrying_ineligible_evidence",
+            "scope_lens_isolates_a_foreign_scope",
+            "perspective_lens_isolates_another_actors_record",
+            "pins_lead_without_owning_the_whole_budget",
+            "attention_tier_outranks_relevance",
+            "archive_tier_leaves_the_default_pack_named",
+            "archive_tier_returns_on_an_explicit_archived_query",
+            "age_tie_breaks_deterministically_by_record_id",
+            "record_limit_truncation_reports_over_budget",
+            "character_budget_truncation_is_reported_separately",
+        }
+
+        self.assertEqual(required - {case["case_id"] for case in RETRIEVAL_CASES}, set())
+
+    def test_every_contamination_class_is_exercised_by_at_least_one_record(self) -> None:
+        labelled = {
+            str(record["contamination_class"])
+            for case in RETRIEVAL_CASES
+            for record in case["records"]
+            if record["contamination_class"]
+        }
+
+        self.assertEqual(set(CONTAMINATION_CLASSES) - labelled, set())
+
+
+class SeededRegressionTests(unittest.TestCase):
+    def test_a_seeded_ranking_regression_breaks_order_and_fails_the_suite(self) -> None:
+        from omh.memory import build_project_memory_recall_pack
+
+        def _reversed(paths, query="", **kwargs):
+            pack = build_project_memory_recall_pack(paths, query, **kwargs)
+            return {**pack, "included_records": list(reversed(pack["included_records"]))}
+
+        report = run_memory_retrieval_evaluation(pack_builder=_reversed)
+
+        self.assertFalse(report["passed"])
+        self.assertLess(report["summary"]["exact_order_cases"], report["case_count"])
+        self.assertGreater(report["summary"]["failed_cases"], 0)
+
+    def test_a_seeded_expected_hit_regression_fails_the_suite(self) -> None:
+        from omh.memory import build_project_memory_recall_pack
+
+        def _drops_the_leader(paths, query="", **kwargs):
+            pack = build_project_memory_recall_pack(paths, query, **kwargs)
+            return {**pack, "included_records": pack["included_records"][1:]}
+
+        report = run_memory_retrieval_evaluation(pack_builder=_drops_the_leader)
+
+        self.assertFalse(report["passed"])
+        self.assertGreater(report["summary"]["missing_inclusion_count"], 0)
+        self.assertLess(report["summary"]["expected_hit_count"], report["summary"]["expected_included_count"])
+
+    def test_a_seeded_scope_leak_increments_the_scope_counter_and_fails(self) -> None:
+        builder = _leak_builder("mem_r51_other_scope", "scope_lens_isolates_a_foreign_scope")
+
+        report = run_memory_retrieval_evaluation(pack_builder=builder)
+        case = _case_result(report, "scope_lens_isolates_a_foreign_scope")
+
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["summary"]["foreign_scope_contamination"], 1)
+        self.assertEqual(case["contamination"]["foreign_scope_contamination"], 1)
+        self.assertEqual(
+            [(row["record_id"], row["expected_disposition"], row["observed_disposition"]) for row in case["unexpected_inclusions"]],
+            [("mem_r51_other_scope", "absent", "included")],
+        )
+
+    def test_a_seeded_perspective_leak_increments_the_perspective_counter_and_fails(self) -> None:
+        builder = _leak_builder("mem_r62_theirs", "perspective_lens_isolates_another_actors_record")
+
+        report = run_memory_retrieval_evaluation(pack_builder=builder)
+
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["summary"]["foreign_perspective_contamination"], 1)
+        self.assertEqual(report["summary"]["foreign_scope_contamination"], 0)
+
+    def test_a_seeded_expiry_leak_increments_the_expired_counter_and_fails(self) -> None:
+        builder = _leak_builder("mem_r31_expired", "expired_volatile_record_leaves_the_pack")
+
+        report = run_memory_retrieval_evaluation(pack_builder=builder)
+        case = _case_result(report, "expired_volatile_record_leaves_the_pack")
+
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["summary"]["expired_contamination"], 1)
+        self.assertEqual(
+            [(row["record_id"], row["expected_disposition"]) for row in case["exclusion_reason_drift"]],
+            [("mem_r31_expired", "excluded:expired_volatile")],
+        )
+
+    def test_a_seeded_archive_leak_increments_the_archive_counter_and_fails(self) -> None:
+        builder = _leak_builder("mem_r91_archived", "archive_tier_leaves_the_default_pack_named")
+
+        report = run_memory_retrieval_evaluation(pack_builder=builder)
+
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["summary"]["archived_contamination"], 1)
+
+    def test_a_seeded_stale_leak_increments_the_stale_counter_and_fails(self) -> None:
+        builder = _leak_builder("mem_r41_stale", "stale_review_is_excluded_by_default")
+
+        report = run_memory_retrieval_evaluation(pack_builder=builder)
+
+        self.assertFalse(report["passed"])
+        self.assertEqual(report["summary"]["stale_contamination"], 1)
+
+    def test_a_seeded_budget_regression_is_reported_apart_from_a_relevance_miss(self) -> None:
+        """A pack that keeps every expected record but overruns its budget must
+        fail as a budget violation, with the relevance counters left clean."""
+        from omh.memory import build_project_memory_recall_pack
+
+        def _ignores_the_budget(paths, query="", **kwargs):
+            pack = build_project_memory_recall_pack(paths, query, **{**kwargs, "limit": 99, "max_chars": None})
+            return {**pack, "truncated": bool(kwargs.get("limit", 6) < len(pack["included_records"]))}
+
+        report = run_memory_retrieval_evaluation(pack_builder=_ignores_the_budget)
+        case = _case_result(report, "record_limit_truncation_reports_over_budget")
+
+        self.assertFalse(report["passed"])
+        self.assertGreater(report["summary"]["budget_violation_count"], 0)
+        self.assertEqual(
+            [(row["violation"], row["limit"], row["observed"]) for row in case["budget_violations"]],
+            [("record_limit_exceeded", 2, 4)],
+        )
+        self.assertEqual(report["summary"]["missing_inclusion_count"], 0)
+
+    def test_a_seeded_ineligible_evidence_regression_fails_the_stale_inspection_case(self) -> None:
+        """--include-stale must deliver the stale record still marked ineligible."""
+        from omh.memory import build_project_memory_recall_pack
+
+        def _blesses_the_stale_record(paths, query="", **kwargs):
+            pack = build_project_memory_recall_pack(paths, query, **kwargs)
+            included = [
+                {**item, "replay_evaluation": {**item.get("replay_evaluation", {}), "eligible": True}}
+                for item in pack["included_records"]
+            ]
+            return {**pack, "included_records": included}
+
+        report = run_memory_retrieval_evaluation(pack_builder=_blesses_the_stale_record)
+        case = _case_result(report, "include_stale_surfaces_the_record_carrying_ineligible_evidence")
+
+        self.assertFalse(case["passed"])
+        self.assertEqual([row["record_id"] for row in case["ineligible_evidence_drift"]], ["mem_r41_stale"])
+
+    def test_every_finding_names_the_fixture_record_and_both_dispositions(self) -> None:
+        builder = _leak_builder("mem_r51_other_scope", "scope_lens_isolates_a_foreign_scope")
+        report = run_memory_retrieval_evaluation(pack_builder=builder)
+
+        findings = [
+            row
+            for case in report["cases"]
+            for key in ("unexpected_inclusions", "missing_inclusions", "exclusion_reason_drift")
+            for row in case[key]
+        ]
+        self.assertTrue(findings)
+        for row in findings:
+            self.assertEqual(
+                set(row),
+                {"case_id", "record_id", "expected_disposition", "observed_disposition", "reason_code", "contamination_class"},
+            )
+            self.assertTrue(row["case_id"] and row["record_id"])
+
+
+class RetrievalReportComparisonTests(unittest.TestCase):
+    def test_reports_with_different_revisions_refuse_comparison(self) -> None:
+        left = run_memory_retrieval_evaluation(target_revision="rev-a")
+        right = run_memory_retrieval_evaluation(target_revision="rev-b")
+
+        comparison = compare_retrieval_reports(left, right)
+
+        self.assertFalse(comparison["comparable"])
+        self.assertEqual(comparison["mismatched_identity_fields"], ["target_revision"])
+
+    def test_reports_with_a_different_fixture_digest_refuse_comparison(self) -> None:
+        left = run_memory_retrieval_evaluation(target_revision="rev-a")
+        right = {**copy.deepcopy(left), "fixture_digest": "0" * 64}
+
+        comparison = compare_retrieval_reports(left, right)
+
+        self.assertFalse(comparison["comparable"])
+        self.assertEqual(comparison["mismatched_identity_fields"], ["fixture_digest"])
+
+    def test_matching_identities_compare_and_name_the_regressed_case(self) -> None:
+        from omh.memory import build_project_memory_recall_pack
+
+        def _reversed(paths, query="", **kwargs):
+            pack = build_project_memory_recall_pack(paths, query, **kwargs)
+            return {**pack, "included_records": list(reversed(pack["included_records"]))}
+
+        left = run_memory_retrieval_evaluation(target_revision="rev-a")
+        right = run_memory_retrieval_evaluation(target_revision="rev-a", pack_builder=_reversed)
+
+        comparison = compare_retrieval_reports(left, right)
+
+        self.assertTrue(comparison["comparable"])
+        self.assertFalse(comparison["identical_results"])
+        self.assertIn("exact_and_partial_relevance", comparison["regressed_cases"])
+
+
+class RetrievalExecutionBoundaryTests(unittest.TestCase):
+    def test_the_fixture_corpus_reads_no_clock_and_imports_nothing_remote(self) -> None:
+        source = (_SOURCE_ROOT / "memory_retrieval_fixtures.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".", 1)[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".", 1)[0])
+
+        self.assertFalse(imported & {"http", "httpx", "requests", "socket", "urllib", "openai", "anthropic", "subprocess"})
+        # Call sites, not prose: the module docstring names ``utc_now`` to
+        # explain why the corpus does not use it, and a text scan would read
+        # that explanation as the very thing it forbids.
+        called = {
+            node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, (ast.Attribute, ast.Name))
+        }
+        self.assertFalse(
+            called & {"now", "today", "utc_now", "time", "monotonic", "perf_counter", "perf_counter_ns"},
+            "a fixture that reads the wall clock goes stale on its own",
+        )
+
+    def test_the_suite_writes_nothing_into_an_existing_memory_store(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            store = root / ".omh" / "memory" / "records"
+            store.mkdir(parents=True)
+            record, _review = materialize_fixture_record(RETRIEVAL_CASES[0]["records"][0])
+            (store / "existing.json").write_text(json.dumps(record, sort_keys=True), encoding="utf-8")
+            before = hashlib.sha256(b"".join(sorted(path.read_bytes() for path in (root / ".omh").rglob("*") if path.is_file()))).hexdigest()
+
+            report = run_memory_retrieval_evaluation()
+
+            after = hashlib.sha256(b"".join(sorted(path.read_bytes() for path in (root / ".omh").rglob("*") if path.is_file()))).hexdigest()
+            self.assertEqual(before, after)
+            self.assertNotIn(str(root), _serialize(report))
+
+    def test_the_report_states_its_offline_execution_and_claim_boundary(self) -> None:
+        report = run_memory_retrieval_evaluation()
+
+        self.assertIn("no model call", report["execution_boundary"])
+        self.assertIn("never execution, review, CI, merge", report["claim_boundary"])
+        self.assertIn("separate observed-evidence contract", report["claim_boundary"])
+
+
+class RetrievalSchemaCompatibilityTests(unittest.TestCase):
+    def test_the_existing_evaluation_report_schema_is_untouched(self) -> None:
+        """Old omh_memory_evaluation/v1 reports stay readable: the retrieval
+        result is a sibling schema, never a widening of the existing one."""
+        report = run_memory_evaluation("small", repetitions=1)
+
+        self.assertEqual(report["schema_version"], "omh_memory_evaluation/v1")
+        self.assertEqual(set(report) & set(RETRIEVAL_IDENTITY_FIELDS), {"schema_version"})
+        self.assertNotIn("cases", report)
+
+
+class RetrievalSuiteCliTests(unittest.TestCase):
+    def test_the_cli_writes_the_report_and_exits_zero_when_the_corpus_passes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            output = root / "retrieval.json"
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes"), "memory", "recall-suite", "--revision", "rev-a", "--output", str(output)]
+            )
+
+            self.assertEqual((status, stderr), (0, ""))
+            payload = json.loads(stdout)
+            self.assertEqual(payload["schema_version"], RETRIEVAL_EVALUATION_SCHEMA_VERSION)
+            self.assertTrue(payload["passed"])
+            self.assertEqual(payload["target_revision"], "rev-a")
+            self.assertEqual(payload, json.loads(output.read_text(encoding="utf-8")))
+
+    def test_the_cli_exits_non_zero_when_the_report_fails(self) -> None:
+        failing = {**run_memory_retrieval_evaluation(), "passed": False}
+        with mock.patch("omh.commands.memory.run_memory_retrieval_evaluation", return_value=failing):
+            status, stdout, _stderr = run_cli(["memory", "recall-suite"])
+
+        self.assertEqual(status, 1)
+        self.assertFalse(json.loads(stdout)["passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New command `omh memory recall-suite` runs a retained retrieval-quality fixture corpus through the production project-memory recall-pack builder and exits non-zero on a regression.
- New retained corpus in `src/workflows/memory_retrieval_fixtures.py`: 16 cases, each declaring its own records, pins, delivery counters, query, scope and perspective lens, record and character budgets, and the expected disposition of every record.
- New evaluator in `src/workflows/memory_evaluation.py`: `run_memory_retrieval_evaluation`, `retrieval_report_identity`, `compare_retrieval_reports`, reporting under the new schema `omh_memory_retrieval_evaluation/v1`.
- New `effective_recall_configuration()` in `src/workflows/memory.py` projects the live ranking constants so a report can bind to the configuration it was produced under.
- New `docs/MEMORY.md` section "Retrieval Regression Suite".
- 27 new tests in `tests/test_memory_retrieval_suite.py`.

Closes #1427.

### Why This Exists

OMH could already validate project-memory record transitions and replay consistency, but it had no retained end-to-end corpus for the query-facing recall pack. A change to relevance ranking, pins, age decay, attention tiers, the scope or perspective lens, budget cuts, or stale-record handling could keep every record valid and still deliver the wrong context. Feature-level unit tests exist for each mechanism, but nothing proved the combined retrieval path produced the intended pack, and nothing detected a harmful cross-feature interaction between them.

### User / Operator Impact

A maintainer about to change anything in the recall ladder now has one offline command that says whether retrieval still selects, orders, excludes, and explains records correctly:

```sh
omh memory recall-suite --revision "$(git rev-parse HEAD)"
```

Exit status is the gate, so it can stand in CI ahead of a recall change without anyone reading the report first. `--output` keeps the JSON.

### How It Works

Each case gets its own temporary store, is seeded with exactly the records, pins, and delivery counters its fixture declares, and is queried at the fixture's own clock through `build_project_memory_recall_pack` — the same builder handoff preparation uses. The evaluator copies no ranking, eligibility, or budget logic: every verdict is a comparison of retained record ids and production reason codes against what the builder returned.

Coverage across interacting features: exact and partial relevance, no-match behavior, same-topic disagreement including the cut sibling hint, correction and supersession, expired volatile retention, stale review and the `--include-stale` inspection path, scope isolation, perspective isolation, pins interacting with the record budget, attention tier outranking relevance, age ties, both archive directions, record-limit truncation, and character-budget truncation.

Determinism is structural, not incidental. Every timestamp is absolute and the corpus declares its own `now`, so no case turns red because a day passed. Records are written straight into the fixture store rather than captured and approved, because approval stamps the real clock and mints a random record id. The store reader sorts by file name, so neither dict iteration nor filesystem order can reorder a pack. Two runs in separate processes produced byte-identical reports.

Findings are separated by cause. Ordering failures, missing expected hits, and unexpected inclusions are counted apart from budget violations (`record_limit_exceeded`, `char_budget_exceeded`, `truncation_flag_drift`), so a pack that returns the right records but overruns its budget is never reported as a relevance miss. A record that a lens, a deadline, or a tier was supposed to keep out carries a contamination class, so an unexpected inclusion increments `foreign_scope_contamination`, `foreign_perspective_contamination`, `stale_contamination`, `expired_contamination`, or `archived_contamination` under its own name. Every finding names the case, the record id, the expected disposition, the observed disposition, and the production reason code.

Reports bind to the fixture digest, evaluator version, corpus version, a digest of the effective retrieval configuration, the fixture clock, and `--revision`. `compare_retrieval_reports` refuses a comparison whose identities differ and names the mismatched fields, so a corpus edit or a weight change is never attributed to a retrieval regression.

### Files And Contracts Touched

- `src/workflows/memory_retrieval_fixtures.py` (new): `RETRIEVAL_CASES`, `materialize_fixture_record`, `fixture_digest`, `CONTAMINATION_CLASSES`, `FIXTURE_CLOCK`.
- `src/workflows/memory_evaluation.py`: `run_memory_retrieval_evaluation`, `retrieval_report_identity`, `compare_retrieval_reports`, `RETRIEVAL_EVALUATION_SCHEMA_VERSION`, `RETRIEVAL_IDENTITY_FIELDS`. The existing `run_memory_evaluation` and `omh_memory_evaluation/v1` are untouched.
- `src/workflows/memory.py`: added `effective_recall_configuration()`. No behavior change to capture, approval, ranking, or recall.
- `src/commands/memory.py`, `src/commands/memory_parser.py`: the `memory recall-suite` subcommand and its exit-status mapping.
- `docs/MEMORY.md`: new "Retrieval Regression Suite" section.
- `tests/test_memory_retrieval_suite.py` (new).

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `uv run python -P -m omh.cli memory recall-suite --revision testrev`, run twice into files and compared with `cmp`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — `Ran 10414 tests in 721.677s`, `OK (skipped=1)`. All 27 new tests appear in that run and pass.
- `PYTHONPATH=tests uv run python -m unittest tests/test_memory_retrieval_suite.py` — 27 tests, OK.
- `PYTHONPATH=tests uv run python -m unittest tests/test_memory_evaluation.py` — 7 tests, OK, confirming the existing evaluation surface is unchanged.
- `uv run --group lint ruff check src tests` — All checks passed.
- `uv run python -m compileall -q src tests` — clean.
- `uv run python -m omh.cli docs workflows --check`, `docs roles --check`, `docs claims --check --json`, `docs capability-families --check`, `docs ulw-inventory --check`, `docs ulw-site --check` — all exit 0.
- `git diff --check` — clean.
- `drift_report()["ok"]` is `True` with no failing entries.
- Two separate `omh memory recall-suite --revision testrev` processes wrote byte-identical reports (`cmp` reported no difference); changing only `--revision` changed the report, as designed.
- Seeded regressions, each proven to fail the suite under its own counter by a test that wraps the production builder: reversed ordering (drops `exact_order_cases`), a dropped leader (raises `missing_inclusion_count`, lowers `expected_hit_count`), scope leak (`foreign_scope_contamination` 1), perspective leak (`foreign_perspective_contamination` 1, scope counter stays 0), expiry leak (`expired_contamination` 1 plus a named `exclusion_reason_drift` row), archive leak (`archived_contamination` 1), stale leak (`stale_contamination` 1), a budget overrun reported as `record_limit_exceeded` with `missing_inclusion_count` still 0, and a stale record wrongly marked eligible under `--include-stale` (`ineligible_evidence_drift`).
- CLI exit status: 0 on a passing corpus; 1 when the report reports failure.
- Isolation: a pre-existing memory store outside the suite is byte-identical before and after a run, and the serialized report contains no temporary path.

### Not Tested / Not Applicable

- `harness validate`, `release checklist --json`, `release hermes-smoke`, the packaged install smoke, and `omh --help`: not run because this change adds no skill, no capability family, no install artifact, and no release surface. It touches one CLI subcommand, two workflow modules, and one hand-written doc, none of which feed the release or harness manifests.
- Workflow-learning review queue smoke: no learning contract changed.
- Manual Hermes/TUI check: not run because no Hermes-facing surface, plugin, or TUI widget is touched. The new command is OMH-local and offline.

## Risk

Low. Nothing in the production recall path changed behavior: the only addition to `src/workflows/memory.py` is a read-only projection of existing constants, and no capture, approval, ranking, eligibility, or budget code was edited. The realistic risk is corpus maintenance: an intentional retuning of a recall weight will now fail this suite, which is the point, but it means a maintainer must re-derive the affected expectation from the production pack rather than editing a fixture to match. A test asserts every fixture record carries exactly one expected disposition, so a record cannot be added and then silently pass by having none.

## Compatibility / Rollout

`omh_memory_evaluation/v1` is untouched, so reports from earlier builds remain readable as they are, with no migration. The retrieval result ships as a sibling schema, `omh_memory_retrieval_evaluation/v1`, and a reader dispatches on `schema_version`; a test pins that the two report shapes stay disjoint. The new subcommand is additive and changes no existing command's output or exit status.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

The report's own `claim_boundary` states that it is retrieval agreement against a synthetic OMH-owned fixture corpus only, never execution, review, CI, merge, provider-quality, or Hermes internal-memory evidence, and that a model-judge or external memory-provider result may enter only through a separate observed-evidence contract. Fixture text is synthetic; no user memory, prompt, secret, or provider output is persisted. Timing is not recorded at all, so it cannot make correctness nondeterministic.

## Follow-Up

- Wire `omh memory recall-suite` into a CI step once the sharding layout is next revisited, so a recall change cannot merge without it.
- Provider-specific retrieval quality, latency, and cost still need separately authenticated observations and stay outside this offline pass/fail result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkRnGrts5ZxhCKfTPQ9Ze8
