### PR TITLE
test(voice): pin that the two readiness capabilities never trade turns

### DIFF
--- a/tests/test_realtime_voice_trial_receipts.py
+++ b/tests/test_realtime_voice_trial_receipts.py
@@ -25,6 +25,8 @@ from _local_package import load_local_package
 load_local_package()
 from omh.quality.routing_precision import ROUTING_INTERVENTION_CASES, ROUTING_PRECISION_CASES
 from omh.routing.chat import route_chat_message
+from omh.routing.policy import REALTIME_VOICE_CONNECTOR_READINESS_PHRASES
+from omh.routing.recommend import _WHOLE_PHRASE_ONLY_TRIGGER_TOKENS
 from omh.skills.catalog import builtin_definitions
 from omh.workflows.realtime_voice_trial_receipts import (
     ENVIRONMENT_FACETS,
@@ -679,6 +681,36 @@ class SeparatedStateTests(unittest.TestCase):
             "external tool trial for the weather plugin before adoption", source="discord"
         )
         self.assertNotIn("realtime_voice_trial", payload["chat_response"]["state"])
+
+    def test_the_memory_provider_lane_keeps_its_turns_when_voice_is_mentioned(self) -> None:
+        """Two capabilities share one readiness lane without sharing cards.
+
+        `external-connector-readiness` answers both realtime voice adoption
+        and optional memory-provider lifecycle, so a message naming one must
+        not acquire the other's card. Their vocabularies are disjoint -- the
+        memory lane's whole-phrase-only tokens and this lane's voice phrases
+        share no token -- and the direction at risk is a memory-provider
+        question that happens to say "voice": it reaches the lane, and it
+        stays a memory question.
+        """
+        for message in (
+            "memory provider readiness before we enable it",
+            "memory provider lifecycle and retention posture",
+            "memory provider readiness for the voice assistant",
+        ):
+            with self.subTest(message=message):
+                payload = build_chat_interaction_payload(message, source="discord")
+                self.assertEqual(payload["chat_response"]["kind"], "external_connector_readiness")
+                self.assertNotIn("realtime_voice_trial", payload["chat_response"]["state"])
+
+    def test_the_two_lanes_share_no_trigger_token(self) -> None:
+        held_back = _WHOLE_PHRASE_ONLY_TRIGGER_TOKENS["external-connector-readiness"]
+        voice_tokens = {
+            token
+            for phrase in REALTIME_VOICE_CONNECTOR_READINESS_PHRASES
+            for token in phrase.replace("-", " ").split()
+        }
+        self.assertEqual(voice_tokens & held_back, set())
 
 
 class NeighbouringRecordTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

Follow-up to #1435 (issue #1426), which merged while this guard was still in verification. Test-only; no production code changes.

### What Changed

Three assertions in `tests/test_realtime_voice_trial_receipts.py` pinning that the two adoption capabilities now sharing `external-connector-readiness` never trade turns.

### Why This Exists

`external-connector-readiness` answers two different adoption questions that arrived days apart: whether a realtime voice connector keeps whole spoken turns (#1426, PR #1435) and whether an optional memory provider is reversible (#1428, PR #1434). Both correctly land on the same readiness lane, and neither PR's tests could have covered the interaction, because when each was written the other did not exist. Nothing was pinning that a message naming one capability does not acquire the other's card.

### User / Operator Impact

None directly. This keeps a future change from silently making one capability answer the other's turns, which a reader would see as the wrong card on a correct-looking route.

### How It Works

The two vocabularies are disjoint today. #1434 holds twelve tokens back from this skill (`delete`, `disable`, `export`, `failure`, `lifecycle`, `memory`, `portability`, `posture`, `retention`, `switch`, `switching`, `sync`) and none appears in any realtime-voice phrase; one assertion now checks that intersection is empty rather than leaving it to inspection.

The direction actually at risk is a memory-provider question that happens to say "voice". It reaches the lane, and it must stay a memory question, so it is pinned by name alongside two plain memory-lifecycle phrasings. The mirror case, a voice trial question keeping its own card, is pinned too.

### Files And Contracts Touched

`tests/test_realtime_voice_trial_receipts.py` only. No contract, routing, catalog, or generated artifact changed.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite on the merge commit this branches from: `Ran 10535 tests`, `OK (skipped=1)`. The single skip is pre-existing.
- `tests/test_realtime_voice_trial_receipts.py`: 57 tests, all passing, including the three added here.
- Ruff, compileall, the byte gates, and `git diff --check` all pass; `drift_report()["ok"]` is true and no count or budget moved, since this adds no routing case, skill, or demo card.
- Routing probed directly across both lanes and `capability-toggle`: memory-lifecycle phrasings reach the lane without the voice marker, voice phrasings reach it with `direct:realtime_voice_connector_readiness`, and `capability-toggle` is unaffected.

### Not Tested / Not Applicable

- The release, smoke, and install-path commands were run on #1435 and nothing here touches installable output, packaging, or any generated artifact, so re-running them would re-observe that PR's evidence rather than this one's.
- Workflow-learning review queue smoke: no learning contract changed.
- Manual Hermes/TUI check: not run; this adds assertions over an existing chat-state projection and renders nothing new.
- No microphone, call, room, voice connector, speech provider, or tool action was executed or observed.

## Risk

Very low. Test-only, and every assertion passes against main as it stands, so this records current behavior rather than changing it. The exposure is the opposite one: if a future change legitimately merges the two lanes' vocabularies, these guards will need revisiting rather than silently loosening.

## Compatibility / Rollout

No runtime or contract change. Safe to revert on its own.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

## Follow-Up

Any further capability added to this lane needs the same disjointness check. The lane is shared; the cards are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkRnGrts5ZxhCKfTPQ9Ze8
