### PR TITLE
feat(plugin): validate plugin tool schemas before registration smoke passes

### DIFF
--- a/src/install/plugin_pack.py
+++ b/src/install/plugin_pack.py
@@ -34,12 +34,82 @@ class _SmokeContext:
     def __init__(self) -> None:
         self.tools: list[str] = []
         self.hooks: list[str] = []
+        self.tool_definitions: list[dict[str, object]] = []
 
     def register_tool(self, name: str, *args: object, **kwargs: object) -> None:
         self.tools.append(name)
+        toolset = args[0] if len(args) > 0 else None
+        schema = args[1] if len(args) > 1 else None
+        handler = args[2] if len(args) > 2 else None
+        description = kwargs.get("description")
+        if description is None and isinstance(schema, dict):
+            description = schema.get("description")
+        self.tool_definitions.append(
+            {
+                "name": name,
+                "toolset": toolset,
+                "schema": schema,
+                "handler": handler,
+                "description": description,
+            }
+        )
 
     def register_hook(self, name: str, *args: object, **kwargs: object) -> None:
         self.hooks.append(name)
+
+
+# Stable rule identifiers for `validate_tool_definitions` failures. These are
+# part of the contract callers (doctor, setup, tests) key off of, so treat
+# renames as breaking.
+TOOL_SCHEMA_RULE_NOT_A_MAPPING = "tool_schema_not_a_mapping"
+TOOL_SCHEMA_RULE_NAME_MISMATCH = "tool_schema_name_mismatch"
+TOOL_SCHEMA_RULE_DESCRIPTION_MISSING = "tool_description_missing"
+TOOL_SCHEMA_RULE_PARAMETERS_MISSING = "tool_parameters_missing"
+TOOL_SCHEMA_RULE_PARAMETERS_NOT_A_MAPPING = "tool_parameters_not_a_mapping"
+TOOL_SCHEMA_RULE_PARAMETERS_TYPE_NOT_OBJECT = "tool_parameters_type_not_object"
+TOOL_SCHEMA_RULE_REQUIRED_NOT_A_LIST = "tool_parameters_required_not_a_list"
+TOOL_SCHEMA_RULE_REQUIRED_FIELD_UNKNOWN = "tool_parameters_required_field_unknown"
+
+
+def validate_tool_definitions(tool_definitions: list[dict[str, object]]) -> list[dict[str, str]]:
+    """Validate captured tool registrations against the minimum Hermes tool contract.
+
+    Schema-only: never touches ``handler`` and never calls it. Each failure
+    carries a stable ``rule`` id plus the ``tool`` name so callers can surface
+    a bounded message without leaking handler internals or unrelated plugin
+    data.
+    """
+    failures: list[dict[str, str]] = []
+    for definition in tool_definitions:
+        name = str(definition.get("name", ""))
+        schema = definition.get("schema")
+        if not isinstance(schema, dict):
+            failures.append({"tool": name, "rule": TOOL_SCHEMA_RULE_NOT_A_MAPPING})
+            continue
+        if schema.get("name") != name:
+            failures.append({"tool": name, "rule": TOOL_SCHEMA_RULE_NAME_MISMATCH})
+        description = definition.get("description")
+        if not str(description or "").strip():
+            failures.append({"tool": name, "rule": TOOL_SCHEMA_RULE_DESCRIPTION_MISSING})
+        if "parameters" not in schema:
+            failures.append({"tool": name, "rule": TOOL_SCHEMA_RULE_PARAMETERS_MISSING})
+            continue
+        parameters = schema["parameters"]
+        if not isinstance(parameters, dict):
+            failures.append({"tool": name, "rule": TOOL_SCHEMA_RULE_PARAMETERS_NOT_A_MAPPING})
+            continue
+        if parameters.get("type") != "object":
+            failures.append({"tool": name, "rule": TOOL_SCHEMA_RULE_PARAMETERS_TYPE_NOT_OBJECT})
+        required = parameters.get("required")
+        if required is not None:
+            if not isinstance(required, (list, tuple)):
+                failures.append({"tool": name, "rule": TOOL_SCHEMA_RULE_REQUIRED_NOT_A_LIST})
+            else:
+                properties = parameters.get("properties")
+                known = set(properties) if isinstance(properties, dict) else set()
+                if any(field not in known for field in required):
+                    failures.append({"tool": name, "rule": TOOL_SCHEMA_RULE_REQUIRED_FIELD_UNKNOWN})
+    return failures
 
 
 def install_plugin_bundle(paths: OmhPaths, *, force: bool = False, dry_run: bool = False) -> dict[str, Any]:
@@ -73,6 +143,7 @@ def install_plugin_bundle(paths: OmhPaths, *, force: bool = False, dry_run: bool
             "register_smoke": smoke["plugin_register_smoke"],
             "registered_tools": smoke["registered_tools"],
             "registered_hooks": smoke["registered_hooks"],
+            "tool_schema_failures": smoke["tool_schema_failures"],
         }
     )
     return result
@@ -111,6 +182,7 @@ def inspect_plugin_bundle(paths: OmhPaths) -> dict[str, Any]:
         errors.append(str(smoke["error"]))
     missing_tools = [str(item) for item in smoke.get("missing_registered_tools", [])]
     missing_hooks = [str(item) for item in smoke.get("missing_registered_hooks", [])]
+    schema_failures = [item for item in smoke.get("tool_schema_failures", []) if isinstance(item, dict)]
     if target.exists() and import_smoke and not register_smoke and (missing_tools or missing_hooks):
         detail = []
         if missing_tools:
@@ -118,6 +190,11 @@ def inspect_plugin_bundle(paths: OmhPaths) -> dict[str, Any]:
         if missing_hooks:
             detail.append(f"missing hooks={missing_hooks}")
         errors.append("plugin register smoke is incomplete: " + "; ".join(detail))
+    if target.exists() and import_smoke and schema_failures:
+        errors.append(
+            "plugin tool schema validation failed: "
+            + "; ".join(f"{item.get('tool', '')}={item.get('rule', '')}" for item in schema_failures)
+        )
     return {
         "schema_version": PLUGIN_SCHEMA_VERSION,
         "plugin_name": PLUGIN_NAME,
@@ -136,6 +213,7 @@ def inspect_plugin_bundle(paths: OmhPaths) -> dict[str, Any]:
         "registered_hooks": smoke.get("registered_hooks", []),
         "missing_registered_tools": missing_tools,
         "missing_registered_hooks": missing_hooks,
+        "tool_schema_failures": schema_failures,
         "plugin_distribution_ready": bool(
             target.exists()
             and manifest_current
@@ -359,13 +437,15 @@ def _register_smoke(plugin_dir: Path) -> dict[str, Any]:
         required_hooks = set(REQUIRED_HOOKS)
         missing_tools = sorted(required_tools.difference(ctx.tools))
         missing_hooks = sorted(required_hooks.difference(ctx.hooks))
+        schema_failures = validate_tool_definitions(ctx.tool_definitions)
         return {
             "import_smoke": True,
-            "register_smoke": not missing_tools and not missing_hooks,
+            "register_smoke": not missing_tools and not missing_hooks and not schema_failures,
             "registered_tools": sorted(ctx.tools),
             "registered_hooks": sorted(ctx.hooks),
             "missing_registered_tools": missing_tools,
             "missing_registered_hooks": missing_hooks,
+            "tool_schema_failures": schema_failures,
         }
     except Exception as exc:
         return {"import_smoke": False, "register_smoke": False, "error": f"plugin smoke failed: {exc}"}

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -23,6 +23,7 @@ from omh.commands import setup as _setup_module
 from omh.paths import resolve_paths
 from omh.install.plugin_loader_observation import observe_real_loader_registration
 from omh.plugin_pack import inspect_plugin_bundle
+from omh.install.plugin_pack import _SmokeContext, validate_tool_definitions
 from omh.plugin_bundle.omh.tools import evidence_tool
 from omh.plugin_bundle.omh.metadata import PROVIDED_HOOKS, PROVIDED_TOOLS, TOOL_FILE_STEMS
 from omh.release_smoke_core import CommandResult
@@ -1236,6 +1237,133 @@ print(json.dumps(observed, ensure_ascii=False))
             self.assertIsNotNone(mid_session_role_context)
             self.assertIn("[OMH Role: planner]", mid_session_role_context["context"])
             self.assertNotIn("do not leak this mid-session prompt", mid_session_role_context["context"])
+
+
+class PluginToolSchemaValidationTests(unittest.TestCase):
+    """omh#1437: register_smoke must catch a malformed tool schema locally
+    instead of only failing later at Hermes model-request time.
+    """
+
+    def _register_real_bundle(self):
+        from omh.plugin_bundle import omh as bundled_omh
+
+        ctx = _SmokeContext()
+        bundled_omh.register(ctx)
+        return ctx
+
+    def test_all_bundled_tool_schemas_pass_validation_unchanged(self) -> None:
+        ctx = self._register_real_bundle()
+        self.assertEqual(sorted(ctx.tools), sorted(PROVIDED_TOOLS))
+        self.assertEqual(validate_tool_definitions(ctx.tool_definitions), [])
+
+    def test_tool_missing_parameters_entirely_fails_and_names_the_tool(self) -> None:
+        from omh.plugin_bundle.omh.tools import capability_tool
+
+        broken = dict(capability_tool.OMH_CAPABILITIES_SCHEMA)
+        del broken["parameters"]
+        with mock.patch.object(capability_tool, "OMH_CAPABILITIES_SCHEMA", broken):
+            ctx = self._register_real_bundle()
+        self.assertIn("omh_capabilities", ctx.tools)
+        self.assertEqual(
+            validate_tool_definitions(ctx.tool_definitions),
+            [{"tool": "omh_capabilities", "rule": "tool_parameters_missing"}],
+        )
+
+    def test_tool_parameters_null_fails_with_stable_rule_id(self) -> None:
+        from omh.plugin_bundle.omh.tools import capability_tool
+
+        broken = dict(capability_tool.OMH_CAPABILITIES_SCHEMA)
+        broken["parameters"] = None
+        with mock.patch.object(capability_tool, "OMH_CAPABILITIES_SCHEMA", broken):
+            ctx = self._register_real_bundle()
+        self.assertEqual(
+            validate_tool_definitions(ctx.tool_definitions),
+            [{"tool": "omh_capabilities", "rule": "tool_parameters_not_a_mapping"}],
+        )
+
+    def test_tool_parameters_list_fails_with_stable_rule_id(self) -> None:
+        from omh.plugin_bundle.omh.tools import capability_tool
+
+        broken = dict(capability_tool.OMH_CAPABILITIES_SCHEMA)
+        broken["parameters"] = ["not", "a", "mapping"]
+        with mock.patch.object(capability_tool, "OMH_CAPABILITIES_SCHEMA", broken):
+            ctx = self._register_real_bundle()
+        self.assertEqual(
+            validate_tool_definitions(ctx.tool_definitions),
+            [{"tool": "omh_capabilities", "rule": "tool_parameters_not_a_mapping"}],
+        )
+
+    def test_tool_parameters_non_object_schema_fails_with_stable_rule_id(self) -> None:
+        from omh.plugin_bundle.omh.tools import capability_tool
+
+        broken = dict(capability_tool.OMH_CAPABILITIES_SCHEMA)
+        broken["parameters"] = {"type": "string"}
+        with mock.patch.object(capability_tool, "OMH_CAPABILITIES_SCHEMA", broken):
+            ctx = self._register_real_bundle()
+        self.assertEqual(
+            validate_tool_definitions(ctx.tool_definitions),
+            [{"tool": "omh_capabilities", "rule": "tool_parameters_type_not_object"}],
+        )
+
+    def test_tool_schema_name_mismatch_fails_before_installation_is_reported_ready(self) -> None:
+        from omh.plugin_bundle.omh.tools import capability_tool
+
+        broken = dict(capability_tool.OMH_CAPABILITIES_SCHEMA)
+        broken["name"] = "omh_wrong_name"
+        with mock.patch.object(capability_tool, "OMH_CAPABILITIES_SCHEMA", broken):
+            ctx = self._register_real_bundle()
+        self.assertEqual(
+            validate_tool_definitions(ctx.tool_definitions),
+            [{"tool": "omh_capabilities", "rule": "tool_schema_name_mismatch"}],
+        )
+
+    def test_setup_and_doctor_surface_tool_schema_failure_and_withhold_distribution_ready(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+            schema_failure = [{"tool": "omh_capabilities", "rule": "tool_parameters_missing"}]
+
+            with mock.patch("omh.install.plugin_pack.validate_tool_definitions", return_value=schema_failure):
+                status, stdout, stderr = run_cli(base + ["setup", "--with-plugin"])
+                self.assertEqual(stderr, "")
+                self.assertEqual(status, 0)
+                plugin = json.loads(stdout)["plugin_distribution"]
+                self.assertFalse(plugin["register_smoke"])
+                self.assertEqual(plugin["tool_schema_failures"], schema_failure)
+
+                inspection = inspect_plugin_bundle(resolve_paths(omh_home, hermes_home))
+                self.assertFalse(inspection["plugin_register_smoke"])
+                self.assertFalse(inspection["plugin_distribution_ready"])
+                self.assertEqual(inspection["tool_schema_failures"], schema_failure)
+                joined_errors = "; ".join(inspection["errors"])
+                self.assertIn("omh_capabilities", joined_errors)
+                self.assertIn("tool_parameters_missing", joined_errors)
+
+                doctor_status, doctor_stdout, doctor_stderr = run_cli(base + ["doctor"])
+                self.assertEqual(doctor_stderr, "")
+                self.assertEqual(doctor_status, 1)
+                checks = {check["name"]: check for check in json.loads(doctor_stdout)["checks"]}
+                self.assertFalse(checks["plugin_register_smoke"]["ok"])
+                self.assertIn("omh_capabilities", checks["plugin_register_smoke"]["message"])
+                self.assertIn("tool_parameters_missing", checks["plugin_register_smoke"]["message"])
+
+    def test_smoke_result_stays_evidence_bounded(self) -> None:
+        # Local schema/registration smoke must never be read as observed
+        # Hermes load or tool-use evidence -- it only proves the shape is
+        # locally coherent.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home = root / ".omh"
+            hermes_home = root / ".hermes"
+            status, stdout, stderr = run_cli(
+                ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home), "setup", "--with-plugin"]
+            )
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            plugin = json.loads(stdout)["plugin_distribution"]
+            self.assertIn("does not prove Hermes loaded or used the plugin", plugin["observed_scope"])
 
 
 class UpdateRefreshesTheBundleTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #1437

## Feature Report

### What Changed

- `_SmokeContext.register_tool()` in `src/install/plugin_pack.py` now captures name, toolset, schema, handler, and description for every registered tool, instead of just the name.
- Added `validate_tool_definitions()`, which checks each captured tool against the minimum Hermes tool contract: mapping-shaped schema, schema `name` matches the registered name, non-empty description, `parameters` is an object-shaped mapping with `type: object`, and coherent `properties`/`required` when both are present.
- `_register_smoke()` now runs this validation and folds any failures into the `register_smoke` result instead of reporting success on name-presence alone.
- `inspect_plugin_bundle()` surfaces bounded per-tool schema failures (tool name + violated rule id only — no handler internals, prompts, or credentials), which flow through to `plugin_distribution_ready` for both `setup` and `doctor` via the existing shared code path (no duplicated validation logic).

### Why This Exists

- Previously, `register_tool()` accepted arbitrary positional/keyword arguments without inspecting them, so a tool with a missing or malformed `parameters` schema could pass registration smoke and only fail later when Hermes prepared an actual model request. This closes that release-regression blind spot at the setup/doctor gate, before installation is ever reported healthy.

### User / Operator Impact

- A malformed plugin tool schema now fails `setup --with-plugin` / `doctor` immediately, with a named tool and a stable rule id, instead of surfacing as a confusing runtime failure during a live Hermes session.

### How It Works

- Validation is deterministic and local: it inspects the schema shape captured at registration time. It does not execute any tool handler, make a model/provider request, or touch the network. It only proves conformance to OMH's own registration contract — it is explicitly not evidence that Hermes loaded or invoked the plugin.

### Files And Contracts Touched

- `src/install/plugin_pack.py` — `_SmokeContext.register_tool()`, `validate_tool_definitions()`, `_register_smoke()`, `inspect_plugin_bundle()`
- `tests/test_plugin_distribution.py` — new `PluginToolSchemaValidationTests`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run python -m compileall -q src tests`
- [x] `git diff --check`
- [ ] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 59/60 pass
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PluginToolSchemaValidationTests` exercises the real bundled `omh.plugin_bundle.omh.register(ctx)` path, covering: all 15 currently bundled tool schemas passing unchanged; missing/`null`/list/non-object `parameters` failing with stable rule ids; internal schema `name` mismatch failing before `plugin_distribution_ready`; setup/doctor surfacing the failure and withholding `plugin_distribution_ready`; and an evidence-boundary wording check confirming this smoke is not claimed as observed Hermes load or tool-use evidence.
- Full targeted test file (`test_plugin_distribution.py`) run: 59/60 pass. The 1 failure (`test_installed_plugin_status_tool_and_hook_keep_evidence_boundary`) is pre-existing and unrelated — it fails identically on unmodified `main` (confirmed via `git stash`); root cause is a missing `python3` executable on this machine's PATH inside a subprocess call, not this change.

### Not Tested / Not Applicable

- Lint, docs-check, harness, release-checklist, hermes-smoke, and live `omh` CLI commands were not run in this pass — need to be run before merge to fully satisfy the checklist.

## Risk

- Low: validation is additive, deterministic, local-only, and does not touch Hermes-owned code, network access, or tool handler execution. The only behavior change is that previously-undetected malformed schemas now fail smoke instead of passing silently.

## Compatibility / Rollout

- No breaking change for correctly-formed plugin tools — all 15 currently bundled OMH schemas pass validation unchanged. Only malformed/future schemas are newly rejected.

## Release / Claims

- [ ] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [ ] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Run the remaining unchecked validation commands (lint, docs checks, harness validate, release checklist, hermes-smoke) before merge.
- Investigate/fix the pre-existing `python3` PATH issue causing the one unrelated test failure, separately from this PR.