### PR TITLE
test(egress): promptness guards assert mechanism, not wall clock

### DIFF
--- a/tests/test_egress_attempt_receipts.py
+++ b/tests/test_egress_attempt_receipts.py
@@ -9,8 +9,8 @@ import sys
 import time
 import unittest
 from abc import ABC
-from collections.abc import Callable, Mapping
-from contextlib import closing
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import closing, contextmanager
 from dataclasses import dataclass, field
 from functools import cached_property, partial
 from pathlib import Path
@@ -100,6 +100,50 @@ class AttemptRequest(TypedDict):
     payload_bytes: int
     idempotency_key: str | None
     approval_ref: str | None
+
+
+BUSY_BUDGET_MILLISECONDS = 10
+BUSY_BUDGET_SECONDS = BUSY_BUDGET_MILLISECONDS / 1000
+
+
+@contextmanager
+def _bounded_by_configured_budget(
+    test: unittest.TestCase,
+    *,
+    connections: int,
+    factory: type[sqlite3.Connection] | None = None,
+) -> Iterator[None]:
+    """Bound a failure path by its mechanism rather than by a measured duration.
+
+    These paths must return without waiting: no retry loop, no backoff sleep,
+    no wait longer than the configured contention budget. Those are properties
+    of the code, so this asserts them directly: the exact number of SQLite
+    connections the path opens, the busy budget each one carries (the same
+    budget ``test_connections_use_ten_millisecond_busy_budget`` pins as a
+    ``PRAGMA``), and that nothing slept. Reading a clock instead would assert
+    the same properties only on an idle machine, so a loaded shared runner
+    reports a false failure.
+    """
+    connect = sqlite3.connect
+    budgets: list[float] = []
+
+    def recording_connect(
+        database: Path, *, timeout: float, isolation_level: None
+    ) -> sqlite3.Connection:
+        budgets.append(timeout)
+        if factory is None:
+            return connect(database, timeout=timeout, isolation_level=isolation_level)
+        return connect(
+            database, timeout=timeout, isolation_level=isolation_level, factory=factory
+        )
+
+    with (
+        patch.object(sqlite3, "connect", side_effect=recording_connect),
+        patch.object(time, "sleep") as sleeper,
+    ):
+        yield
+    sleeper.assert_not_called()
+    test.assertEqual(budgets, [BUSY_BUDGET_SECONDS] * connections)
 
 
 def _digest(value: str) -> str:
@@ -213,15 +257,13 @@ class EgressAttemptStoreTests(unittest.TestCase):
         _ = self.store.open_attempt(**_request("seed"))
         with closing(sqlite3.connect(self.store.database_path)) as holder:
             _ = holder.execute("BEGIN IMMEDIATE")
-            started = time.monotonic()
-            with self.assertRaises(receipt_module.AttemptStoreError):
-                _ = self.store.open_attempt(**_request("blocked"))
-            elapsed = time.monotonic() - started
+            with _bounded_by_configured_budget(self, connections=1):
+                with self.assertRaises(receipt_module.AttemptStoreError):
+                    _ = self.store.open_attempt(**_request("blocked"))
             holder.rollback()
 
         with self.assertRaises(sqlite3.ProgrammingError):
             _ = holder.execute("SELECT 1")
-        self.assertLess(elapsed, 0.1)
         self.assertEqual(len(self.store.public_rows()), 1)
 
     def test_connections_use_ten_millisecond_busy_budget(self) -> None:
@@ -230,7 +272,10 @@ class EgressAttemptStoreTests(unittest.TestCase):
                 connection, created = SchemaProbe.connect(self.store)
                 with closing(connection):
                     self.assertEqual(created, cold)
-                    self.assertEqual(connection.execute("PRAGMA busy_timeout").fetchone(), (10,))
+                    self.assertEqual(
+                        connection.execute("PRAGMA busy_timeout").fetchone(),
+                        (BUSY_BUDGET_MILLISECONDS,),
+                    )
                     self.assertEqual(connection.execute("PRAGMA synchronous").fetchone(), (2,))
                     self.assertEqual(connection.execute("PRAGMA journal_mode").fetchone(), ("delete",))
                     self.assertEqual(connection.execute("PRAGMA foreign_keys").fetchone(), (1,))
@@ -528,25 +573,20 @@ class EgressAttemptStoreTests(unittest.TestCase):
 
         handler = Mock()
         wrapper, args, _, _ = self._registered_handler(handler)
-        connect = sqlite3.connect
         platform_os = Mock(wraps=os)
         platform_os.name = "nt"
         with (
             patch.object(receipt_module, "os", platform_os),
-            patch.object(sqlite3, "connect", side_effect=partial(connect, factory=FailedCommit)),
+            _bounded_by_configured_budget(self, connections=1, factory=FailedCommit),
         ):
             self.assertFalse(self.store.database_path.exists())
-            started = time.monotonic()
             result = wrapper(args, session_id="session-1")
-            elapsed = time.monotonic() - started
         self.assertIn("error", _response(result))
         handler.assert_not_called()
-        self.assertLess(elapsed, 0.1)
         self.assertEqual(commits, ["schema", "attempt"])
         self.assertEqual(self.store.public_rows(), [])
 
     def test_posix_directory_failures_block_handler_after_commit(self) -> None:
-        native_posix = os.name == "posix"
         for operation in ("open", "fsync"):
             with self.subTest(operation=operation):
                 self.home = Path(self.temporary.name) / operation
@@ -563,20 +603,16 @@ class EgressAttemptStoreTests(unittest.TestCase):
                 platform_os.name = "posix"
                 failed_operation = {"open": directory_open, "fsync": directory_fsync}[operation]
                 failed_operation.side_effect = OSError("injected directory failure")
-                with patch.object(receipt_module, "os", platform_os):
-                    started = time.monotonic()
+                with (
+                    patch.object(receipt_module, "os", platform_os),
+                    _bounded_by_configured_budget(self, connections=1),
+                ):
                     result = wrapper(args, session_id="session-1")
-                    elapsed = time.monotonic() - started
                     failed_operation.assert_called_once()
                     if operation == "fsync":
                         directory_close.assert_called_once_with(123)
                 self.assertIn("error", _response(result))
                 handler.assert_not_called()
-                # Semantic faults run everywhere; this POSIX-only operation's
-                # physical latency is measured only on its native platform.
-                # The native Windows cold-failure deadline remains separate.
-                if native_posix:
-                    self.assertLess(elapsed, 0.1)
                 rows = self.store.public_rows()
                 self.assertEqual([row["row_type"] for row in rows], ["attempt"])
                 # A committed-but-unconfirmed attempt remains unresolved, never replayable.


### PR DESCRIPTION
## Feature Report

### What Changed

- Every wall-clock promptness assertion in `tests/test_egress_attempt_receipts.py` is replaced by an assertion on the mechanism that actually makes those paths prompt. Three `time.monotonic()` / `assertLess(elapsed, 0.1)` pairs are gone, and no `time.monotonic()` call remains in the module.
- A new module-level context manager, `_bounded_by_configured_budget`, wraps each failure path and pins three facts: the exact number of SQLite connections the path opens, the busy budget every one of those connections carries, and that `time.sleep` was never called.
- The ten-millisecond busy budget is now a named constant shared by the new guard and `test_connections_use_ten_millisecond_busy_budget`, so the guard's bound and the `PRAGMA` it derives from cannot drift apart.
- No production code changed. `src/plugin_bundle/omh/egress_attempt_receipts.py` and `src/plugin_bundle/omh/egress_attempts.py` are untouched.

### Why This Exists

The three guards measured how long a real call took on the machine running them. That is a property of the runner, not of the code under test, so the tests failed under CI contention on branches that had nothing to do with this module. Observed twice in one afternoon:

- PR #1438, [test-windows shard 0](https://github.com/rlaope/oh-my-hermes/actions/runs/34348403167/job/102455495813): `test_windows_commit_failure_blocks_handler_and_does_not_mint_attempt` failed at `self.assertLess(elapsed, 0.1)` with a measured `0.18700000000001182`.
- PR #1431, first CI attempt, same module: 0.375s on Linux and 0.109s on Windows. A re-run with no code change was clean.

Both branches were test-only or unrelated to egress receipts. A test that a clean re-run fixes is a test that stops being read, and these particular guards are worth reading: they are what stops a durability failure from being papered over with a retry.

### User / Operator Impact

None at runtime. The egress attempt-receipt behaviour is unchanged. The impact is on the repo: CI stops producing red builds that carry no information, and the promptness guards keep their meaning instead of being widened or dropped the next time contention spikes.

### How It Works

The production code was read first to establish what actually bounds these paths. `AttemptStore` has no retry loop, no backoff, and no sleep. What bounds it is `sqlite3.connect(..., timeout=0.01)` in `_connect`: a ten-millisecond busy budget, deliberately three orders below SQLite's five-second default, with a comment in the source explaining that it is a retry budget and not a whole-operation deadline. So the promptness the guards were protecting reduces to exactly three code properties:

1. the path opens a fixed, small number of connections, so no retry loop reconnects;
2. each connection carries the configured budget, so no wait can grow to the SQLite default;
3. nothing sleeps, so no backoff is inserted above SQLite.

`_bounded_by_configured_budget` asserts all three. It patches `sqlite3.connect` to record each call's `timeout` kwarg, optionally composing the caller's `Connection` factory so the Windows commit-failure test keeps its injected fault, and patches `time.sleep` to a mock that must never be called. On exit it asserts the recorded budgets equal `[BUSY_BUDGET_SECONDS] * connections`.

The three call sites all pass `connections=1`, which is the real count for each: one `_connect()` per `open_attempt`. The Windows test additionally keeps its existing `commits == ["schema", "attempt"]` assertion, which was already an exact commit-attempt count and is unchanged.

The POSIX directory test gains coverage rather than losing it. Its wall-clock bound was previously asserted only under `if native_posix:`, because elapsed time on a simulated platform is meaningless. The mechanism assertion is platform-independent, so that guard now runs on Windows shards too.

### Files And Contracts Touched

- `tests/test_egress_attempt_receipts.py` — the only changed file. New helper `_bounded_by_configured_budget` and constants `BUSY_BUDGET_MILLISECONDS` / `BUSY_BUDGET_SECONDS`; three guards rewritten; `test_connections_use_ten_millisecond_busy_budget` now reads the shared constant instead of a literal `10`.
- No contract, catalog, routing, or generated artifact is involved. No count or budget totals moved.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

Test-only. The module under test is the Hermes registry egress guard, but nothing about its behaviour or its installed surface changes.

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

Also run and green, beyond the template list: `uv run python -m omh.cli docs claims --check --json`, `uv run python -m omh.cli docs ulw-inventory --check`, `uv run python -m omh.cli docs ulw-site --check`.

### Observed Evidence

- Full suite: `Ran 10563 tests in 782.992s` — `OK (skipped=1)`. The single skip is pre-existing and is not in the touched module; this diff adds no `skip`, `xfail`, or quarantine marker.
- Touched module: 18 tests, `OK`.
- **Determinism.** 30 consecutive runs of `tests/test_egress_attempt_receipts.py`: 30 passed, 0 failed.
- **The flake reproduces locally, and the fix survives it.** On a 14-core machine, with 48 CPU-burning processes running and the test process at `nice -n 20`:
  - the guards as they stand on `main` failed 1 run in 12, with `AssertionError: 0.14753679200657643 not less than 0.1` — the same assertion and the same shape as the PR #1438 failure;
  - the guards in this PR passed 20 out of 20 under that same load, and 10 out of 10 under a lighter 8-way load.
- **The guards still catch what they are for.** Three defects were seeded into `AttemptStore` one at a time. Each turned all three guards red (4 failures: three tests, one of which has two subtests), and each was reverted, leaving the production module byte-identical:

| Seeded defect | Result |
| --- | --- |
| `time.sleep(0.5)` backoff before `sqlite3.connect` in `_connect` | 4 failures, `Calls: [call(0.5)]` |
| busy budget widened from `timeout=0.01` to `timeout=5.0` | 4 failures |
| reconnect retry loop around `sqlite3.connect` in `_connect` | 4 failures |

  The second seed is the exact regression the original assertion existed to catch, and it is the one a mechanism assertion is most often accused of missing. It does not miss it: the connect timeout is recorded per call and compared to the configured budget.

### Not Tested / Not Applicable

- `omh --help` and the isolated-home install smoke: no installer, CLI surface, or packaged artifact is touched by a change confined to one test module.
- Workflow-learning review queue smoke: no learning contract changed.
- Manual Hermes/TUI check: not run, and not applicable. The change is a test module; nothing reaches an installed profile, a plugin manifest, or a TUI widget.
- No Windows or Linux runner was exercised locally. The claim that the POSIX test's guard now also runs on Windows rests on the assertions being platform-independent by construction, not on an observation. CI on this PR is the first observation of them on those shards.
- The local load reproduction is evidence that these assertions are clock-dependent under contention, not a measurement of the CI runners themselves. The CI evidence for that is the two linked failures.

## Risk

Low, and bounded to test code. The one thing worth naming: the new guard is stricter than the old one about connection count, so a future change that legitimately opens a second connection on one of these paths will fail here. That is intended. The failure message points at the exact count, and the fix is to update the count deliberately after deciding the second connection is correct — not to widen a threshold, which is how the old guard would have absorbed the same change silently.

`time.sleep` is patched process-wide inside the guarded window. These tests are single-threaded and nothing in the window sleeps legitimately, but a future test that needs a real sleep inside the window would need to say so.

## Compatibility / Rollout

No compatibility surface. No behaviour change, no schema change, no generated artifact, no dependency. Nothing to roll out.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; test-only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap — `release hermes-smoke` ran in plan mode and reports its own boundary that plan mode is not evidence of a Hermes install; `--live` was not run and is not applicable to a test-only change.

## Follow-Up

- No tracking issue was opened for this flake before the fix; the evidence is the two CI runs linked above. If the coordinator wants one for the record, it can be filed and closed against this PR.
- A sweep of `tests/` for the same pattern found two other wall-clock bounds, both left alone as out of scope for this flake: `tests/test_fanout_signal_safety.py:372` asserts under 25 seconds and `tests/test_fanout_dispatch.py:4656` under 30 seconds. Both wrap real subprocess dispatch, and a bound two to three orders of magnitude above the work is a hang detector rather than a promptness guard, so neither carries the contention sensitivity that a 0.1-second bound does. Neither has been observed flaking. Reporting them, not changing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkRnGrts5ZxhCKfTPQ9Ze8
