### PR TITLE
fix(install): an omh update survives a symlinked plugin directory

### DIFF
--- a/src/install/installer.py
+++ b/src/install/installer.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from ..core.errors import OmhError
 from ..converter import convert_from_dir, convert_references_from_dir
-from ..local_store import atomic_write_text, read_json_object_result
+from ..local_store import atomic_write_text, discard_path, is_directory_link, read_json_object_result
 from ..manifest import local_modifications, new_manifest, read_manifest, skill_records, write_manifest
 from ..paths import (
     OmhPaths,
@@ -891,7 +891,7 @@ def _collect_removal(
     force: bool,
     managed_plugin: bool = False,
 ) -> None:
-    if not path.exists() and not path.is_symlink():
+    if not path.exists() and not is_directory_link(path):
         return
     if managed_plugin and not _looks_like_managed_plugin(path):
         decision = resolve_approval_tier(
@@ -903,10 +903,7 @@ def _collect_removal(
     if dry_run:
         would_remove.append(str(path))
         return
-    if path.is_dir() and not path.is_symlink():
-        shutil.rmtree(path)
-    else:
-        path.unlink()
+    discard_path(path)
     removed.append(str(path))
 
 

--- a/src/install/plugin_pack.py
+++ b/src/install/plugin_pack.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib.resources as resources
 import importlib.util
-import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,7 +9,7 @@ from typing import Any
 
 from ..version import __version__
 from ..hashutil import sha256_file, sha256_text
-from ..local_store import atomic_write_json, ensure_dir, read_json_object, utc_now
+from ..local_store import atomic_write_json, discard_path, ensure_dir, is_directory_link, read_json_object, utc_now
 from ..paths import OmhPaths
 from ..plugin_bundle.omh.metadata import PROVIDED_HOOKS, PROVIDED_TOOLS, REQUIRED_HOOKS
 
@@ -117,7 +116,11 @@ def install_plugin_bundle(paths: OmhPaths, *, force: bool = False, dry_run: bool
     source_records = bundled_plugin_records()
     existing_manifest = read_plugin_manifest(target)
     dirty = plugin_local_modifications(existing_manifest, target)
-    unmanaged = target.exists() and existing_manifest is None
+    # `is_directory_link` as well as `exists`: `Path.exists` follows the link,
+    # so a dangling plugin symlink or junction reads as absent and would slip
+    # past the ownership guard into the replacement path without --force. The
+    # guard asks whether anything occupies the path OMH cannot prove it wrote.
+    unmanaged = (target.exists() or is_directory_link(target)) and existing_manifest is None
     if unmanaged and not force:
         raise PluginPackError(f"{target} exists without an OMH plugin manifest; use --force to replace it")
     if dirty and not force:
@@ -335,17 +338,22 @@ def _copy_plugin_bundle(target: Path, file_records: list[dict[str, str]]) -> Non
     tmp = parent / f".{target.name}.installing"
     backup = parent / f".{target.name}.previous"
     ensure_dir(parent)
-    shutil.rmtree(tmp, ignore_errors=True)
-    shutil.rmtree(backup, ignore_errors=True)
+    # `discard_path`, not `shutil.rmtree`: an older OMH layout symlinked the
+    # plugin directory at a shared location, and rmtree cannot unlink a
+    # symlink. The renamed-aside `.omh.previous` link therefore survived every
+    # update, and the next update's `target.rename(backup)` hit ENOTDIR
+    # because rename(2) refuses to rename a directory over a non-directory.
+    discard_path(tmp, ignore_errors=True)
+    discard_path(backup, ignore_errors=True)
     try:
         _copy_resource_tree(root, tmp)
         atomic_write_json(tmp / PLUGIN_MANAGED_MANIFEST, _new_plugin_manifest(target, file_records))
         if target.exists():
             target.rename(backup)
         tmp.rename(target)
-        shutil.rmtree(backup, ignore_errors=True)
+        discard_path(backup, ignore_errors=True)
     except OSError:
-        shutil.rmtree(tmp, ignore_errors=True)
+        discard_path(tmp, ignore_errors=True)
         if backup.exists() and not target.exists():
             backup.rename(target)
         raise

--- a/src/install/plugin_pack.py
+++ b/src/install/plugin_pack.py
@@ -348,13 +348,25 @@ def _copy_plugin_bundle(target: Path, file_records: list[dict[str, str]]) -> Non
     try:
         _copy_resource_tree(root, tmp)
         atomic_write_json(tmp / PLUGIN_MANAGED_MANIFEST, _new_plugin_manifest(target, file_records))
-        if target.exists():
+        # `is_directory_link` as well as `exists`, for the same reason the
+        # ownership guard needs it: a dangling link occupies the path while
+        # `exists()` reports it absent. Skipping the rename-aside for it leaves
+        # `tmp.rename(target)` renaming a directory over a link, which is the
+        # ENOTDIR this change exists to stop -- so --force could not repair the
+        # very machine the guard tells the operator to repair with it. The
+        # guard has already established that OMH owns the path or that --force
+        # was given.
+        if target.exists() or is_directory_link(target):
             target.rename(backup)
         tmp.rename(target)
         discard_path(backup, ignore_errors=True)
     except OSError:
         discard_path(tmp, ignore_errors=True)
-        if backup.exists() and not target.exists():
+        # The rollback asks about links too, or it skips the one case it must
+        # not skip. A dangling link renamed aside answers False to
+        # `backup.exists()`, so without this the operator's link would be gone
+        # and `.omh.previous` would be left holding it.
+        if (backup.exists() or is_directory_link(backup)) and not (target.exists() or is_directory_link(target)):
             backup.rename(target)
         raise
 

--- a/src/install/self_update_platform.py
+++ b/src/install/self_update_platform.py
@@ -10,10 +10,10 @@ from typing import Literal, Protocol
 
 try:
     from ..core.errors import OmhError
-    from ..system.local_store import atomic_write_text
+    from ..system.local_store import atomic_write_text, is_directory_link, is_junction
 except ImportError:  # pragma: no cover - direct-source installer smoke.
     from core.errors import OmhError
-    from system.local_store import atomic_write_text
+    from system.local_store import atomic_write_text, is_directory_link, is_junction
 
 
 JUNCTION_TIMEOUT_SECONDS = 15.0
@@ -62,7 +62,7 @@ class SelfUpdatePlatform:
         return venv / ("Scripts" if self.is_windows else "bin")
 
     def link_target(self, root: Path, link: Path) -> Path | None:
-        if not _is_directory_link(link):
+        if not is_directory_link(link):
             return None
         try:
             raw = os.readlink(link)
@@ -127,20 +127,15 @@ class SelfUpdatePlatform:
         atomic_write_text(launcher, f'@echo off\r\n"{_windows_spelling(target)}" %*\r\n')
 
 
-def _is_junction(path: Path) -> bool:
-    is_junction = getattr(path, "is_junction", None)
-    return bool(is_junction and is_junction())
-
-
-def _is_directory_link(path: Path) -> bool:
-    return path.is_symlink() or _is_junction(path)
-
-
 def _remove_directory_link(path: Path) -> None:
-    is_junction = _is_junction(path)
-    if not path.exists() and not path.is_symlink() and not is_junction:
+    # `is_junction` / `is_directory_link` come from `local_store` so that the
+    # generation-pointer seam here and the plugin-install cleanup share one
+    # answer to "is this entry a link?". Two answers is how a junction ends up
+    # walked as a directory on Windows.
+    junction = is_junction(path)
+    if not path.exists() and not path.is_symlink() and not junction:
         return
-    if is_junction:
+    if junction:
         path.rmdir()
     else:
         path.unlink()
@@ -151,7 +146,7 @@ remove_directory_link = _remove_directory_link
 
 def _replace_windows_pointer(temporary: Path, current: Path, backup: Path) -> None:
     """Switch a junction pair without replacing an existing junction in place."""
-    had_current = _is_directory_link(current)
+    had_current = is_directory_link(current)
     if current.exists() and not had_current:
         raise OSError(f"current generation pointer is not a directory junction: {current}")
     if had_current:
@@ -159,7 +154,7 @@ def _replace_windows_pointer(temporary: Path, current: Path, backup: Path) -> No
     try:
         os.replace(temporary, current)
     except OSError:
-        if had_current and _is_directory_link(backup) and not _is_directory_link(current):
+        if had_current and is_directory_link(backup) and not is_directory_link(current):
             os.replace(backup, current)
         raise
     if had_current:

--- a/src/system/local_store.py
+++ b/src/system/local_store.py
@@ -5,6 +5,7 @@ import json
 import os
 import random
 import secrets
+import shutil
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -40,6 +41,58 @@ def ensure_dir(path: Path, *, private: bool = False) -> None:
     path.mkdir(parents=True, exist_ok=True)
     if private:
         path.chmod(0o700)
+
+
+def is_junction(path: Path) -> bool:
+    """True when *path* is a Windows directory junction.
+
+    ``Path.is_junction`` only ever returns True on Windows, so the probe is
+    fetched by name rather than called directly.
+    """
+    probe = getattr(path, "is_junction", None)
+    return bool(probe and probe())
+
+
+def is_directory_link(path: Path) -> bool:
+    """True when *path* is a symlink or a Windows directory junction.
+
+    A directory link answers True to ``is_dir()`` when it resolves and False
+    when it dangles, so every removal or replacement decision has to ask about
+    the link itself before it asks about the link's target.
+    """
+    return path.is_symlink() or is_junction(path)
+
+
+def discard_path(path: Path, *, ignore_errors: bool = False) -> None:
+    """Remove *path* whatever it is: symlink, junction, file, or directory.
+
+    ``shutil.rmtree`` cannot remove a symbolic link. It descends into the
+    link's target, fails, and with ``ignore_errors=True`` leaves the link in
+    place without a word. A leftover link at a path an install is about to
+    rename over then breaks that rename, because ``rename(2)`` refuses to
+    rename a directory over a non-directory (``ENOTDIR``). Removal therefore
+    has to dispatch on the entry type, and a directory link has to be unlinked
+    as a link rather than walked as a directory.
+
+    ``ignore_errors`` mirrors ``shutil.rmtree``'s flag and extends it to the
+    unlink branches, so a best-effort pre-clean stays best-effort for every
+    entry type instead of only for real directories. A missing path is always
+    a no-op.
+    """
+    if path.is_dir() and not is_directory_link(path):
+        shutil.rmtree(path, ignore_errors=ignore_errors)
+        return
+    if not path.exists() and not is_directory_link(path):
+        return
+    try:
+        if is_junction(path):
+            # A junction is a directory entry; unlink refuses it on Windows.
+            path.rmdir()
+        else:
+            path.unlink()
+    except OSError:
+        if not ignore_errors:
+            raise
 
 
 def ensure_file(path: Path, *, private: bool = False) -> None:

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -1533,10 +1533,48 @@ class SymlinkedPluginDirectoryTests(unittest.TestCase):
             self.assertTrue(bundle.is_symlink())
             self.assertFalse(bundle.exists())
 
-            status, _, stderr = run_cli(base + ["update"])
+            status, stdout, stderr = run_cli(base + ["update"])
             self.assertEqual(status, 0, stderr)
             self.assertTrue(bundle.is_symlink())
             self.assertEqual(os.readlink(bundle), str(shared))
+            self.assertIn("use --force to replace it", stdout + stderr)
+
+    def test_a_dangling_plugin_link_is_replaced_with_force(self) -> None:
+        # The other half of that guard, and the reason the replacement asks
+        # `is_directory_link` and not only `exists`. The note above tells the
+        # operator that --force is the remedy; when --force then died on
+        # `rename(dir, symlink)` with ENOTDIR, the guard was naming a remedy
+        # that did not exist.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, _, stderr = run_cli(base + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            bundle, shared = self._link_bundle_to_shared(root)
+            shutil.rmtree(shared)
+
+            status, _, stderr = run_cli(base + ["update", "--force"])
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(bundle.is_symlink())
+            self.assertTrue((bundle / "memory_provider.py").is_file())
+            self.assertFalse((bundle.parent / ".omh.previous").is_symlink())
+            self.assertFalse((bundle.parent / ".omh.previous").exists())
+
+    def _rename_failing_into(self, target: Path) -> Any:
+        """Patch for `Path.rename` that fails only the install of the new tree.
+
+        The rollback renames `.omh.previous` back onto the same target, so the
+        source name is what separates the two -- matching on the destination
+        alone would break the rollback this is meant to exercise.
+        """
+        real_rename = Path.rename
+
+        def failing_rename(self: Path, dest: Any) -> Path:
+            if self.name.endswith(".installing") and Path(dest) == target:
+                raise OSError(errno.EXDEV, "forced install failure")
+            return real_rename(self, dest)
+
+        return failing_rename
 
     def test_a_failed_rename_restores_a_symlinked_bundle(self) -> None:
         # The rollback is the whole reason the replacement renames aside rather
@@ -1554,15 +1592,7 @@ class SymlinkedPluginDirectoryTests(unittest.TestCase):
             paths = resolve_paths(omh_home, hermes_home)
             target = paths.hermes_plugin_dir
 
-            real_rename = Path.rename
-
-            def failing_rename(self: Path, dest: Any) -> Path:
-                # Fail only the install of the new tree, never the rollback.
-                if self.name.endswith(".installing") and Path(dest) == target:
-                    raise OSError(errno.EXDEV, "forced install failure")
-                return real_rename(self, dest)
-
-            with mock.patch.object(Path, "rename", failing_rename):
+            with mock.patch.object(Path, "rename", self._rename_failing_into(target)):
                 with self.assertRaises(OSError):
                     install_plugin_bundle(paths)
 
@@ -1570,6 +1600,33 @@ class SymlinkedPluginDirectoryTests(unittest.TestCase):
             self.assertEqual(os.readlink(target), str(shared))
             self.assertFalse((target.parent / ".omh.previous").exists())
             self.assertFalse((target.parent / ".omh.previous").is_symlink())
+            self.assertFalse((target.parent / ".omh.installing").exists())
+
+    def test_a_failed_rename_restores_a_dangling_plugin_link(self) -> None:
+        # The case the rollback could not see. A dangling link renamed aside to
+        # `.omh.previous` answers False to `backup.exists()`, so reading it as
+        # absent leaves the target gone and the operator's link stranded under
+        # the backup name -- the one outcome the error message cannot help them
+        # undo, because it never names where the link went.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home, hermes_home = root / ".omh", root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+            status, _, stderr = run_cli(base + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            _, shared = self._link_bundle_to_shared(root)
+            shutil.rmtree(shared)
+            paths = resolve_paths(omh_home, hermes_home)
+            target = paths.hermes_plugin_dir
+
+            with mock.patch.object(Path, "rename", self._rename_failing_into(target)):
+                with self.assertRaises(OSError):
+                    install_plugin_bundle(paths, force=True)
+
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(os.readlink(target), str(shared))
+            self.assertFalse((target.parent / ".omh.previous").is_symlink())
+            self.assertFalse((target.parent / ".omh.previous").exists())
             self.assertFalse((target.parent / ".omh.installing").exists())
 
 

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
+import errno
 import hashlib
 import importlib.resources as resources
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tomllib
 import unittest
 from types import ModuleType
+from typing import Any
 from unittest import mock
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from _cli_harness import run_cli
 from _local_package import load_local_package
+from _platform_support import requires_symlinks
 
 load_local_package()
 
@@ -23,7 +27,7 @@ from omh.commands import setup as _setup_module
 from omh.paths import resolve_paths
 from omh.install.plugin_loader_observation import observe_real_loader_registration
 from omh.plugin_pack import inspect_plugin_bundle
-from omh.install.plugin_pack import _SmokeContext, validate_tool_definitions
+from omh.install.plugin_pack import _SmokeContext, install_plugin_bundle, validate_tool_definitions
 from omh.plugin_bundle.omh.tools import evidence_tool
 from omh.plugin_bundle.omh.metadata import PROVIDED_HOOKS, PROVIDED_TOOLS, TOOL_FILE_STEMS
 from omh.release_smoke_core import CommandResult
@@ -1441,6 +1445,132 @@ class UpdateRefreshesTheBundleTests(unittest.TestCase):
             status, _, stderr = run_cli(base + ["update"])
             self.assertEqual(status, 0, stderr)
             self.assertEqual(marker.read_text(encoding="utf-8"), "# edited outside OMH\n")
+
+
+@requires_symlinks
+class SymlinkedPluginDirectoryTests(unittest.TestCase):
+    """A plugin directory that is a link, not a directory (issue from PR #1430).
+
+    An older OMH layout pointed a bot profile's `plugins/omh` at a shared
+    location with a symlink. `_copy_plugin_bundle` renamed that link aside to
+    `.omh.previous` and then cleaned up with `shutil.rmtree(..., ignore_errors=True)`,
+    which cannot unlink a symlink: it descends into the target, fails, and says
+    nothing. The stale link survived, and the next update's
+    `target.rename(backup)` hit `rename(dir, symlink)` -- ENOTDIR -- and took
+    down `omh update` for every profile on the machine.
+
+    The link is also what the ownership guard has to see. `Path.exists` follows
+    it, so a dangling link reads as an empty path and would let the replacement
+    run without `--force` on something OMH never wrote.
+    """
+
+    def _bundle_dir(self, hermes_home: Path) -> Path:
+        return hermes_home / "plugins" / "omh"
+
+    def _link_bundle_to_shared(self, root: Path) -> tuple[Path, Path]:
+        """Recreate the older layout: `plugins/omh` is a link to a shared tree."""
+        bundle = self._bundle_dir(root / ".hermes")
+        shared = root / ".hermes" / "shared-omh"
+        bundle.rename(shared)
+        bundle.symlink_to(shared, target_is_directory=True)
+        return bundle, shared
+
+    def test_two_consecutive_updates_replace_a_symlinked_bundle(self) -> None:
+        # One update is not enough to prove the fix: the crash was on the
+        # SECOND update, after the first one left an unremovable `.omh.previous`
+        # link behind. Both updates have to succeed and the leftover has to be
+        # gone before the machine is actually repaired.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, _, stderr = run_cli(base + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            bundle, _ = self._link_bundle_to_shared(root)
+            self.assertTrue(bundle.is_symlink())
+
+            status, _, stderr = run_cli(base + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(bundle.is_symlink())
+            self.assertTrue((bundle / "memory_provider.py").is_file())
+
+            leftover = bundle.parent / ".omh.previous"
+            self.assertFalse(leftover.is_symlink())
+            self.assertFalse(leftover.exists())
+
+            status, _, stderr = run_cli(base + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue((bundle / "memory_provider.py").is_file())
+
+    def test_a_stale_previous_link_does_not_block_an_update(self) -> None:
+        # The leftover from the old code path, reproduced directly: a machine
+        # that already carries `.omh.previous` as a symlink must still update.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, _, stderr = run_cli(base + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            bundle = self._bundle_dir(root / ".hermes")
+            stale = bundle.parent / ".omh.previous"
+            stale.symlink_to(root / ".hermes" / "gone", target_is_directory=True)
+
+            status, _, stderr = run_cli(base + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertFalse(stale.is_symlink())
+            self.assertTrue((bundle / "memory_provider.py").is_file())
+
+    def test_a_dangling_plugin_link_is_kept_without_force(self) -> None:
+        # `Path.exists` follows the link, so a dangling one reads as absent.
+        # Without the link-aware ownership guard the replacement path runs on
+        # a link OMH cannot prove it wrote, and the operator's pointer is gone
+        # with a clean exit code. It has to be kept and named instead.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+            status, _, stderr = run_cli(base + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            bundle, shared = self._link_bundle_to_shared(root)
+            shutil.rmtree(shared)
+            self.assertTrue(bundle.is_symlink())
+            self.assertFalse(bundle.exists())
+
+            status, _, stderr = run_cli(base + ["update"])
+            self.assertEqual(status, 0, stderr)
+            self.assertTrue(bundle.is_symlink())
+            self.assertEqual(os.readlink(bundle), str(shared))
+
+    def test_a_failed_rename_restores_a_symlinked_bundle(self) -> None:
+        # The rollback is the whole reason the replacement renames aside rather
+        # than deleting. If the install of the new tree fails after the link has
+        # been moved to `.omh.previous`, the operator gets their link back.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            omh_home, hermes_home = root / ".omh", root / ".hermes"
+            base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
+            status, _, stderr = run_cli(base + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            _, shared = self._link_bundle_to_shared(root)
+            # `resolve_paths` resolves the home, so the product's spelling of
+            # the plugin directory is the one the rename is compared against.
+            paths = resolve_paths(omh_home, hermes_home)
+            target = paths.hermes_plugin_dir
+
+            real_rename = Path.rename
+
+            def failing_rename(self: Path, dest: Any) -> Path:
+                # Fail only the install of the new tree, never the rollback.
+                if self.name.endswith(".installing") and Path(dest) == target:
+                    raise OSError(errno.EXDEV, "forced install failure")
+                return real_rename(self, dest)
+
+            with mock.patch.object(Path, "rename", failing_rename):
+                with self.assertRaises(OSError):
+                    install_plugin_bundle(paths)
+
+            self.assertTrue(target.is_symlink())
+            self.assertEqual(os.readlink(target), str(shared))
+            self.assertFalse((target.parent / ".omh.previous").exists())
+            self.assertFalse((target.parent / ".omh.previous").is_symlink())
+            self.assertFalse((target.parent / ".omh.installing").exists())
 
 
 class UpdateCarriesRegistrationTests(unittest.TestCase):


### PR DESCRIPTION
## Feature Report

Supersedes #1430. The bug, the causal chain, and the shape of the fix are
JuznemHub's work in that PR. This one keeps all of it and closes the two defects
the review at
https://github.com/rlaope/oh-my-hermes/pull/1430#pullrequestreview-5154939220
found in it: the link-aware replacement bypassed the ownership guard, and the
rollback could not undo the one case that made it reachable. Both are fixed
here, so the replacement is safe rather than removed.

### What Changed

- Added `discard_path()`, `is_directory_link()`, and `is_junction()` to
  `src/system/local_store.py`. `discard_path` removes a path whatever its type:
  symlink, Windows junction, regular file, or directory.
- `_copy_plugin_bundle` now uses `discard_path` at all four cleanup sites in
  place of `shutil.rmtree(..., ignore_errors=True)`.
- The plugin ownership guard in `install_plugin_bundle` now reads
  `(target.exists() or is_directory_link(target)) and existing_manifest is None`,
  so a dangling plugin link is protected by `--force` like any other directory
  OMH cannot prove it wrote.
- The rename-aside inside `_copy_plugin_bundle` asks the same question:
  `if target.exists() or is_directory_link(target)`, so `--force` can actually
  replace a dangling link instead of dying on `rename(dir, symlink)`.
- The rollback predicate asks it too, on both sides:
  `(backup.exists() or is_directory_link(backup)) and not (target.exists() or
  is_directory_link(target))`. Without that, a failed install of a dangling link
  left the target gone and the link stranded under `.omh.previous`.
- `installer._collect_removal` and `self_update_platform` now call the shared
  helpers instead of carrying their own type dispatch and junction probe.
- Six regression tests in `tests/test_plugin_distribution.py`, guarded with the
  repo's `requires_symlinks`.

The last three bullets are the part #1430 got wrong, and they only work as a
set. See **The clause from #1430, and why it needed two more fixes**.

### Why This Exists

An older OMH layout pointed a bot profile's `plugins/omh` at a shared location
with a symlink. On such a machine `omh update` crashed with
`NotADirectoryError: [Errno 20]` for every bot profile, and stayed crashed.

The chain, reproduced here on macOS:

1. `target.rename(backup)` renames the symlink to `.omh.previous`. Renaming a
   symlink just moves the link, so this works.
2. `shutil.rmtree(backup, ignore_errors=True)` fails to remove it. `rmtree`
   cannot unlink a symlink; it descends into the link's target, fails, and
   `ignore_errors=True` swallows the failure.
3. The stale `.omh.previous` link survives across updates.
4. The next update's `target.rename(backup)` is now `rename(dir, symlink)`,
   which `rename(2)` refuses with `ENOTDIR`.

Measured directly, on this platform:

```
dst = dangling symlink:      rename FAILED NotADirectoryError errno=20
dst = symlink to real dir:   rename FAILED NotADirectoryError errno=20
dst = real empty dir:        rename OK
rmtree(symlink, ignore_errors=True): link still there = True
```

### The clause from #1430, and why it needed two more fixes

#1430 also added `or target.is_symlink()` to the target-exists check inside
`_copy_plugin_bundle`. That clause changes behaviour only for a **dangling**
link, because a resolvable one already passes `exists()`. Standing alone it was
unsafe in two ways, both reproduced here rather than taken on faith.

**It bypassed the ownership guard.** `Path.exists()` follows the link, so a
dangling one reads as absent and `unmanaged` came out False. Applying #1430's
shape on this branch and running `omh update` with no `--force`:

```
[dangling] --force=False: status=0
    link_survives=False is_real_dir=True
```

The operator's link is destroyed, on a clean exit, with no `--force`. Before the
clause the same case was harmless only because the command crashed first.

**The rollback could not undo it.** With the clause in and the old
`backup.exists() and not target.exists()` predicate, forcing an `OSError` on
`tmp.rename(target)` for a dangling link leaves the target gone:

```
FAIL: test_a_failed_rename_restores_a_dangling_plugin_link
    AssertionError: False is not true   # target.is_symlink()
```

So the clause is kept, and both holes are closed with it: the ownership guard
and the rollback predicate now ask `is_directory_link` alongside `exists`.
`is_directory_link` rather than `is_symlink` because it is the strict superset
that also covers a dangling Windows junction.

The alternative was to drop the clause and leave `--force` broken for a dangling
link. That was rejected: the guard's own message tells the operator that
`--force` is the remedy, and a CLI that names a remedy which then crashes with
`NotADirectoryError` is a false promise in user-facing output. All four cells,
measured on this branch:

| plugin dir | `omh update` | `omh update --force` |
| --- | --- | --- |
| symlink to a real tree | replaced by a real directory, exit 0 | replaced by a real directory, exit 0 |
| dangling symlink | kept, exit 0, named in the note | replaced by a real directory, exit 0 |

No cell leaves a `.omh.previous` or `.omh.installing` behind.

### User / Operator Impact

- `omh update` no longer crashes on a profile whose plugin directory is a
  symlink, and no longer needs a manual `rm` of a stale `.omh.previous` first.
- Consecutive updates are idempotent on such a machine.
- A dangling plugin link is kept without `--force`, and `--force` genuinely
  replaces it, so the guard's message names a remedy that works.
- A failed install never strands the operator's link under `.omh.previous`.
- `omh uninstall` now removes a plugin directory that is a Windows junction with
  `rmdir` rather than `unlink`, which would have failed.

### How It Works

`discard_path(path, *, ignore_errors=False)` dispatches on the entry type: a
real directory goes to `shutil.rmtree`, a link (symlink or junction) is unlinked
or `rmdir`ed as the link itself, a regular file is unlinked, and a missing path
is a no-op. `ignore_errors` mirrors `shutil.rmtree`'s flag and extends it to the
unlink branches, so the install's best-effort pre-clean stays best-effort for
every entry type rather than only for real directories.

The type dispatch already existed in `_collect_removal` and the junction probe
already existed in `self_update_platform`, so rather than adding a third form
both now call the shared one. That also makes the uninstall path junction-aware,
which it was not.

### Files And Contracts Touched

- `src/system/local_store.py` — new `discard_path`, `is_directory_link`,
  `is_junction`; exported through the `omh.local_store` shim.
- `src/install/plugin_pack.py` — ownership guard, rename-aside, and rollback
  predicate are all link-aware; four cleanup sites in `_copy_plugin_bundle` go
  through `discard_path`; `shutil` import dropped.
- `src/install/installer.py` — `_collect_removal` uses the shared helpers.
- `src/install/self_update_platform.py` — private `_is_junction` /
  `_is_directory_link` replaced by the shared ones; `_remove_directory_link`
  behaviour unchanged.
- `tests/test_plugin_distribution.py` — new `SymlinkedPluginDirectoryTests`.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: not run. The
      change is exercised end to end through `omh setup` / `omh update` inside
      the test harness against temporary `--omh-home` / `--hermes-home` trees;
      no Hermes runtime or TUI surface is touched.

Also run, beyond the template set: `uv run python -m omh.cli docs claims --check
--json`, `docs ulw-inventory --check`, `docs ulw-site --check`.

### Observed Evidence

- New tests: `PYTHONPATH=tests uv run python -m unittest
  tests.test_plugin_distribution.SymlinkedPluginDirectoryTests -v` → 6/6 pass.
- **The regression really regresses.** Reverting only the four `discard_path`
  call sites in `_copy_plugin_bundle` back to `shutil.rmtree(...,
  ignore_errors=True)`, leaving everything else in place, turns the suite red
  with the reported error:

  ```
  ERROR: test_a_stale_previous_link_does_not_block_an_update
    File "src/install/plugin_pack.py", line 353, in _copy_plugin_bundle
      target.rename(backup)
  NotADirectoryError: [Errno 20] Not a directory:
    '.../.hermes/plugins/omh' -> '.../.hermes/plugins/.omh.previous'

  FAIL: test_two_consecutive_updates_replace_a_symlinked_bundle
    AssertionError: True is not false   # the stale .omh.previous link survived
  ```

  The source was restored from a saved copy and re-verified afterwards.
- **Each half of the link-aware replacement was isolated.** Reverting only the
  rename-aside clause turns `test_a_dangling_plugin_link_is_replaced_with_force`
  red with `NotADirectoryError: [Errno 20]` at `tmp.rename(target)`. Restoring
  the clause but reverting only the rollback predicate turns
  `test_a_failed_rename_restores_a_dangling_plugin_link` red on
  `target.is_symlink()`, which is the link being destroyed by the failed
  install. Neither fix is carrying the other.
- **All four cells re-measured** on the final source, as tabled above. No cell
  leaves a `.omh.previous` or `.omh.installing` behind.
- **Ownership guard.** `omh update` on a dangling plugin link, no `--force`:
  exit 0, link intact, note reads `... exists without an OMH plugin manifest;
  use --force to replace it`. With `--force`: replaced by a real directory at
  exit 0. Both pinned as tests, and the note text is asserted.
- **Rollback, both link kinds.** Forcing `OSError` on `tmp.rename(target)`: the
  exception propagates, the link is restored at the target, and neither
  `.omh.previous` nor `.omh.installing` is left behind. Pinned as two tests, one
  for a resolvable link and one for a dangling one.
- **#1430's shape.** Applying it on this branch and running `omh update` with no
  `--force` on a dangling link: exit 0 and the link destroyed, as quoted above.

### Not Tested / Not Applicable

- `release hermes-smoke`, `omh --help`, and the packaged install smoke: not run.
  They exercise the release and command-package surfaces, which this change does
  not touch; the plugin install path is covered directly by the suite above.
- Workflow-learning and dry-run smokes: no learning contract, catalog, skill,
  routing case, or generated artifact changed, so no count or byte gate moves.
- **Windows.** Every junction branch added here is reasoned from
  `Path.is_junction` and the existing junction seam in
  `src/install/self_update_platform.py`, not executed. That covers
  `discard_path`'s `rmdir` branch and every `is_directory_link` call added to
  the ownership guard, the rename-aside, the rollback, and
  `_collect_removal` — all of it verified on macOS only. The new tests carry the
  repo's `requires_symlinks` guard and skip on the windows-latest CI leg. Both
  Windows CI shards pass, which shows the shared-helper refactor did not break
  the existing junction seam; it does **not** exercise a junction through any of
  the new paths, and nothing here should be read as evidence that it does.

## Risk

Low, with two widenings worth naming. `_copy_plugin_bundle` keeps its atomic
rename contract: the backup is still made by rename and still restored by
rename on failure. What changed is that a link at any of those paths is now
seen as occupying the path rather than read through to its target, and that a
link or file at a temporary path is actually removed instead of silently
surviving.

The replacement branch is now reachable for a dangling link, which is what
#1430's review flagged. That is safe here only because the ownership guard sees
the same link and the rollback restores it, and both of those are pinned by
tests that go red on their own. If any future change loosens the guard, the
dangling-link cell becomes destructive again.

The widening is that `discard_path` and `is_directory_link` are now also used by
`installer._collect_removal` and `self_update_platform`. On POSIX the dispatch
is identical to what those call sites already did; on Windows a junction now
takes the `rmdir` branch instead of an `unlink` that would have failed. Both are
covered by the existing plugin and staged-self-update suites.

## Compatibility / Rollout

No compatibility concerns and no config or schema change. A machine whose plugin
directory is a symlink is transparently converted to a real directory on the
next `omh update`, which is the intended end state. A machine whose plugin
directory is a dangling link changes from "update crashes" to "update keeps it
and says so", which is strictly better.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — a
      bugfix on the install path; no channel change.
- [x] Runtime/native capability claims are backed by evidence or marked as not
      observed — Windows junction behaviour is explicitly marked not observed.
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as
      execution, review, CI, or merge evidence — N/A, no handoffs here.
- [x] Evidence contains no credentials, raw prompts, raw platform events,
      transcripts, or unrelated private data.
- [x] Known manual Hermes checks are listed, including any `omh release
      hermes-smoke --live` gap — listed above; the `--live` smoke was not run.

## Follow-Up

- Two more inline junction probes remain, in `src/install/self_update_state.py`
  and `src/install/self_update_state_validation.py`. They match
  `is_directory_link` exactly and could fold into it, but they are outside this
  bug's blast radius.
- A Windows host with a real junction at the plugin path would close the one
  dimension this PR reasons about instead of executing. See **Not Tested**.

Thanks to @JuznemHub for finding this and for a causal analysis that reproduced
exactly as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
