### PR TITLE
build(deps): pin the cache actions to v6.1.0 and move the test with them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           mkdir -p timings-history
           cp tools/test_sharding/timings.json timings-history/timings.json
       - name: Restore bounded timing history
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: timings-history
           key: test-sharding-timings-${{ github.run_id }}
@@ -417,7 +417,7 @@ jobs:
           cp timings-merged/timings.json timings-history/timings.json
       - name: Save bounded timing history
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: timings-history
           key: test-sharding-timings-${{ github.run_id }}

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -3971,8 +3971,8 @@ class RouterContentTests(unittest.TestCase):
         # replacement that bypasses exact-once accounting.
         self.assertIn("python tools/test_sharding/plan.py --shards 2", ci)
         self.assertIn("--durations timings-history/timings.json", ci)
-        self.assertIn("actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684", ci)
-        self.assertIn("actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809", ci)
+        self.assertIn("actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9", ci)
+        self.assertIn("actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9", ci)
         self.assertIn("test-sharding-timings-${{ github.run_id }}", ci)
         self.assertIn("python tools/test_sharding/run.py --plan shard-plan/plan.json", ci)
         self.assertIn("--lane linux-${{ matrix.python-version }} --shard ${{ matrix.shard }}", ci)


### PR DESCRIPTION
## Feature Report

### What Changed

- `.github/workflows/ci.yml` pins `actions/cache/restore` and `actions/cache/save` to `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` (v6.1.0), up from v4.2.3 and v4.2.4 respectively.
- `tests/test_router_content.py` moves both pinned SHAs in `test_first_release_trust_surfaces_are_present` in the same commit.

### Why This Exists

Dependabot opened #1443 (restore, 4.2.3 → 6.1.0) and #1445 (save, 4.2.4 → 6.1.0). Neither can pass on its own. The suite asserts the exact pinned SHA of each action as a supply-chain surface, so a bump that moves the workflow without the test fails `test_first_release_trust_surfaces_are_present` — and that same test then fails the other PR for the pin it did not touch. Each bot PR is red on the other's pin, so neither can go first. Doing both in one commit is what makes either mergeable.

This supersedes #1443 and #1445.

### User / Operator Impact

None at runtime. This is CI infrastructure. The pinned-SHA guard keeps doing its job instead of blocking the bump it was never meant to block.

### How It Works

Both subactions live in the `actions/cache` repository, so they share one commit. The SHA was verified against upstream rather than taken from the bot's summary:

```
$ gh api repos/actions/cache/git/ref/tags/v6.1.0 -q '"\(.object.type) \(.object.sha)"'
commit 55cc8345863c7cc4c66a329aec7e433d2d1c52a9
```

That is the SHA both Dependabot PRs name.

### Files And Contracts Touched

- `.github/workflows/ci.yml` — the restore step in `plan`, the save step in `aggregate`
- `tests/test_router_content.py` — the two pinned-SHA assertions

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py` — `Ran 111 tests`, `OK`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `git diff --check`
- [ ] Full suite — not run locally; CI runs the matrix and this change touches no product code.
- [ ] Docs byte gates, `harness validate`, `release checklist`, `release hermes-smoke`, installed-CLI smoke — not run; no catalog, skill, generated artifact, installer, or release surface is touched.
- [ ] Manual Hermes/TUI check — not applicable, no TUI surface.

### Observed Evidence

- The targeted test passes with the moved pins: `Ran 111 tests in 0.708s / OK`.
- The upstream tag ref resolves to the SHA both bumps name, quoted above.
- The failure this fixes is observed on #1443: `test (3.11, 1)` → `AssertionError: 'actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684' not found in` the workflow text, `Ran 5246 tests`, `FAILED (failures=1, skipped=10)`.

### Not Tested / Not Applicable

- The v4 → v6 cache behaviour itself on a real cache hit. The save step is gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so only a merge to main exercises it. A regression there degrades shard-timing history to the committed fallback; it does not fail the build.

## Risk

Low, and bounded to CI. If v6.1.0 changed the restore/save contract in a way this workflow depends on, the visible effect is that the timing history stops restoring and the planner falls back to `tools/test_sharding/timings.json`, which is the documented fallback path.

Closes #1443
Closes #1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8