### PR TITLE
ci: run both Windows shards to completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,10 @@ jobs:
     needs: plan
     runs-on: windows-latest
     strategy:
+      # Each shard runs a disjoint half of the suite, so cancelling the sibling
+      # when one fails leaves that half unmeasured and the blast radius unknown
+      # -- and it cancelled a different half on each of two consecutive heads.
+      fail-fast: false
       matrix:
         shard: [0, 1]
     steps:


### PR DESCRIPTION
## Feature Report

### What Changed

- `.github/workflows/ci.yml` sets `fail-fast: false` on the `test-windows` matrix strategy. The `test` (ubuntu) matrix is left alone.

### Why This Exists

The two Windows shards run disjoint halves of the suite, and the `aggregate` job exists to reconcile exact-once coverage across them. But the matrix had no `fail-fast: false`, so the first shard to fail cancelled its sibling — and the cancelled shard was a different half each time.

Observed on PR #1442, across two consecutive heads:

| Head | shard 0 | shard 1 |
| --- | --- | --- |
| `a88a8526` | cancelled | failure |
| `8e16583b` | failure | cancelled |

Neither head was ever measured whole. Each fix attempt on that PR was judged against half the evidence, and the half that went unmeasured swapped between runs, so the true failure set stayed hidden. Reading the cancelled shard-0 log from `8e16583b` afterwards showed the failure set was substantially larger than what the reported shard had made visible.

### User / Operator Impact

None at runtime. A red Windows run now reports everything it measured instead of roughly half of it, so a maintainer reads one log rather than inferring the missing half from a later run that cancels the other side.

### How It Works

`fail-fast: false` stops GitHub Actions cancelling the sibling leg when one matrix leg fails. Both shards run to completion and both upload their result artifact, which the `aggregate` job already consumes — its fail-closed reconciliation is unchanged and still red if any leg did not succeed.

### Files And Contracts Touched

- `.github/workflows/ci.yml` — the `test-windows` job's `strategy` block only.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py` — `Ran 111 tests`, `OK`. This is the module that asserts on `ci.yml` content, including the pinned action SHAs.
- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `git diff --check`
- [ ] Full suite — not run locally. No Python source changes; the one test module that reads `ci.yml` is run above.
- [ ] Docs byte gates, `harness validate`, `release checklist`, `release hermes-smoke`, installed-CLI smoke — not run; no catalog, skill, generated artifact, installer or release surface is touched.
- [ ] Manual Hermes/TUI check — not applicable, no TUI surface.

### Observed Evidence

- The change is confined to the `test-windows` strategy block; the diff is four added lines including three of comment.
- The shard-cancellation pattern above is read from the two runs on PR #1442, not inferred.

### Not Tested / Not Applicable

- The behaviour this enables can only be observed on a Windows run that actually fails. The next red Windows run is what proves both shards now report.
- The ubuntu matrix keeps its default fail-fast deliberately. Its four legs all reported on the last red run, so there is no evidence it hides anything.

## Risk

Low. Both shards already upload their results unconditionally (`if: always()`), and `aggregate` is fail-closed on any non-success leg, so nothing here can turn a red run green. The cost is wall clock on a failing run, since the sibling shard is no longer cancelled early.

## Compatibility / Rollout

No compatibility surface. Takes effect on the next Windows run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8