### PR TITLE
feat(ecosystem): reconcile plugin outcome routing with the active host catalog

### DIFF
--- a/docs/PLUGIN-CATALOG-COVERAGE.md
+++ b/docs/PLUGIN-CATALOG-COVERAGE.md
@@ -1,0 +1,184 @@
+# Plugin Catalog Coverage
+
+**Audience:** maintainers and Hermes host operators.
+
+OMH ships one packaged ecosystem catalog snapshot and a small hand-curated
+outcome matrix. Both are pinned to a repository revision, so a plugin the host
+admitted this morning, a reviewed revision that moved under an existing
+identity, a withdrawal, or a host-version constraint the host refused stays
+invisible until somebody edits the repository.
+
+`plugin_catalog_snapshot/v1` is the input that closes that gap without OMH
+acquiring anything. An authorized host or operator exports its own catalog to
+a file; OMH validates it, reconciles it against its own workflow ownership,
+and reports `plugin_catalog_coverage/v1`.
+
+Read-only, in the strict sense: no network request, no credential read, no
+plugin import, no dependency installation, no host configuration change, no
+GitHub mutation, no background polling. The supplied file is the only input.
+The host keeps everything it already owns — acquisition, admission,
+compatibility enforcement, installation, activation, updates, removal blocks,
+permissions, and runtime execution. OMH owns interpretation, routing, and
+evidence-bounded status.
+
+## Command
+
+```sh
+omh ecosystem plugin-catalog coverage \
+  --input current-snapshot.json \
+  --previous previous-snapshot.json \
+  --profile default \
+  --now 2026-09-10T10:00:00Z \
+  --json
+```
+
+Every flag except `--input` is optional. `--previous` is what turns the report
+from a listing into a change report. `--profile` refuses a snapshot taken for
+a different profile. `--now` pins the clock the freshness decision is made
+against.
+
+## The snapshot contract
+
+```json
+{
+  "schema_version": "plugin_catalog_snapshot/v1",
+  "producer": {"kind": "hermes_host", "ref": "hermes-host-a", "host_version": "0.13.2"},
+  "profile_ref": "default",
+  "observed_at": "2026-09-10T09:00:00Z",
+  "catalog_revision": "catalog-rev-2026-09-10",
+  "entry_count": 1,
+  "entries": [
+    {
+      "plugin_id": "alpha-provider",
+      "content_revision": "rev-2",
+      "tier": "verified",
+      "declared_capabilities": ["provider"],
+      "required_env_names": ["ALPHA_API_KEY"],
+      "platform_limits": [],
+      "host_version_constraint": ">=0.13",
+      "host_version_status": "satisfied",
+      "removal_status": "active"
+    }
+  ]
+}
+```
+
+Both key sets are closed. An unsupported field is a refusal, not a warning.
+
+| Field | What it is |
+| --- | --- |
+| `producer.kind` | `hermes_host` or `authorized_operator`. OMH never produces a snapshot. |
+| `profile_ref` | Which host profile the snapshot describes. |
+| `catalog_revision` | The host's own revision or deterministic digest for the catalog state. |
+| `plugin_id` | Stable identity. Change classification keys on this. |
+| `content_revision` | The reviewed content behind that identity at snapshot time. |
+| `tier` | `official`, `verified`, `community`, or `unreviewed`. |
+| `declared_capabilities` | Open vocabulary of lowercase tokens. Claims, not observations. |
+| `required_env_names` | Environment variable **names**. A credential value here is refused. |
+| `platform_limits` | `desktop`, `headless`, `linux`, `macos`, `windows`. |
+| `host_version_constraint` | Opaque text OMH never parses. |
+| `host_version_status` | `satisfied`, `unsatisfied`, or `unknown` — the host's own answer. |
+| `removal_status` | `active`, `deprecated`, or `removed`. |
+
+**OMH does not solve versions.** `host_version_constraint` is carried through
+as opaque text; `host_version_status` is where the host reports the result of
+enforcing it, because enforcement is the host's job.
+
+**Names, not values.** `required_env_names` is the one field whose honest
+content reads like a secret (`GITHUB_TOKEN`, `ALPHA_API_KEY`). It is screened
+with the narrow issued-credential detector rather than the wider
+sensitive-word one, so a name is accepted and an issued key is refused. Every
+other string is screened as a bounded opaque reference. There is no field a
+file body, a repository excerpt, or a credential value can arrive in.
+
+## What the answer says
+
+Each row carries exactly one **coverage class** and exactly one **change
+class**. They answer different questions and never merge.
+
+| Coverage class | When |
+| --- | --- |
+| `mapped` | A declared capability OMH owns a workflow for. |
+| `generic_review` | Declared something, but nothing OMH owns — including host-core-only mechanics. |
+| `incompatible` | `host_version_status` is `unsatisfied`. |
+| `removed` | `removal_status` is `removed`, or the entry left the catalog. |
+| `unknown` | Declared no capabilities at all; there is nothing to interpret. |
+
+| Change class | When |
+| --- | --- |
+| `added` | Identity absent from the prior snapshot. With no prior snapshot, every row is a first sighting. |
+| `changed` | Identity present before, and tracked metadata moved. `changed_fields` names what. |
+| `unchanged` | Identity present before, nothing tracked moved. |
+| `removed` | Identity present before, absent now. |
+
+Withdrawal and incompatibility are decided before capability mapping, so a
+withdrawn or refused entry is never routed as adoption guidance for something
+the host will not run.
+
+### Routing
+
+| Declared capability | Owner workflow |
+| --- | --- |
+| `provider` | `provider-profile-posture` |
+| `connector` | `external-connector-readiness` |
+| `observability` | `ops-observability-card` |
+| `memory` | `memory-sync` |
+| `media` | `media-input-operator` |
+| `host_core` | none — reported with `owner_boundary: hermes_host` |
+| anything else, or nothing | `skill-scout` (bounded generic review) |
+| held entries | `security-safety-review` (plugin risk review) |
+
+An entry declaring several owned capabilities takes the first in that order as
+its primary `route` and lists the rest in `additional_routes`, so the primary
+owner is the same on every run.
+
+### What never happens
+
+- **No entry reaches a ready state.** Catalog presence cannot produce one.
+  `adoption_guidance` is `route_to_owner`, `generic_review`, `host_owned`, or
+  `held`; the owner workflow's own readiness contract is where an adoption
+  answer comes from.
+- **A removal hold reports a catalog withdrawal only.** It never says an
+  installed copy was disabled or uninstalled — OMH cannot see installed copies,
+  and `installed_copy_state` is listed in the row's `unavailable_evidence`.
+- **Declared capabilities stay claims.** They can be incomplete or drift from
+  implementation. `host_observed_behavior`, `host_permission_grant`, and
+  `plugin_execution` are in every row's `unavailable_evidence`, always.
+
+## Failing closed
+
+| Input | Result |
+| --- | --- |
+| No `--input` | `snapshot_state: unavailable`, no entries, exit 1 |
+| Missing or unreadable file | `snapshot_state: unavailable`, no entries, exit 1 |
+| Oversized file or entry list | Refused before parsing or reconciling; never truncated |
+| Malformed, unsupported field, duplicate identity | Refused with bounded diagnostics |
+| Snapshot from another profile | Refused — it is a real observation of something else |
+| Older than the freshness horizon | Reported with `snapshot_state: stale` and every row held on `stale_snapshot` |
+
+Diagnostics are positional. Each one names an entry index and a field name and
+never the value that failed, so an untrusted snapshot cannot route its own
+content through OMH's error output. The list is capped and closed with a count.
+
+**Absence never inherits presence.** An `unavailable` answer carries no
+entries and no packaged-catalog substitute. The `packaged_reference` block is
+still attached with `used_as_host_coverage: false`, so a reader can see that
+OMH declined to use it rather than wondering whether it silently did.
+
+## The packaged catalog
+
+`omh ecosystem awesome-hermes summary|list|inspect|outcomes` still work
+unchanged. Every one of their payloads now carries
+`coverage_scope: snapshot_limited` and a note saying so in words: they project
+one pinned upstream revision packaged into an OMH release, and they cannot
+report anything the host admitted, revised, or withdrew since. For current
+host coverage, reconcile a snapshot.
+
+## Implementation
+
+| Surface | Path |
+| --- | --- |
+| Input contract and validation | `src/workflows/plugin_catalog_snapshots.py` |
+| Reconciliation and routing | `src/workflows/plugin_catalog_coverage.py` |
+| CLI adapter | `src/commands/plugin_catalog.py` |
+| Tests | `tests/test_plugin_catalog_coverage.py` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ references rather than normal user steps.
 | Capture and recall reviewed project context | [Project Memory](MEMORY.md) |
 | Answer what a web page said as of a date, or compare then versus now | [Temporal Source Receipts](TEMPORAL-SOURCE-RECEIPTS.md) |
 | Judge whether a realtime voice connector keeps whole spoken turns | [Realtime Voice Trial Receipts](REALTIME-VOICE-TRIAL-RECEIPTS.md) |
+| See which OMH workflow owns each plugin in the active host catalog | [Plugin Catalog Coverage](PLUGIN-CATALOG-COVERAGE.md) |
 | Choose a situation-level workflow | [Playbooks](PLAYBOOKS.md) |
 | Prepare or verify a release | [Release](RELEASE.md) |
 

--- a/src/catalogs/awesome_hermes_agent.py
+++ b/src/catalogs/awesome_hermes_agent.py
@@ -18,6 +18,19 @@ UPSTREAM_README_SHA256: Final = "33d58901d6f8a96f1801406c293d5c3061dce2e23a05257
 UPSTREAM_ITEM_COUNT: Final = 216
 UPSTREAM_PLUGIN_COUNT: Final = 35
 
+#: What this catalog and the selected-outcome matrix are, said in the payloads
+#: themselves rather than only in a doc. Both are projections of one upstream
+#: revision packaged into an OMH release; neither observes the catalog a host
+#: is running today, and a reader who mistakes one for the other believes OMH
+#: covered plugins that were admitted, revised, or withdrawn since.
+PACKAGED_COVERAGE_SCOPE: Final = "snapshot_limited"
+PACKAGED_COVERAGE_SCOPE_NOTE: Final = (
+    "This is the upstream catalog snapshot packaged with this OMH revision, not the active host catalog. "
+    "It cannot report entries the host admitted, revised, or removed after the pinned revision. For current "
+    "host coverage, reconcile a host-supplied plugin_catalog_snapshot/v1 with "
+    "`omh ecosystem plugin-catalog coverage`."
+)
+
 
 class AwesomeHermesCatalogError(ValueError):
     pass
@@ -181,6 +194,8 @@ def awesome_hermes_summary() -> dict[str, str | int | dict[str, int]]:
         "schema_version": COVERAGE_SCHEMA_VERSION,
         "source_repo": SOURCE_REPO,
         "source_commit": awesome_hermes_catalog().source.commit,
+        "coverage_scope": PACKAGED_COVERAGE_SCOPE,
+        "coverage_scope_note": PACKAGED_COVERAGE_SCOPE_NOTE,
         **summary.to_dict(),
     }
 
@@ -205,6 +220,8 @@ def awesome_hermes_coverage_payload(
         "item_count": len(coverage),
         "summary": _summarize_coverage(coverage).to_dict(),
         "catalog_summary": awesome_hermes_summary(),
+        "coverage_scope": PACKAGED_COVERAGE_SCOPE,
+        "coverage_scope_note": PACKAGED_COVERAGE_SCOPE_NOTE,
         "items": [item.to_dict() for item in coverage],
         "claim_boundary": (
             "Coverage means OMH has a routing, review, readiness, or handoff surface. It is not external "

--- a/src/catalogs/awesome_hermes_agent_outcomes.py
+++ b/src/catalogs/awesome_hermes_agent_outcomes.py
@@ -7,7 +7,12 @@ import json
 import re
 from typing import Final
 
-from .awesome_hermes_agent import AwesomeHermesCatalogError, UPSTREAM_SOURCE_COMMIT
+from .awesome_hermes_agent import (
+    AwesomeHermesCatalogError,
+    PACKAGED_COVERAGE_SCOPE,
+    PACKAGED_COVERAGE_SCOPE_NOTE,
+    UPSTREAM_SOURCE_COMMIT,
+)
 
 
 PLUGIN_OUTCOME_SCHEMA_VERSION: Final = "awesome_hermes_plugin_outcome_matrix/v1"
@@ -75,6 +80,8 @@ def awesome_hermes_plugin_outcomes() -> dict[str, object]:
     return {
         "schema_version": PLUGIN_OUTCOME_SCHEMA_VERSION,
         "source_commit": source_commit,
+        "coverage_scope": PACKAGED_COVERAGE_SCOPE,
+        "coverage_scope_note": PACKAGED_COVERAGE_SCOPE_NOTE,
         "outcomes": [outcome.to_dict() for outcome in outcomes],
         "claim_boundary": claim_boundary,
     }

--- a/src/commands/ecosystem.py
+++ b/src/commands/ecosystem.py
@@ -4,6 +4,8 @@ import argparse
 
 from ..catalogs.awesome_hermes_agent import (
     AwesomeHermesCatalogError,
+    PACKAGED_COVERAGE_SCOPE,
+    PACKAGED_COVERAGE_SCOPE_NOTE,
     awesome_hermes_coverage_payload,
     awesome_hermes_item,
     awesome_hermes_summary,
@@ -11,6 +13,15 @@ from ..catalogs.awesome_hermes_agent import (
 from ..catalogs.awesome_hermes_agent_outcomes import awesome_hermes_plugin_outcomes
 from ..installer import OmhError
 from .common import _print_json, _wants_json
+
+
+def _print_packaged_scope() -> None:
+    """Say on every packaged-catalog surface that it is not host coverage.
+
+    The label lives next to the numbers rather than in a doc, because the
+    numbers are what a reader quotes.
+    """
+    print(f"Scope: {PACKAGED_COVERAGE_SCOPE} -- {PACKAGED_COVERAGE_SCOPE_NOTE}")
 
 
 def cmd_ecosystem_awesome_summary(args: argparse.Namespace) -> int:
@@ -27,6 +38,7 @@ def cmd_ecosystem_awesome_summary(args: argparse.Namespace) -> int:
         for status, count in status_counts.items():
             print(f"- {status}: {count}")
     print("Boundary: coverage is OMH routing/readiness context, not plugin installation or safety approval.")
+    _print_packaged_scope()
     print("For machine-readable output, rerun with `--json`.")
     return 0
 
@@ -66,6 +78,7 @@ def cmd_ecosystem_awesome_list(args: argparse.Namespace) -> int:
         if hidden > 0:
             print(f"... {hidden} more")
     print("Boundary: list output does not install, trust, or load any external plugin.")
+    _print_packaged_scope()
     return 0
 
 
@@ -77,6 +90,8 @@ def cmd_ecosystem_awesome_inspect(args: argparse.Namespace) -> int:
     payload = {
         "schema_version": "awesome_hermes_agent_item_coverage/v1",
         "item": coverage.to_dict(),
+        "coverage_scope": PACKAGED_COVERAGE_SCOPE,
+        "coverage_scope_note": PACKAGED_COVERAGE_SCOPE_NOTE,
         "claim_boundary": (
             "Item coverage is a local OMH comparison. It is not external repository trust, plugin load, "
             "runtime execution, or feature parity evidence."
@@ -94,6 +109,7 @@ def cmd_ecosystem_awesome_inspect(args: argparse.Namespace) -> int:
     print(f"OMH surfaces: {', '.join(coverage.omh_surfaces)}")
     for note in coverage.notes:
         print(f"- {note}")
+    _print_packaged_scope()
     return 0
 
 
@@ -111,6 +127,7 @@ def cmd_ecosystem_awesome_outcomes(args: argparse.Namespace) -> int:
             continue
         print(f"- {outcome['plugin_id']}: {outcome['implementation_state']}")
     print(f"Boundary: {payload['claim_boundary']}")
+    _print_packaged_scope()
     return 0
 
 

--- a/src/commands/ecosystem.py
+++ b/src/commands/ecosystem.py
@@ -13,6 +13,7 @@ from ..catalogs.awesome_hermes_agent import (
 from ..catalogs.awesome_hermes_agent_outcomes import awesome_hermes_plugin_outcomes
 from ..installer import OmhError
 from .common import _print_json, _wants_json
+from .plugin_catalog import _add_plugin_catalog_commands
 
 
 def _print_packaged_scope() -> None:
@@ -162,6 +163,8 @@ def _add_ecosystem_commands(sub) -> None:
     outcomes = awesome_sub.add_parser("outcomes", help="Show selected plugin outcomes and OMH claim boundaries.")
     outcomes.add_argument("--json", action="store_true", help="Print the machine-readable outcome matrix.")
     outcomes.set_defaults(func=cmd_ecosystem_awesome_outcomes)
+
+    _add_plugin_catalog_commands(ecosystem_sub)
 
 
 __all__ = [

--- a/src/commands/plugin_catalog.py
+++ b/src/commands/plugin_catalog.py
@@ -1,0 +1,125 @@
+"""`omh ecosystem plugin-catalog coverage` -- the offline snapshot adapter.
+
+Consumes supplied JSON and nothing else. It performs no network fetch, reads
+no credential, imports no plugin, installs no dependency, and changes no host
+configuration; the two `--input`/`--previous` files are the only inputs and
+stdout is the only output.
+
+Fail-closed shape, deliberately split across the exit code rather than folded
+into one:
+
+- A snapshot that cannot be interpreted -- unreadable, oversized, malformed,
+  duplicate-identity, or taken for another profile -- is refused with its
+  bounded diagnostics and no payload. There is no partial coverage report,
+  because a partial one reads exactly like a complete one.
+- No snapshot at all prints the `unavailable` payload and exits non-zero. The
+  reader still gets a machine-readable answer, and that answer is "OMH has no
+  host coverage", never the packaged catalog wearing a host label.
+- A snapshot older than the freshness horizon prints its rows with every one
+  of them held on `stale_snapshot`, so nothing in it can be read as current
+  adoption guidance.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from ..installer import OmhError
+from ..workflows.plugin_catalog_coverage import (
+    PluginCatalogCoverageError,
+    build_plugin_catalog_coverage,
+    plugin_catalog_coverage_unavailable,
+    render_plugin_catalog_coverage,
+)
+from ..workflows.plugin_catalog_snapshots import (
+    PluginCatalogSnapshotError,
+    load_plugin_catalog_snapshot,
+)
+from .common import _print_json, _wants_json
+
+
+def cmd_ecosystem_plugin_catalog_coverage(args: argparse.Namespace) -> int:
+    if not args.input.strip():
+        return _emit_unavailable(args, "no plugin catalog snapshot path was supplied")
+    try:
+        snapshot = load_plugin_catalog_snapshot(args.input)
+    except PluginCatalogSnapshotError as exc:
+        return _emit_unavailable(args, str(exc))
+    previous: dict[str, Any] | None = None
+    if args.previous.strip():
+        try:
+            previous = load_plugin_catalog_snapshot(args.previous)
+        except PluginCatalogSnapshotError as exc:
+            raise OmhError(f"previous snapshot: {exc}") from exc
+    try:
+        payload = build_plugin_catalog_coverage(
+            snapshot,
+            previous=previous,
+            profile_ref=args.profile,
+            now=args.now,
+        )
+    except PluginCatalogCoverageError as exc:
+        raise OmhError(str(exc)) from exc
+    _emit(args, payload)
+    return 0
+
+
+def _emit_unavailable(args: argparse.Namespace, reason: str) -> int:
+    _emit(args, plugin_catalog_coverage_unavailable(reason))
+    return 1
+
+
+def _emit(args: argparse.Namespace, payload: dict[str, Any]) -> None:
+    if _wants_json(args):
+        _print_json(payload)
+        return
+    print(render_plugin_catalog_coverage(payload))
+
+
+def _add_plugin_catalog_commands(ecosystem_sub) -> None:
+    plugin_catalog = ecosystem_sub.add_parser(
+        "plugin-catalog",
+        help="Reconcile a supplied host plugin catalog snapshot with OMH workflow ownership.",
+    )
+    plugin_catalog_sub = plugin_catalog.add_subparsers(dest="plugin_catalog_command", required=True)
+
+    coverage = plugin_catalog_sub.add_parser(
+        "coverage",
+        help="Report OMH outcome coverage for one plugin_catalog_snapshot/v1 file.",
+        description=(
+            "Read one plugin_catalog_snapshot/v1 an authorized host or operator produced and report which "
+            "OMH workflow owns each plugin outcome, what changed since a prior snapshot, which entries are "
+            "held by a removal or an unmet host-version constraint, and what evidence OMH does not have. "
+            "OMH fetches nothing, reads no credential, imports no plugin, installs no dependency, and "
+            "changes no host configuration."
+        ),
+    )
+    coverage.add_argument(
+        "--input",
+        default="",
+        help="Path to the current plugin_catalog_snapshot/v1 JSON file. Without it the answer is unavailable.",
+    )
+    coverage.add_argument(
+        "--previous",
+        default="",
+        help="Path to the prior snapshot to classify added, changed, unchanged, and removed entries against.",
+    )
+    coverage.add_argument(
+        "--profile",
+        default="",
+        help="Refuse the snapshot unless it was taken for this exact profile.",
+    )
+    coverage.add_argument(
+        "--now",
+        default="",
+        help="ISO-8601 reference time; a snapshot past the freshness horizon holds every entry it carries.",
+    )
+    coverage.add_argument("--json", action="store_true", help="Emit the machine payload instead of plain text.")
+    coverage.set_defaults(func=cmd_ecosystem_plugin_catalog_coverage)
+
+
+__all__ = [
+    "_add_plugin_catalog_commands",
+    "cmd_ecosystem_plugin_catalog_coverage",
+]

--- a/src/workflows/plugin_catalog_coverage.py
+++ b/src/workflows/plugin_catalog_coverage.py
@@ -1,0 +1,523 @@
+"""Plugin catalog coverage (`plugin_catalog_coverage/v1`, issue #1449).
+
+Reconciles one host-supplied `plugin_catalog_snapshot/v1` against OMH's own
+workflow ownership and answers four questions a maintainer currently cannot
+ask: which OMH workflow owns each plugin outcome, what changed since the prior
+snapshot, whether a compatibility or removal status blocks use, and what
+evidence OMH does not have.
+
+Everything here is a pure function of the two snapshots it is handed. Nothing
+is fetched, imported, installed, activated, or executed, and no host
+configuration is read or written.
+
+Four separations do the work, and none of them collapses into another:
+
+- **Coverage class is not change class.** An entry gets exactly one coverage
+  class -- what OMH can do with it -- and, separately, exactly one change class
+  -- how it differs from the prior snapshot. A first sighting of an entry that
+  OMH cannot map is `added` and `generic_review`, not one merged verdict.
+- **A rediscovered entry is not a new one.** Change classification keys on
+  `plugin_id`, and `changed` requires a difference in tracked metadata. An
+  identical snapshot replayed produces `unchanged` for every row and no new
+  row at all. A reviewed content revision that moved under a known identity is
+  `changed`, and both revisions survive into the row -- reporting that as
+  `added` would lose the fact that the identity was already reviewed once.
+- **Catalog presence is not readiness.** No entry ever reaches a ready state
+  here. A mapped entry is routed to the workflow that owns its outcome, and
+  that workflow's own readiness contract is where an adoption answer comes
+  from. An unsatisfied host-version constraint or a catalog removal is held
+  outright, and a stale snapshot holds every row it carries.
+- **Absence does not inherit presence.** When no snapshot is available the
+  answer is `unavailable` with no entries. It never falls back to the packaged
+  catalog OMH ships, because that catalog describes a repository revision and
+  says nothing about the host's live catalog.
+
+A removal hold says the catalog withdrew the entry. It never says an installed
+copy was disabled or uninstalled: OMH cannot see installed copies, and the
+host owns that state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+from ..catalogs.awesome_hermes_agent import (
+    PACKAGED_COVERAGE_SCOPE,
+    PACKAGED_COVERAGE_SCOPE_NOTE,
+    UPSTREAM_SOURCE_COMMIT,
+)
+from .plugin_catalog_snapshots import (
+    MAX_DIAGNOSTICS,
+    snapshot_entries,
+    snapshot_freshness,
+    snapshot_identity,
+    validate_plugin_catalog_snapshot,
+)
+
+
+PLUGIN_CATALOG_COVERAGE_SCHEMA_VERSION: Final = "plugin_catalog_coverage/v1"
+
+COVERAGE_CLAIM_BOUNDARY: Final = (
+    "Plugin catalog coverage interprets one supplied catalog snapshot against OMH workflow ownership. "
+    "Declared capabilities are catalog claims, not observed plugin behavior, and coverage is not plugin "
+    "installation, admission, compatibility enforcement, permission, activation, update, removal, or "
+    "execution evidence. A removal hold reports a catalog withdrawal only and says nothing about whether "
+    "an installed copy exists, was disabled, or was uninstalled."
+)
+
+#: Exactly one of these per row. `unknown` is the honest class for an entry
+#: that declared no capabilities at all -- there is nothing to interpret, which
+#: is different from having declared something OMH does not own.
+COVERAGE_CLASSES: Final = ("mapped", "generic_review", "incompatible", "removed", "unknown")
+
+#: Exactly one of these per row, against the prior snapshot.
+CHANGE_CLASSES: Final = ("added", "changed", "unchanged", "removed")
+
+#: What OMH tells the reader to do next. There is deliberately no `ready`:
+#: catalog presence cannot produce one, and each owner workflow keeps its own
+#: readiness contract.
+ADOPTION_GUIDANCE: Final = ("route_to_owner", "generic_review", "host_owned", "held")
+
+#: Declared capability token -> the OMH workflow that owns that outcome, in
+#: precedence order. The order is the tie-break when one entry declares
+#: several, so a multi-capability entry routes to the same primary owner on
+#: every run.
+CAPABILITY_OWNERS: Final = (
+    ("provider", "provider-profile-posture"),
+    ("connector", "external-connector-readiness"),
+    ("observability", "ops-observability-card"),
+    ("memory", "memory-sync"),
+    ("media", "media-input-operator"),
+)
+
+#: The capability that names host loader, transport, permission, and
+#: installation mechanics. OMH owns no workflow for it on purpose; the row is
+#: reported with a host owner boundary rather than routed into an OMH lane.
+HOST_CORE_CAPABILITY: Final = "host_core"
+
+#: The bounded route for an entry OMH cannot map. Capability scouting is what
+#: answers "is there an OMH surface for this?", so an unmapped entry lands
+#: there rather than disappearing from the report.
+GENERIC_REVIEW_ROUTE: Final = "skill-scout"
+
+#: The bounded route for a held entry. A withdrawal or an unmet host-version
+#: constraint is a review question, not an adoption one.
+HELD_REVIEW_ROUTE: Final = "security-safety-review"
+
+#: Evidence OMH never has about any catalog entry, whatever its class.
+BASELINE_UNAVAILABLE_EVIDENCE: Final = (
+    "host_observed_behavior",
+    "host_permission_grant",
+    "plugin_execution",
+)
+
+#: Metadata whose movement makes an existing identity `changed`. Identity
+#: itself is excluded: a different `plugin_id` is a different entry.
+TRACKED_ENTRY_FIELDS: Final = (
+    "content_revision",
+    "declared_capabilities",
+    "host_version_constraint",
+    "host_version_status",
+    "platform_limits",
+    "removal_status",
+    "required_env_names",
+    "tier",
+)
+
+_SNAPSHOT_STATES: Final = ("current", "stale", "unavailable")
+
+
+class PluginCatalogCoverageError(ValueError):
+    """The supplied inputs cannot produce a coverage answer at all."""
+
+
+def build_plugin_catalog_coverage(
+    snapshot: Mapping[str, Any],
+    *,
+    previous: Mapping[str, Any] | None = None,
+    profile_ref: str = "",
+    now: str = "",
+) -> dict[str, Any]:
+    """Reconcile one snapshot, optionally against the prior one.
+
+    Raises `PluginCatalogCoverageError` for every input that cannot be
+    interpreted -- malformed, oversized, duplicate-identity, or from a
+    different profile than the caller asked about. Those fail closed rather
+    than producing a partial answer, because a partial coverage report reads
+    exactly like a complete one.
+    """
+    diagnostics = validate_plugin_catalog_snapshot(snapshot)
+    if diagnostics:
+        raise PluginCatalogCoverageError("; ".join(diagnostics))
+    previous_snapshot: Mapping[str, Any] | None = None
+    if previous is not None:
+        previous_diagnostics = validate_plugin_catalog_snapshot(previous)
+        if previous_diagnostics:
+            raise PluginCatalogCoverageError(
+                "; ".join(f"previous snapshot: {item}" for item in previous_diagnostics[:MAX_DIAGNOSTICS])
+            )
+        previous_snapshot = previous
+    identity = snapshot_identity(snapshot)
+    requested_profile = profile_ref.strip()
+    if requested_profile and requested_profile != identity["profile_ref"]:
+        raise PluginCatalogCoverageError(
+            "snapshot was taken for a different profile than the one requested; "
+            "a cross-profile snapshot is a real observation of something else"
+        )
+    if previous_snapshot is not None:
+        previous_identity = snapshot_identity(previous_snapshot)
+        if previous_identity["profile_ref"] != identity["profile_ref"]:
+            raise PluginCatalogCoverageError(
+                "previous snapshot was taken for a different profile; comparing across profiles would "
+                "report host changes that never happened"
+            )
+    freshness = snapshot_freshness(snapshot, now=now)
+    snapshot_state = "current" if freshness["state"] == "fresh" else "stale"
+    current = {entry["plugin_id"]: entry for entry in snapshot_entries(snapshot)}
+    prior = (
+        {entry["plugin_id"]: entry for entry in snapshot_entries(previous_snapshot)}
+        if previous_snapshot is not None
+        else {}
+    )
+    rows = [
+        _coverage_row(
+            plugin_id,
+            current.get(plugin_id),
+            prior.get(plugin_id),
+            snapshot_state=snapshot_state,
+        )
+        for plugin_id in sorted(set(current) | set(prior))
+    ]
+    return _coverage_payload(
+        rows,
+        identity=identity,
+        previous_identity=snapshot_identity(previous_snapshot) if previous_snapshot is not None else None,
+        freshness=freshness,
+        snapshot_state=snapshot_state,
+        entry_count=len(current),
+        diagnostics=[],
+    )
+
+
+def plugin_catalog_coverage_unavailable(reason: str) -> dict[str, Any]:
+    """The answer when no snapshot is available.
+
+    Carries no entries and no packaged-catalog substitute. The packaged
+    reference block is still attached, labelled as the snapshot-limited
+    repository projection it is, so a reader can see that OMH declined to use
+    it rather than wondering whether it silently did.
+    """
+    bounded = reason.strip()[:200] or "no plugin catalog snapshot was supplied"
+    return _coverage_payload(
+        [],
+        identity={
+            "producer_kind": "",
+            "producer_ref": "",
+            "host_version": "",
+            "profile_ref": "",
+            "observed_at": "",
+            "catalog_revision": "",
+        },
+        previous_identity=None,
+        freshness={
+            "state": "unknown",
+            "age_seconds": None,
+            "stale_after_seconds": None,
+            "evaluated_at": "",
+        },
+        snapshot_state="unavailable",
+        entry_count=0,
+        diagnostics=[bounded],
+    )
+
+
+def render_plugin_catalog_coverage(payload: Mapping[str, Any]) -> str:
+    """The concise chat status for one coverage answer."""
+    summary = payload["summary"]
+    lines = [f"Plugin catalog coverage: {payload['snapshot_state']}"]
+    if payload["snapshot_state"] == "unavailable":
+        lines.append("No host catalog snapshot was supplied, so OMH reports no host coverage.")
+        for diagnostic in payload["diagnostics"]:
+            lines.append(f"  - {diagnostic}")
+        lines.extend(["", _packaged_reference_line(payload), "", str(payload["claim_boundary"])])
+        return "\n".join(lines)
+    identity = payload["snapshot"]
+    lines.append(
+        f"Snapshot: revision {identity['catalog_revision']} from {identity['producer_kind']} "
+        f"{identity['producer_ref']} observed {identity['observed_at']} (profile {identity['profile_ref']})"
+    )
+    freshness = payload["freshness"]
+    lines.append(f"Freshness: {freshness['state']} (age {freshness['age_seconds']}s)")
+    lines.append(f"Entries: {payload['entry_count']}")
+    lines.append("Coverage:")
+    for name in COVERAGE_CLASSES:
+        lines.append(f"  {name}: {summary['coverage_class_counts'][name]}")
+    lines.append("Changes since the prior snapshot:")
+    if payload["previous_snapshot"] is None:
+        lines.append("  no prior snapshot supplied; every entry is a first sighting")
+    for name in CHANGE_CLASSES:
+        lines.append(f"  {name}: {summary['change_class_counts'][name]}")
+    if payload["held_entries"]:
+        lines.append("Held:")
+        for row in payload["entries"]:
+            if row["adoption_guidance"] == "held":
+                lines.append(f"  {row['plugin_id']}: {', '.join(row['holds'])}")
+    if payload["unresolved_entries"]:
+        lines.append(f"Unresolved: {', '.join(payload['unresolved_entries'])} -> {GENERIC_REVIEW_ROUTE}")
+    lines.extend(["", _packaged_reference_line(payload), "", str(payload["claim_boundary"])])
+    return "\n".join(lines)
+
+
+def _coverage_payload(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    identity: Mapping[str, Any],
+    previous_identity: Mapping[str, Any] | None,
+    freshness: Mapping[str, Any],
+    snapshot_state: str,
+    entry_count: int,
+    diagnostics: Sequence[str],
+) -> dict[str, Any]:
+    if snapshot_state not in _SNAPSHOT_STATES:
+        raise PluginCatalogCoverageError(f"unsupported snapshot state: {snapshot_state}")
+    coverage_counts = {name: 0 for name in COVERAGE_CLASSES}
+    change_counts = {name: 0 for name in CHANGE_CLASSES}
+    for row in rows:
+        coverage_counts[str(row["coverage_class"])] += 1
+        change_counts[str(row["change_class"])] += 1
+    held = sorted(str(row["plugin_id"]) for row in rows if row["adoption_guidance"] == "held")
+    unresolved = sorted(
+        str(row["plugin_id"]) for row in rows if row["coverage_class"] in {"generic_review", "unknown"}
+    )
+    return {
+        "schema_version": PLUGIN_CATALOG_COVERAGE_SCHEMA_VERSION,
+        "snapshot_state": snapshot_state,
+        "snapshot": dict(identity),
+        "previous_snapshot": dict(previous_identity) if previous_identity is not None else None,
+        "freshness": dict(freshness),
+        "entry_count": entry_count,
+        "summary": {
+            "coverage_class_counts": coverage_counts,
+            "change_class_counts": change_counts,
+            "held_count": len(held),
+            "unresolved_count": len(unresolved),
+        },
+        "entries": [dict(row) for row in rows],
+        "held_entries": held,
+        "unresolved_entries": unresolved,
+        "packaged_reference": {
+            "catalog_revision": UPSTREAM_SOURCE_COMMIT,
+            "coverage_scope": PACKAGED_COVERAGE_SCOPE,
+            "coverage_scope_note": PACKAGED_COVERAGE_SCOPE_NOTE,
+            "used_as_host_coverage": False,
+        },
+        "diagnostics": list(diagnostics),
+        "claim_boundary": COVERAGE_CLAIM_BOUNDARY,
+    }
+
+
+def _coverage_row(
+    plugin_id: str,
+    entry: Mapping[str, Any] | None,
+    prior: Mapping[str, Any] | None,
+    *,
+    snapshot_state: str,
+) -> dict[str, Any]:
+    present = entry is not None
+    source = entry if entry is not None else (prior if prior is not None else {})
+    capabilities = tuple(str(item) for item in source.get("declared_capabilities", ()))
+    platform_limits = tuple(str(item) for item in source.get("platform_limits", ()))
+    env_names = tuple(str(item) for item in source.get("required_env_names", ()))
+    removal_status = str(source.get("removal_status", ""))
+    host_version_status = str(source.get("host_version_status", ""))
+    classification = _classify(
+        present=present,
+        capabilities=capabilities,
+        removal_status=removal_status,
+        host_version_status=host_version_status,
+    )
+    holds = list(classification["holds"])
+    guidance = str(classification["adoption_guidance"])
+    if snapshot_state == "stale":
+        holds.append("stale_snapshot")
+        guidance = "held"
+    advisories = _advisories(
+        tier=str(source.get("tier", "")),
+        removal_status=removal_status,
+        platform_limits=platform_limits,
+        env_names=env_names,
+        host_core=HOST_CORE_CAPABILITY in capabilities,
+    )
+    return {
+        "plugin_id": plugin_id,
+        "present_in_snapshot": present,
+        "coverage_class": classification["coverage_class"],
+        "change_class": _change_class(entry, prior),
+        "changed_fields": _changed_fields(entry, prior),
+        "content_revision": str(entry.get("content_revision", "")) if entry is not None else "",
+        "previous_content_revision": str(prior.get("content_revision", "")) if prior is not None else "",
+        "tier": str(source.get("tier", "")),
+        "declared_capabilities": list(capabilities),
+        "owner_boundary": classification["owner_boundary"],
+        "route": classification["route"],
+        "additional_routes": list(classification["additional_routes"]),
+        "adoption_guidance": guidance,
+        "holds": sorted(set(holds)),
+        "advisories": advisories,
+        "unavailable_evidence": _unavailable_evidence(
+            coverage_class=str(classification["coverage_class"]),
+            host_version_status=host_version_status,
+            platform_limits=platform_limits,
+        ),
+        "required_env_names": list(env_names),
+        "platform_limits": list(platform_limits),
+        "host_version_constraint": str(source.get("host_version_constraint", "")),
+        "host_version_status": host_version_status,
+        "removal_status": removal_status,
+    }
+
+
+def _classify(
+    *,
+    present: bool,
+    capabilities: tuple[str, ...],
+    removal_status: str,
+    host_version_status: str,
+) -> dict[str, Any]:
+    """Exactly one coverage class per entry, by fixed precedence.
+
+    Withdrawal and incompatibility come before capability mapping on purpose:
+    routing a withdrawn or refused entry to its outcome owner would read as
+    adoption guidance for something the host will not run.
+    """
+    if not present:
+        return _held("removed", "withdrawn_from_catalog")
+    if removal_status == "removed":
+        return _held("removed", "catalog_removal")
+    if host_version_status == "unsatisfied":
+        return _held("incompatible", "host_version_unsatisfied")
+    owned = [workflow for capability, workflow in CAPABILITY_OWNERS if capability in capabilities]
+    if owned:
+        return {
+            "coverage_class": "mapped",
+            "owner_boundary": "omh",
+            "route": owned[0],
+            "additional_routes": tuple(owned[1:]),
+            "adoption_guidance": "route_to_owner",
+            "holds": (),
+        }
+    if HOST_CORE_CAPABILITY in capabilities:
+        return {
+            "coverage_class": "generic_review",
+            "owner_boundary": "hermes_host",
+            "route": GENERIC_REVIEW_ROUTE,
+            "additional_routes": (),
+            "adoption_guidance": "host_owned",
+            "holds": (),
+        }
+    return {
+        "coverage_class": "generic_review" if capabilities else "unknown",
+        "owner_boundary": "omh",
+        "route": GENERIC_REVIEW_ROUTE,
+        "additional_routes": (),
+        "adoption_guidance": "generic_review",
+        "holds": (),
+    }
+
+
+def _held(coverage_class: str, hold: str) -> dict[str, Any]:
+    return {
+        "coverage_class": coverage_class,
+        "owner_boundary": "omh",
+        "route": HELD_REVIEW_ROUTE,
+        "additional_routes": (),
+        "adoption_guidance": "held",
+        "holds": (hold,),
+    }
+
+
+def _change_class(entry: Mapping[str, Any] | None, prior: Mapping[str, Any] | None) -> str:
+    """One change class per row against the prior snapshot.
+
+    With no prior snapshot every row is `added` -- a first sighting. Calling it
+    `unchanged` would claim a comparison that never happened, and the payload
+    says separately that no previous snapshot was supplied so a reader can tell
+    a first run from one admitted entry.
+    """
+    if entry is None:
+        return "removed"
+    if prior is None:
+        return "added"
+    return "changed" if _changed_fields(entry, prior) else "unchanged"
+
+
+def _changed_fields(entry: Mapping[str, Any] | None, prior: Mapping[str, Any] | None) -> list[str]:
+    if entry is None or prior is None:
+        return []
+    return [field for field in TRACKED_ENTRY_FIELDS if entry.get(field) != prior.get(field)]
+
+
+def _advisories(
+    *,
+    tier: str,
+    removal_status: str,
+    platform_limits: tuple[str, ...],
+    env_names: tuple[str, ...],
+    host_core: bool,
+) -> list[str]:
+    advisories: list[str] = []
+    if tier == "unreviewed":
+        advisories.append("unreviewed_tier")
+    if removal_status == "deprecated":
+        advisories.append("catalog_deprecation")
+    if platform_limits:
+        advisories.append("platform_limited")
+    if env_names:
+        advisories.append("requires_environment_names")
+    if host_core:
+        advisories.append("host_owned_mechanics")
+    return sorted(advisories)
+
+
+def _unavailable_evidence(
+    *,
+    coverage_class: str,
+    host_version_status: str,
+    platform_limits: tuple[str, ...],
+) -> list[str]:
+    evidence = set(BASELINE_UNAVAILABLE_EVIDENCE)
+    if platform_limits:
+        evidence.add("host_platform_match")
+    if host_version_status == "unknown":
+        evidence.add("host_version_evaluation")
+    if coverage_class == "removed":
+        evidence.add("installed_copy_state")
+    return sorted(evidence)
+
+
+def _packaged_reference_line(payload: Mapping[str, Any]) -> str:
+    reference = payload["packaged_reference"]
+    return (
+        f"Packaged catalog {reference['catalog_revision']} is {reference['coverage_scope']} and was not "
+        "used as host coverage."
+    )
+
+
+__all__ = [
+    "ADOPTION_GUIDANCE",
+    "BASELINE_UNAVAILABLE_EVIDENCE",
+    "CAPABILITY_OWNERS",
+    "CHANGE_CLASSES",
+    "COVERAGE_CLAIM_BOUNDARY",
+    "COVERAGE_CLASSES",
+    "GENERIC_REVIEW_ROUTE",
+    "HELD_REVIEW_ROUTE",
+    "HOST_CORE_CAPABILITY",
+    "PLUGIN_CATALOG_COVERAGE_SCHEMA_VERSION",
+    "TRACKED_ENTRY_FIELDS",
+    "PluginCatalogCoverageError",
+    "build_plugin_catalog_coverage",
+    "plugin_catalog_coverage_unavailable",
+    "render_plugin_catalog_coverage",
+]

--- a/src/workflows/plugin_catalog_snapshots.py
+++ b/src/workflows/plugin_catalog_snapshots.py
@@ -1,0 +1,436 @@
+"""Host plugin catalog snapshots (`plugin_catalog_snapshot/v1`, issue #1449).
+
+OMH ships one packaged ecosystem catalog and a hand-curated outcome matrix.
+Both are pinned to a repository revision, so a plugin the host admitted this
+morning, a reviewed revision that changed underneath an identity, a removal,
+or a host-version constraint the host refused is invisible until a maintainer
+edits the repository. This contract is the input that makes those visible
+without OMH acquiring anything.
+
+A snapshot is produced by an authorized host or operator and handed to OMH as
+a file. OMH validates it, reconciles it (see
+`omh.workflows.plugin_catalog_coverage`), and reports. It fetches nothing,
+reads no credential, imports no plugin, installs no dependency, and changes no
+host configuration -- the file is the only input, and reading it is the only
+thing that happens.
+
+Three properties carry the contract:
+
+- **Identity and content revision are separate fields.** `plugin_id` is the
+  stable identity the host uses; `content_revision` is the reviewed content
+  behind it at snapshot time. Keeping them apart is what lets a reviewed
+  revision change read as `changed` for a known identity rather than as a new
+  plugin, and it is why both revisions survive into the coverage row.
+- **Every field is untrusted metadata.** Identifiers come from outside OMH, so
+  each one is screened as a bounded opaque reference. `required_env_names`
+  carries environment variable *names* -- the one field whose legitimate
+  content contains the words `TOKEN` and `SECRET` -- so it is screened with
+  `is_secret_value_shaped`, which flags issued credential material and never a
+  name. There is no field a credential value, a file body, or a repository
+  excerpt can arrive in.
+- **A catalog entry is a review signal, not a security guarantee.** Declared
+  capabilities are what the entry claims, recorded as claims. Nothing here is
+  evidence that a plugin behaves the way its entry says, that the host loaded
+  it, or that anyone ran it.
+
+Diagnostics are bounded and positional. A violation names the entry index and
+the field, never the offending value, so a malformed snapshot cannot use OMH's
+own error path to print what it was carrying.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final
+
+from ..system.metadata_safety import (
+    is_body_shaped_metadata_text,
+    is_raw_pii_shaped,
+    is_secret_value_shaped,
+    is_sensitive_metadata_text,
+)
+
+
+PLUGIN_CATALOG_SNAPSHOT_SCHEMA_VERSION: Final = "plugin_catalog_snapshot/v1"
+
+SNAPSHOT_CLAIM_BOUNDARY: Final = (
+    "A plugin catalog snapshot is a bounded, point-in-time record an authorized host or operator "
+    "produced about its own catalog. It is not plugin installation, admission, activation, permission, "
+    "compatibility enforcement, or execution evidence, and OMH acquired none of it."
+)
+
+#: Who may produce a snapshot. Both are outside OMH: the host reports its own
+#: catalog, or an operator exports it. OMH never produces one.
+SNAPSHOT_PRODUCER_KINDS: Final = ("hermes_host", "authorized_operator")
+
+#: What the host says about the entry's review tier. `unreviewed` is a real
+#: value, not a missing one -- an admitted-but-unreviewed entry still routes.
+ENTRY_TIERS: Final = ("official", "verified", "community", "unreviewed")
+
+#: The host's own answer to its own constraint. OMH does not parse, compare, or
+#: solve `host_version_constraint`; version enforcement is the host's job and
+#: this field is where the host reports the result of doing it.
+HOST_VERSION_STATUSES: Final = ("satisfied", "unsatisfied", "unknown")
+
+#: `removed` means the catalog withdrew the entry. It says nothing about an
+#: installed copy on the machine, which OMH cannot see.
+REMOVAL_STATUSES: Final = ("active", "deprecated", "removed")
+
+#: Platform shapes an entry declares it is limited to. Closed, because an
+#: open platform vocabulary would make "desktop only" unrecognisable.
+PLATFORM_LIMITS: Final = ("desktop", "headless", "linux", "macos", "windows")
+
+#: Bounds. A snapshot is metadata about a catalog, not a catalog dump, and
+#: every one of these is a refusal rather than a truncation: silently dropping
+#: the tail of an oversized snapshot would report coverage over a subset while
+#: claiming to cover the whole catalog.
+MAX_SNAPSHOT_BYTES: Final = 512 * 1024
+MAX_SNAPSHOT_ENTRIES: Final = 512
+MAX_ENTRY_CAPABILITIES: Final = 16
+MAX_ENTRY_ENV_NAMES: Final = 32
+MAX_ENTRY_PLATFORM_LIMITS: Final = len(PLATFORM_LIMITS)
+MAX_METADATA_TEXT: Final = 160
+#: How many diagnostics a caller sees before the list is closed with a count.
+#: A snapshot with a thousand broken entries must not print a thousand lines.
+MAX_DIAGNOSTICS: Final = 20
+
+#: A catalog moves when the host admits, revises, or withdraws an entry, which
+#: is a slower clock than a live connector but not a still one. A day-old
+#: snapshot is reported as stale rather than as the current catalog.
+SNAPSHOT_STALE_AFTER_SECONDS: Final = 24 * 60 * 60
+
+_ENVELOPE_KEYS: Final = (
+    "schema_version",
+    "producer",
+    "profile_ref",
+    "observed_at",
+    "catalog_revision",
+    "entry_count",
+    "entries",
+)
+_PRODUCER_KEYS: Final = ("kind", "ref", "host_version")
+_ENTRY_KEYS: Final = (
+    "plugin_id",
+    "content_revision",
+    "tier",
+    "declared_capabilities",
+    "required_env_names",
+    "platform_limits",
+    "host_version_constraint",
+    "host_version_status",
+    "removal_status",
+)
+
+_OPAQUE_REF = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/+-]{0,127}$")
+_CAPABILITY_TOKEN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,47}$")
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+
+
+class PluginCatalogSnapshotError(ValueError):
+    """A snapshot could not be read at all, before any field was inspected."""
+
+
+def validate_plugin_catalog_snapshot(raw: object) -> list[str]:
+    """Bounded diagnostics for one candidate snapshot; empty means it parsed.
+
+    Positional by design: every diagnostic names an entry index and a field
+    name and never the value that failed, so an untrusted snapshot cannot
+    route its own content through OMH's error output.
+    """
+    diagnostics: list[str] = []
+    if not isinstance(raw, Mapping):
+        return ["snapshot must be a JSON object"]
+    _check_key_set(raw, _ENVELOPE_KEYS, "snapshot", diagnostics)
+    if raw.get("schema_version") != PLUGIN_CATALOG_SNAPSHOT_SCHEMA_VERSION:
+        diagnostics.append(f"snapshot.schema_version must be {PLUGIN_CATALOG_SNAPSHOT_SCHEMA_VERSION}")
+    _validate_producer(raw.get("producer"), diagnostics)
+    _check_opaque(raw.get("profile_ref"), "snapshot.profile_ref", diagnostics)
+    _check_opaque(raw.get("catalog_revision"), "snapshot.catalog_revision", diagnostics)
+    if _parse_stamp(raw.get("observed_at")) is None:
+        diagnostics.append("snapshot.observed_at must be an ISO-8601 timestamp")
+    diagnostics.extend(_validate_entries(raw.get("entries"), raw.get("entry_count")))
+    return _bounded(diagnostics)
+
+
+def load_plugin_catalog_snapshot(path: str | Path) -> dict[str, Any]:
+    """Read one snapshot file, refusing an oversized or unparsable one.
+
+    The byte cap is enforced on the file before `json.loads` sees it, so an
+    oversized input is refused rather than parsed and then measured.
+    """
+    resolved = Path(path).expanduser()
+    try:
+        size = resolved.stat().st_size
+    except OSError as exc:
+        raise PluginCatalogSnapshotError(f"snapshot file could not be read: {exc.strerror or 'unavailable'}") from exc
+    if size > MAX_SNAPSHOT_BYTES:
+        raise PluginCatalogSnapshotError(
+            f"snapshot file exceeds the {MAX_SNAPSHOT_BYTES}-byte bound and was not parsed"
+        )
+    try:
+        text = resolved.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PluginCatalogSnapshotError(f"snapshot file could not be read: {exc.strerror or 'unavailable'}") from exc
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise PluginCatalogSnapshotError(f"snapshot file is not valid JSON at line {exc.lineno}") from exc
+    if not isinstance(parsed, dict):
+        raise PluginCatalogSnapshotError("snapshot file must contain a JSON object")
+    return parsed
+
+
+def snapshot_entries(snapshot: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+    """Entries of a validated snapshot, sorted by identity."""
+    entries = snapshot.get("entries")
+    if not isinstance(entries, Sequence):
+        return ()
+    return tuple(sorted((dict(entry) for entry in entries if isinstance(entry, Mapping)), key=_entry_identity))
+
+
+def snapshot_freshness(snapshot: Mapping[str, Any], *, now: str = "") -> dict[str, Any]:
+    """Whether the snapshot still describes the catalog it was taken from.
+
+    An unreadable reference clock reports `unknown` rather than `fresh`: a
+    snapshot whose age nobody could compute has not been shown to be current.
+    """
+    observed = _parse_stamp(snapshot.get("observed_at"))
+    reference = _parse_stamp(now) if now.strip() else datetime.now(timezone.utc)
+    if observed is None or reference is None:
+        return {
+            "state": "unknown",
+            "age_seconds": None,
+            "stale_after_seconds": SNAPSHOT_STALE_AFTER_SECONDS,
+            "evaluated_at": _format_stamp(reference),
+        }
+    age = int((reference - observed).total_seconds())
+    state = "stale" if age > SNAPSHOT_STALE_AFTER_SECONDS or age < 0 else "fresh"
+    return {
+        "state": state,
+        "age_seconds": age,
+        "stale_after_seconds": SNAPSHOT_STALE_AFTER_SECONDS,
+        "evaluated_at": _format_stamp(reference),
+    }
+
+
+def snapshot_identity(snapshot: Mapping[str, Any]) -> dict[str, Any]:
+    """The producer, profile, time, and revision one coverage answer is bound to."""
+    producer = snapshot.get("producer")
+    producer_map = producer if isinstance(producer, Mapping) else {}
+    return {
+        "producer_kind": str(producer_map.get("kind", "")),
+        "producer_ref": str(producer_map.get("ref", "")),
+        "host_version": str(producer_map.get("host_version", "")),
+        "profile_ref": str(snapshot.get("profile_ref", "")),
+        "observed_at": str(snapshot.get("observed_at", "")),
+        "catalog_revision": str(snapshot.get("catalog_revision", "")),
+    }
+
+
+def _validate_producer(raw: object, diagnostics: list[str]) -> None:
+    if not isinstance(raw, Mapping):
+        diagnostics.append("snapshot.producer must be an object")
+        return
+    _check_key_set(raw, _PRODUCER_KEYS, "snapshot.producer", diagnostics)
+    if raw.get("kind") not in SNAPSHOT_PRODUCER_KINDS:
+        diagnostics.append("snapshot.producer.kind must name an authorized host or operator")
+    _check_opaque(raw.get("ref"), "snapshot.producer.ref", diagnostics)
+    _check_opaque(raw.get("host_version"), "snapshot.producer.host_version", diagnostics)
+
+
+def _validate_entries(raw: object, declared_count: object) -> list[str]:
+    diagnostics: list[str] = []
+    if not isinstance(raw, list):
+        return ["snapshot.entries must be a list"]
+    if len(raw) > MAX_SNAPSHOT_ENTRIES:
+        return [f"snapshot.entries exceeds the {MAX_SNAPSHOT_ENTRIES}-entry bound"]
+    if declared_count != len(raw):
+        diagnostics.append("snapshot.entry_count does not match the number of entries")
+    seen: set[str] = set()
+    for index, entry in enumerate(raw):
+        diagnostics.extend(_validate_entry(entry, index))
+        if isinstance(entry, Mapping):
+            identity = entry.get("plugin_id")
+            if isinstance(identity, str):
+                if identity in seen:
+                    diagnostics.append(f"entries[{index}].plugin_id repeats an identity already in this snapshot")
+                seen.add(identity)
+    return diagnostics
+
+
+def _validate_entry(raw: object, index: int) -> list[str]:
+    diagnostics: list[str] = []
+    label = f"entries[{index}]"
+    if not isinstance(raw, Mapping):
+        return [f"{label} must be an object"]
+    _check_key_set(raw, _ENTRY_KEYS, label, diagnostics)
+    _check_opaque(raw.get("plugin_id"), f"{label}.plugin_id", diagnostics)
+    _check_opaque(raw.get("content_revision"), f"{label}.content_revision", diagnostics)
+    if raw.get("tier") not in ENTRY_TIERS:
+        diagnostics.append(f"{label}.tier must be one of {', '.join(ENTRY_TIERS)}")
+    if raw.get("host_version_status") not in HOST_VERSION_STATUSES:
+        diagnostics.append(f"{label}.host_version_status must be one of {', '.join(HOST_VERSION_STATUSES)}")
+    if raw.get("removal_status") not in REMOVAL_STATUSES:
+        diagnostics.append(f"{label}.removal_status must be one of {', '.join(REMOVAL_STATUSES)}")
+    _check_token_list(
+        raw.get("declared_capabilities"),
+        f"{label}.declared_capabilities",
+        _CAPABILITY_TOKEN,
+        MAX_ENTRY_CAPABILITIES,
+        diagnostics,
+    )
+    _check_env_names(raw.get("required_env_names"), f"{label}.required_env_names", diagnostics)
+    _check_platform_limits(raw.get("platform_limits"), f"{label}.platform_limits", diagnostics)
+    _check_constraint(raw.get("host_version_constraint"), f"{label}.host_version_constraint", diagnostics)
+    return diagnostics
+
+
+def _check_key_set(raw: Mapping[str, Any], expected: tuple[str, ...], label: str, diagnostics: list[str]) -> None:
+    present = set(raw)
+    missing = sorted(set(expected) - present)
+    unexpected = sorted(present - set(expected))
+    if missing:
+        diagnostics.append(f"{label} is missing required fields: {', '.join(missing)}")
+    if unexpected:
+        diagnostics.append(f"{label} carries unsupported fields: {', '.join(unexpected)}")
+
+
+def _check_opaque(value: object, label: str, diagnostics: list[str]) -> None:
+    if not isinstance(value, str) or not _OPAQUE_REF.fullmatch(value):
+        diagnostics.append(f"{label} must be a bounded opaque reference")
+        return
+    if is_sensitive_metadata_text(value) or is_raw_pii_shaped(value):
+        diagnostics.append(f"{label} must not carry credential or personal-identifier text")
+
+
+def _check_constraint(value: object, label: str, diagnostics: list[str]) -> None:
+    """The host's constraint expression, kept as opaque text OMH never parses."""
+    if not isinstance(value, str):
+        diagnostics.append(f"{label} must be a string")
+        return
+    if not value:
+        return
+    if is_body_shaped_metadata_text(value, limit=MAX_METADATA_TEXT):
+        diagnostics.append(f"{label} must be one bounded line")
+        return
+    if is_sensitive_metadata_text(value) or is_raw_pii_shaped(value):
+        diagnostics.append(f"{label} must not carry credential or personal-identifier text")
+
+
+def _check_token_list(
+    value: object,
+    label: str,
+    pattern: re.Pattern[str],
+    bound: int,
+    diagnostics: list[str],
+) -> None:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        diagnostics.append(f"{label} must be a list of strings")
+        return
+    items = [str(item) for item in value]
+    if len(items) > bound:
+        diagnostics.append(f"{label} exceeds the {bound}-item bound")
+        return
+    if items != sorted(items) or len(items) != len(set(items)):
+        diagnostics.append(f"{label} must be sorted and unique")
+    if any(not pattern.fullmatch(item) for item in items):
+        diagnostics.append(f"{label} contains an unsupported token shape")
+
+
+def _check_env_names(value: object, label: str, diagnostics: list[str]) -> None:
+    """Environment variable *names*, never values.
+
+    A name legitimately reads as `GITHUB_TOKEN` or `OPENAI_API_KEY`, so the
+    wider sensitive-text screen would refuse every honest snapshot here. The
+    narrow screen flags issued credential material -- prefixed keys, AWS access
+    key ids -- which a variable name can never match.
+    """
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        diagnostics.append(f"{label} must be a list of strings")
+        return
+    items = [str(item) for item in value]
+    if len(items) > MAX_ENTRY_ENV_NAMES:
+        diagnostics.append(f"{label} exceeds the {MAX_ENTRY_ENV_NAMES}-item bound")
+        return
+    if items != sorted(items) or len(items) != len(set(items)):
+        diagnostics.append(f"{label} must be sorted and unique")
+    if any(not _ENV_NAME.fullmatch(item) for item in items):
+        diagnostics.append(f"{label} must contain environment variable names only")
+        return
+    if any(is_secret_value_shaped(item) for item in items):
+        diagnostics.append(f"{label} contains a credential value rather than a variable name")
+
+
+def _check_platform_limits(value: object, label: str, diagnostics: list[str]) -> None:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        diagnostics.append(f"{label} must be a list of strings")
+        return
+    items = [str(item) for item in value]
+    if len(items) > MAX_ENTRY_PLATFORM_LIMITS:
+        diagnostics.append(f"{label} exceeds the {MAX_ENTRY_PLATFORM_LIMITS}-item bound")
+        return
+    if items != sorted(items) or len(items) != len(set(items)):
+        diagnostics.append(f"{label} must be sorted and unique")
+    if any(item not in PLATFORM_LIMITS for item in items):
+        diagnostics.append(f"{label} must use platform limits from {', '.join(PLATFORM_LIMITS)}")
+
+
+def _bounded(diagnostics: list[str]) -> list[str]:
+    if len(diagnostics) <= MAX_DIAGNOSTICS:
+        return diagnostics
+    hidden = len(diagnostics) - MAX_DIAGNOSTICS
+    return [*diagnostics[:MAX_DIAGNOSTICS], f"... {hidden} further diagnostics were not listed"]
+
+
+def _entry_identity(entry: Mapping[str, Any]) -> str:
+    identity = entry.get("plugin_id")
+    return identity if isinstance(identity, str) else ""
+
+
+def _parse_stamp(value: object) -> datetime | None:
+    """An aware UTC datetime from an ISO-8601 timestamp, else None."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_stamp(value: datetime | None) -> str:
+    if value is None:
+        return ""
+    return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+__all__ = [
+    "ENTRY_TIERS",
+    "HOST_VERSION_STATUSES",
+    "MAX_DIAGNOSTICS",
+    "MAX_ENTRY_CAPABILITIES",
+    "MAX_ENTRY_ENV_NAMES",
+    "MAX_SNAPSHOT_BYTES",
+    "MAX_SNAPSHOT_ENTRIES",
+    "PLATFORM_LIMITS",
+    "PLUGIN_CATALOG_SNAPSHOT_SCHEMA_VERSION",
+    "REMOVAL_STATUSES",
+    "SNAPSHOT_CLAIM_BOUNDARY",
+    "SNAPSHOT_PRODUCER_KINDS",
+    "SNAPSHOT_STALE_AFTER_SECONDS",
+    "PluginCatalogSnapshotError",
+    "load_plugin_catalog_snapshot",
+    "snapshot_entries",
+    "snapshot_freshness",
+    "snapshot_identity",
+    "validate_plugin_catalog_snapshot",
+]

--- a/tests/test_awesome_hermes_agent_plugin_outcomes.py
+++ b/tests/test_awesome_hermes_agent_plugin_outcomes.py
@@ -1,14 +1,28 @@
 from __future__ import annotations
 
+from importlib.resources import files
 import json
 import unittest
 
 from _cli_harness import run_cli
+from omh.catalogs.awesome_hermes_agent import PACKAGED_COVERAGE_SCOPE
 from omh.catalogs.awesome_hermes_agent_outcomes import (
     PLUGIN_OUTCOME_SCHEMA_VERSION,
     _parse_plugin_outcomes,
     awesome_hermes_plugin_outcomes,
 )
+
+
+def stored_matrix() -> dict[str, object]:
+    """The envelope as it sits on disk.
+
+    `_parse_plugin_outcomes` validates the stored envelope, whose key set is
+    closed. `awesome_hermes_plugin_outcomes` returns a projection of it that
+    also carries the coverage-scope label, so feeding the projection back into
+    the parser tests a shape the parser never receives.
+    """
+    resource = files("omh.catalogs").joinpath("awesome_hermes_agent_plugin_outcomes.json")
+    return json.loads(resource.read_text(encoding="utf-8"))
 
 
 class AwesomeHermesAgentPluginOutcomeTests(unittest.TestCase):
@@ -50,12 +64,17 @@ class AwesomeHermesAgentPluginOutcomeTests(unittest.TestCase):
             self.assertEqual(outcomes[plugin_id]["implementation_state"], "omh_native")
 
     def test_loader_rejects_native_claims_without_implementation_evidence(self) -> None:
-        payload = awesome_hermes_plugin_outcomes()
-        invalid = json.loads(json.dumps(payload))
+        invalid = stored_matrix()
         invalid["outcomes"][0]["evidence_refs"] = []
 
         with self.assertRaisesRegex(ValueError, "code or test evidence"):
             _parse_plugin_outcomes(invalid)
+
+    def test_the_matrix_is_labelled_as_a_packaged_snapshot_not_host_coverage(self) -> None:
+        payload = awesome_hermes_plugin_outcomes()
+
+        self.assertEqual(payload["coverage_scope"], PACKAGED_COVERAGE_SCOPE)
+        self.assertIn("not the active host catalog", str(payload["coverage_scope_note"]))
 
     def test_ecosystem_cli_emits_the_outcomes_matrix(self) -> None:
         status, stdout, stderr = run_cli(["ecosystem", "awesome-hermes", "outcomes", "--json"])

--- a/tests/test_plugin_catalog_coverage.py
+++ b/tests/test_plugin_catalog_coverage.py
@@ -1,0 +1,713 @@
+"""Plugin catalog coverage against a supplied host snapshot (issue #1449).
+
+The cases here are grouped by the question each one keeps honest rather than
+by function, because the failures worth catching are all confusions between
+two answers that look alike: a rediscovered entry reading as a new one, a
+stale snapshot reading as the current catalog, the packaged repository catalog
+reading as host coverage, and catalog presence reading as readiness.
+
+No global plugin count is pinned anywhere in this file. Every routing case
+builds the entries it is about, so admitting a new capability shape never
+forces an unrelated number to move.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _cli_harness import run_cli
+from _credential_fixtures import AWS_ACCESS_KEY_ID
+from _local_package import load_local_package
+
+
+load_local_package()
+from omh.catalogs.awesome_hermes_agent import (  # noqa: E402
+    PACKAGED_COVERAGE_SCOPE,
+    awesome_hermes_coverage_payload,
+    awesome_hermes_summary,
+)
+from omh.catalogs.awesome_hermes_agent_outcomes import awesome_hermes_plugin_outcomes  # noqa: E402
+from omh.workflows.plugin_catalog_coverage import (  # noqa: E402
+    COVERAGE_CLASSES,
+    GENERIC_REVIEW_ROUTE,
+    HELD_REVIEW_ROUTE,
+    PLUGIN_CATALOG_COVERAGE_SCHEMA_VERSION,
+    PluginCatalogCoverageError,
+    build_plugin_catalog_coverage,
+    plugin_catalog_coverage_unavailable,
+    render_plugin_catalog_coverage,
+)
+from omh.workflows.plugin_catalog_snapshots import (  # noqa: E402
+    MAX_DIAGNOSTICS,
+    MAX_SNAPSHOT_BYTES,
+    MAX_SNAPSHOT_ENTRIES,
+    PLUGIN_CATALOG_SNAPSHOT_SCHEMA_VERSION,
+    PluginCatalogSnapshotError,
+    load_plugin_catalog_snapshot,
+    validate_plugin_catalog_snapshot,
+)
+
+
+OBSERVED_AT = "2026-09-10T09:00:00Z"
+NOW = "2026-09-10T10:00:00Z"
+MUCH_LATER = "2026-09-30T10:00:00Z"
+
+# Every module that would turn the adapter into a fetcher, an installer, or a
+# loader. The contract's whole premise is that the supplied file is the only
+# input, and an import here would make that claim unenforceable.
+NETWORK_AND_EXECUTION_MODULES = (
+    "http",
+    "httpx",
+    "importlib",
+    "requests",
+    "socket",
+    "ssl",
+    "subprocess",
+    "urllib",
+)
+
+
+def entry(
+    plugin_id: str,
+    *,
+    content_revision: str = "rev-1",
+    tier: str = "verified",
+    declared_capabilities: tuple[str, ...] = ("provider",),
+    required_env_names: tuple[str, ...] = (),
+    platform_limits: tuple[str, ...] = (),
+    host_version_constraint: str = "",
+    host_version_status: str = "satisfied",
+    removal_status: str = "active",
+) -> dict[str, object]:
+    return {
+        "plugin_id": plugin_id,
+        "content_revision": content_revision,
+        "tier": tier,
+        "declared_capabilities": list(declared_capabilities),
+        "required_env_names": list(required_env_names),
+        "platform_limits": list(platform_limits),
+        "host_version_constraint": host_version_constraint,
+        "host_version_status": host_version_status,
+        "removal_status": removal_status,
+    }
+
+
+def snapshot(
+    entries: list[dict[str, object]],
+    *,
+    catalog_revision: str = "catalog-rev-1",
+    observed_at: str = OBSERVED_AT,
+    profile_ref: str = "default",
+    producer_kind: str = "hermes_host",
+) -> dict[str, object]:
+    return {
+        "schema_version": PLUGIN_CATALOG_SNAPSHOT_SCHEMA_VERSION,
+        "producer": {"kind": producer_kind, "ref": "hermes-host-a", "host_version": "0.13.2"},
+        "profile_ref": profile_ref,
+        "observed_at": observed_at,
+        "catalog_revision": catalog_revision,
+        "entry_count": len(entries),
+        "entries": entries,
+    }
+
+
+def rows_by_id(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {str(row["plugin_id"]): row for row in payload["entries"]}
+
+
+class SnapshotIdentityTests(unittest.TestCase):
+    """AC1: one answer, bound to one producer, time, and catalog revision."""
+
+    def test_a_valid_snapshot_produces_sorted_output_bound_to_its_identity(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("zeta-provider"), entry("alpha-connector", declared_capabilities=("connector",))]),
+            now=NOW,
+        )
+
+        self.assertEqual(payload["schema_version"], PLUGIN_CATALOG_COVERAGE_SCHEMA_VERSION)
+        self.assertEqual(payload["snapshot_state"], "current")
+        self.assertEqual(payload["snapshot"]["producer_kind"], "hermes_host")
+        self.assertEqual(payload["snapshot"]["producer_ref"], "hermes-host-a")
+        self.assertEqual(payload["snapshot"]["observed_at"], OBSERVED_AT)
+        self.assertEqual(payload["snapshot"]["catalog_revision"], "catalog-rev-1")
+        self.assertEqual([row["plugin_id"] for row in payload["entries"]], ["alpha-connector", "zeta-provider"])
+        self.assertEqual(payload["entry_count"], 2)
+
+    def test_the_same_inputs_produce_a_byte_identical_answer(self) -> None:
+        inputs = snapshot([entry("beta-memory", declared_capabilities=("memory",)), entry("alpha-provider")])
+
+        first = build_plugin_catalog_coverage(inputs, now=NOW)
+        second = build_plugin_catalog_coverage(inputs, now=NOW)
+
+        self.assertEqual(json.dumps(first, sort_keys=True), json.dumps(second, sort_keys=True))
+
+    def test_entry_order_in_the_file_does_not_change_the_answer(self) -> None:
+        forward = [entry("alpha-provider"), entry("beta-connector", declared_capabilities=("connector",))]
+        reversed_order = list(reversed(forward))
+
+        first = build_plugin_catalog_coverage(snapshot(forward), now=NOW)
+        second = build_plugin_catalog_coverage(snapshot(reversed_order), now=NOW)
+
+        self.assertEqual(json.dumps(first, sort_keys=True), json.dumps(second, sort_keys=True))
+
+
+class ChangeClassificationTests(unittest.TestCase):
+    """AC2 and AC3: a rediscovered entry is not a new one."""
+
+    def test_one_admitted_entry_reports_exactly_one_added_row(self) -> None:
+        previous = snapshot([entry("alpha-provider")])
+        current = snapshot(
+            [entry("alpha-provider"), entry("beta-connector", declared_capabilities=("connector",))],
+            catalog_revision="catalog-rev-2",
+        )
+
+        payload = build_plugin_catalog_coverage(current, previous=previous, now=NOW)
+
+        self.assertEqual(payload["summary"]["change_class_counts"]["added"], 1)
+        self.assertEqual(payload["summary"]["change_class_counts"]["unchanged"], 1)
+        self.assertEqual(payload["summary"]["change_class_counts"]["changed"], 0)
+        self.assertEqual(payload["summary"]["change_class_counts"]["removed"], 0)
+        self.assertEqual(rows_by_id(payload)["beta-connector"]["change_class"], "added")
+
+    def test_replaying_the_same_snapshot_reports_no_new_row(self) -> None:
+        current = snapshot([entry("alpha-provider"), entry("beta-connector", declared_capabilities=("connector",))])
+
+        payload = build_plugin_catalog_coverage(current, previous=current, now=NOW)
+
+        counts = payload["summary"]["change_class_counts"]
+        self.assertEqual(counts["unchanged"], 2)
+        self.assertEqual(counts["added"], 0)
+        self.assertEqual(counts["changed"], 0)
+        self.assertEqual(counts["removed"], 0)
+
+    def test_a_reviewed_revision_change_is_changed_and_keeps_both_revisions(self) -> None:
+        previous = snapshot([entry("alpha-provider", content_revision="rev-1")])
+        current = snapshot(
+            [entry("alpha-provider", content_revision="rev-2")],
+            catalog_revision="catalog-rev-2",
+        )
+
+        payload = build_plugin_catalog_coverage(current, previous=previous, now=NOW)
+        row = rows_by_id(payload)["alpha-provider"]
+
+        self.assertEqual(row["change_class"], "changed")
+        self.assertNotEqual(row["change_class"], "added")
+        self.assertEqual(row["previous_content_revision"], "rev-1")
+        self.assertEqual(row["content_revision"], "rev-2")
+        self.assertEqual(row["changed_fields"], ["content_revision"])
+        self.assertEqual(payload["previous_snapshot"]["catalog_revision"], "catalog-rev-1")
+
+    def test_a_capability_change_is_changed_and_names_the_field_that_moved(self) -> None:
+        previous = snapshot([entry("alpha-plugin", declared_capabilities=("provider",))])
+        current = snapshot([entry("alpha-plugin", declared_capabilities=("connector", "provider"))])
+
+        row = rows_by_id(build_plugin_catalog_coverage(current, previous=previous, now=NOW))["alpha-plugin"]
+
+        self.assertEqual(row["change_class"], "changed")
+        self.assertEqual(row["changed_fields"], ["declared_capabilities"])
+
+    def test_an_entry_that_left_the_catalog_reports_removed_and_keeps_its_prior_revision(self) -> None:
+        previous = snapshot([entry("alpha-provider"), entry("beta-connector", declared_capabilities=("connector",))])
+        current = snapshot([entry("alpha-provider")], catalog_revision="catalog-rev-2")
+
+        row = rows_by_id(build_plugin_catalog_coverage(current, previous=previous, now=NOW))["beta-connector"]
+
+        self.assertEqual(row["change_class"], "removed")
+        self.assertEqual(row["coverage_class"], "removed")
+        self.assertFalse(row["present_in_snapshot"])
+        self.assertEqual(row["previous_content_revision"], "rev-1")
+        self.assertEqual(row["content_revision"], "")
+
+    def test_without_a_prior_snapshot_every_row_is_a_first_sighting(self) -> None:
+        payload = build_plugin_catalog_coverage(snapshot([entry("alpha-provider")]), now=NOW)
+
+        self.assertIsNone(payload["previous_snapshot"])
+        self.assertEqual(payload["summary"]["change_class_counts"]["added"], 1)
+        self.assertIn("no prior snapshot supplied", render_plugin_catalog_coverage(payload))
+
+
+class RemovalAndCompatibilityHoldTests(unittest.TestCase):
+    """AC4 and AC5: withdrawal and incompatibility are held, never ready."""
+
+    def test_a_removed_entry_is_held_and_routed_to_review(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("alpha-provider", removal_status="removed")]),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["alpha-provider"]
+
+        self.assertEqual(row["coverage_class"], "removed")
+        self.assertEqual(row["adoption_guidance"], "held")
+        self.assertEqual(row["route"], HELD_REVIEW_ROUTE)
+        self.assertIn("catalog_removal", row["holds"])
+        self.assertEqual(payload["held_entries"], ["alpha-provider"])
+
+    def test_a_removal_hold_never_claims_an_installed_copy_changed(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("alpha-provider", removal_status="removed")]),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["alpha-provider"]
+
+        self.assertIn("installed_copy_state", row["unavailable_evidence"])
+        boundary = str(payload["claim_boundary"])
+        self.assertIn("says nothing about whether an installed copy exists", boundary)
+        for forbidden in ("disabled the plugin", "uninstalled the plugin"):
+            self.assertNotIn(forbidden, boundary)
+
+    def test_an_unmet_host_version_constraint_is_incompatible_and_held(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot(
+                [
+                    entry(
+                        "alpha-provider",
+                        host_version_constraint=">=0.14",
+                        host_version_status="unsatisfied",
+                    )
+                ]
+            ),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["alpha-provider"]
+
+        self.assertEqual(row["coverage_class"], "incompatible")
+        self.assertEqual(row["adoption_guidance"], "held")
+        self.assertIn("host_version_unsatisfied", row["holds"])
+        self.assertEqual(row["host_version_constraint"], ">=0.14")
+
+    def test_catalog_presence_never_produces_a_ready_state(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot(
+                [
+                    entry("alpha-provider", tier="official"),
+                    entry("beta-connector", declared_capabilities=("connector",), tier="official"),
+                ]
+            ),
+            now=NOW,
+        )
+
+        for row in payload["entries"]:
+            with self.subTest(plugin_id=row["plugin_id"]):
+                self.assertNotIn("ready", str(row["adoption_guidance"]))
+                self.assertIn("host_observed_behavior", row["unavailable_evidence"])
+                self.assertIn("plugin_execution", row["unavailable_evidence"])
+                self.assertIn("host_permission_grant", row["unavailable_evidence"])
+
+    def test_an_unknown_host_version_status_names_the_missing_evaluation(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("alpha-provider", host_version_constraint=">=0.13", host_version_status="unknown")]),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["alpha-provider"]
+
+        self.assertEqual(row["coverage_class"], "mapped")
+        self.assertIn("host_version_evaluation", row["unavailable_evidence"])
+
+
+class OutcomeRoutingTests(unittest.TestCase):
+    """AC6 and AC9: one class per entry, and each capability shape has an owner.
+
+    Each case names the entries it is about, so no global plugin count is
+    pinned and admitting a new shape moves nothing else.
+    """
+
+    def test_each_owned_capability_routes_to_its_workflow(self) -> None:
+        expected = {
+            "provider": "provider-profile-posture",
+            "connector": "external-connector-readiness",
+            "observability": "ops-observability-card",
+            "memory": "memory-sync",
+            "media": "media-input-operator",
+        }
+        entries = [
+            entry(f"{capability}-plugin", declared_capabilities=(capability,)) for capability in sorted(expected)
+        ]
+
+        rows = rows_by_id(build_plugin_catalog_coverage(snapshot(entries), now=NOW))
+
+        for capability, workflow in expected.items():
+            with self.subTest(capability=capability):
+                row = rows[f"{capability}-plugin"]
+                self.assertEqual(row["coverage_class"], "mapped")
+                self.assertEqual(row["route"], workflow)
+                self.assertEqual(row["owner_boundary"], "omh")
+                self.assertEqual(row["adoption_guidance"], "route_to_owner")
+
+    def test_a_multi_capability_entry_takes_one_primary_route_and_lists_the_rest(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("wide-plugin", declared_capabilities=("connector", "memory", "provider"))]),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["wide-plugin"]
+
+        self.assertEqual(row["route"], "provider-profile-posture")
+        self.assertEqual(row["additional_routes"], ["external-connector-readiness", "memory-sync"])
+
+    def test_a_desktop_only_entry_keeps_its_owner_and_names_the_platform_gap(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot(
+                [entry("desktop-media", declared_capabilities=("media",), platform_limits=("desktop",))]
+            ),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["desktop-media"]
+
+        self.assertEqual(row["coverage_class"], "mapped")
+        self.assertEqual(row["route"], "media-input-operator")
+        self.assertEqual(row["platform_limits"], ["desktop"])
+        self.assertIn("platform_limited", row["advisories"])
+        self.assertIn("host_platform_match", row["unavailable_evidence"])
+
+    def test_a_host_core_only_entry_stays_on_the_host_side_of_the_boundary(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("loader-core", declared_capabilities=("host_core",))]),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["loader-core"]
+
+        self.assertEqual(row["owner_boundary"], "hermes_host")
+        self.assertEqual(row["adoption_guidance"], "host_owned")
+        self.assertEqual(row["route"], GENERIC_REVIEW_ROUTE)
+        self.assertIn("host_owned_mechanics", row["advisories"])
+
+    def test_an_unmapped_capability_combination_reaches_generic_review(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("odd-plugin", declared_capabilities=("bus-daemon", "shell-rewrite"))]),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["odd-plugin"]
+
+        self.assertEqual(row["coverage_class"], "generic_review")
+        self.assertEqual(row["route"], GENERIC_REVIEW_ROUTE)
+        self.assertEqual(payload["unresolved_entries"], ["odd-plugin"])
+
+    def test_an_entry_that_declares_nothing_is_unknown_rather_than_absent(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("silent-plugin", declared_capabilities=())]),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["silent-plugin"]
+
+        self.assertEqual(row["coverage_class"], "unknown")
+        self.assertEqual(row["route"], GENERIC_REVIEW_ROUTE)
+        self.assertIn("silent-plugin", payload["unresolved_entries"])
+
+    def test_every_entry_gets_exactly_one_coverage_class_and_the_counts_add_up(self) -> None:
+        entries = [
+            entry("a-provider"),
+            entry("b-connector", declared_capabilities=("connector",)),
+            entry("c-core", declared_capabilities=("host_core",)),
+            entry("d-odd", declared_capabilities=("bus-daemon",)),
+            entry("e-silent", declared_capabilities=()),
+            entry("f-removed", removal_status="removed"),
+            entry("g-blocked", host_version_status="unsatisfied"),
+        ]
+
+        payload = build_plugin_catalog_coverage(snapshot(entries), now=NOW)
+
+        counts = payload["summary"]["coverage_class_counts"]
+        self.assertEqual(set(counts), set(COVERAGE_CLASSES))
+        self.assertEqual(sum(counts.values()), len(entries))
+        for row in payload["entries"]:
+            with self.subTest(plugin_id=row["plugin_id"]):
+                self.assertIn(row["coverage_class"], COVERAGE_CLASSES)
+                self.assertTrue(row["route"])
+
+    def test_a_deprecated_entry_still_routes_but_carries_the_advisory(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("fading-provider", removal_status="deprecated")]),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["fading-provider"]
+
+        self.assertEqual(row["coverage_class"], "mapped")
+        self.assertIn("catalog_deprecation", row["advisories"])
+
+    def test_a_declared_capability_is_recorded_as_a_claim_not_as_behavior(self) -> None:
+        payload = build_plugin_catalog_coverage(
+            snapshot([entry("alpha-provider", declared_capabilities=("provider",))]),
+            now=NOW,
+        )
+        row = rows_by_id(payload)["alpha-provider"]
+
+        self.assertEqual(row["declared_capabilities"], ["provider"])
+        self.assertIn("Declared capabilities are catalog claims, not observed plugin behavior", str(payload["claim_boundary"]))
+
+
+class FailClosedTests(unittest.TestCase):
+    """AC7: bad input produces bounded diagnostics, never a partial answer."""
+
+    def test_a_malformed_snapshot_is_refused(self) -> None:
+        with self.assertRaises(PluginCatalogCoverageError):
+            build_plugin_catalog_coverage({"schema_version": "nope"}, now=NOW)
+
+    def test_an_unsupported_field_is_named_without_echoing_its_value(self) -> None:
+        broken = snapshot([entry("alpha-provider")])
+        broken["entries"][0]["source_code"] = "def exfiltrate(): ..."
+
+        diagnostics = validate_plugin_catalog_snapshot(broken)
+
+        self.assertTrue(any("unsupported fields: source_code" in item for item in diagnostics))
+        self.assertFalse(any("exfiltrate" in item for item in diagnostics))
+
+    def test_a_duplicate_identity_is_refused(self) -> None:
+        duplicated = snapshot([entry("alpha-provider"), entry("alpha-provider", content_revision="rev-2")])
+
+        with self.assertRaisesRegex(PluginCatalogCoverageError, "repeats an identity"):
+            build_plugin_catalog_coverage(duplicated, now=NOW)
+
+    def test_a_cross_profile_snapshot_is_refused_rather_than_reported(self) -> None:
+        with self.assertRaisesRegex(PluginCatalogCoverageError, "different profile"):
+            build_plugin_catalog_coverage(
+                snapshot([entry("alpha-provider")], profile_ref="staging"),
+                profile_ref="default",
+                now=NOW,
+            )
+
+    def test_a_previous_snapshot_from_another_profile_is_refused(self) -> None:
+        with self.assertRaisesRegex(PluginCatalogCoverageError, "different profile"):
+            build_plugin_catalog_coverage(
+                snapshot([entry("alpha-provider")]),
+                previous=snapshot([entry("alpha-provider")], profile_ref="staging"),
+                now=NOW,
+            )
+
+    def test_an_oversized_entry_list_is_refused_rather_than_truncated(self) -> None:
+        oversized = snapshot([entry(f"plugin-{index:04d}") for index in range(MAX_SNAPSHOT_ENTRIES + 1)])
+
+        diagnostics = validate_plugin_catalog_snapshot(oversized)
+
+        self.assertTrue(any(str(MAX_SNAPSHOT_ENTRIES) in item for item in diagnostics))
+        with self.assertRaises(PluginCatalogCoverageError):
+            build_plugin_catalog_coverage(oversized, now=NOW)
+
+    def test_an_oversized_file_is_refused_before_it_is_parsed(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "snapshot.json"
+            path.write_text(" " * (MAX_SNAPSHOT_BYTES + 1), encoding="utf-8")
+
+            with self.assertRaisesRegex(PluginCatalogSnapshotError, "byte bound"):
+                load_plugin_catalog_snapshot(path)
+
+    def test_a_missing_file_is_refused_with_a_bounded_reason(self) -> None:
+        with TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(PluginCatalogSnapshotError, "could not be read"):
+                load_plugin_catalog_snapshot(Path(directory) / "absent.json")
+
+    def test_diagnostics_are_bounded_for_a_snapshot_that_is_broken_everywhere(self) -> None:
+        broken = snapshot([entry(f"plugin-{index}", tier="invented") for index in range(MAX_DIAGNOSTICS + 10)])
+
+        diagnostics = validate_plugin_catalog_snapshot(broken)
+
+        self.assertLessEqual(len(diagnostics), MAX_DIAGNOSTICS + 1)
+        self.assertIn("further diagnostics were not listed", diagnostics[-1])
+
+    def test_a_credential_value_in_an_environment_name_list_is_refused(self) -> None:
+        carrying = snapshot([entry("alpha-provider", required_env_names=(AWS_ACCESS_KEY_ID,))])
+
+        diagnostics = validate_plugin_catalog_snapshot(carrying)
+
+        self.assertTrue(any("credential value rather than a variable name" in item for item in diagnostics))
+        self.assertFalse(any(AWS_ACCESS_KEY_ID in item for item in diagnostics))
+
+    def test_an_environment_variable_name_that_reads_like_a_secret_is_accepted(self) -> None:
+        named = snapshot([entry("alpha-provider", required_env_names=("ALPHA_API_KEY", "GITHUB_TOKEN"))])
+
+        self.assertEqual(validate_plugin_catalog_snapshot(named), [])
+        row = rows_by_id(build_plugin_catalog_coverage(named, now=NOW))["alpha-provider"]
+        self.assertEqual(row["required_env_names"], ["ALPHA_API_KEY", "GITHUB_TOKEN"])
+        self.assertIn("requires_environment_names", row["advisories"])
+
+    def test_a_constraint_string_carrying_a_body_is_refused(self) -> None:
+        carrying = snapshot([entry("alpha-provider", host_version_constraint="```\nrm -rf /\n```")])
+
+        diagnostics = validate_plugin_catalog_snapshot(carrying)
+
+        self.assertTrue(any("one bounded line" in item for item in diagnostics))
+
+
+class FreshnessTests(unittest.TestCase):
+    """AC7 and proposal 4: absence and staleness never inherit presence."""
+
+    def test_a_stale_snapshot_holds_every_entry_it_carries(self) -> None:
+        payload = build_plugin_catalog_coverage(snapshot([entry("alpha-provider")]), now=MUCH_LATER)
+
+        self.assertEqual(payload["snapshot_state"], "stale")
+        self.assertEqual(payload["freshness"]["state"], "stale")
+        row = rows_by_id(payload)["alpha-provider"]
+        self.assertEqual(row["adoption_guidance"], "held")
+        self.assertIn("stale_snapshot", row["holds"])
+
+    def test_a_missing_snapshot_reports_unavailable_and_carries_no_entries(self) -> None:
+        payload = plugin_catalog_coverage_unavailable("no snapshot was supplied")
+
+        self.assertEqual(payload["snapshot_state"], "unavailable")
+        self.assertEqual(payload["entries"], [])
+        self.assertEqual(payload["entry_count"], 0)
+        self.assertEqual(payload["snapshot"]["catalog_revision"], "")
+        self.assertEqual(payload["diagnostics"], ["no snapshot was supplied"])
+
+    def test_an_unavailable_answer_does_not_borrow_the_packaged_catalog(self) -> None:
+        payload = plugin_catalog_coverage_unavailable("no snapshot was supplied")
+
+        self.assertFalse(payload["packaged_reference"]["used_as_host_coverage"])
+        self.assertEqual(payload["packaged_reference"]["coverage_scope"], PACKAGED_COVERAGE_SCOPE)
+        packaged_count = int(awesome_hermes_summary()["plugin_count"])
+        self.assertNotEqual(payload["entry_count"], packaged_count)
+        self.assertEqual(payload["summary"]["coverage_class_counts"]["mapped"], 0)
+
+    def test_an_unreadable_reference_clock_reports_unknown_rather_than_fresh(self) -> None:
+        payload = build_plugin_catalog_coverage(snapshot([entry("alpha-provider")]), now="not-a-timestamp")
+
+        self.assertEqual(payload["freshness"]["state"], "unknown")
+        self.assertEqual(payload["snapshot_state"], "stale")
+
+
+class PackagedInputsStayReadableTests(unittest.TestCase):
+    """AC8: legacy inputs keep working and say what they are."""
+
+    def test_the_packaged_catalog_summary_is_labelled_snapshot_limited(self) -> None:
+        payload = awesome_hermes_summary()
+
+        self.assertEqual(payload["coverage_scope"], PACKAGED_COVERAGE_SCOPE)
+        self.assertIn("not the active host catalog", str(payload["coverage_scope_note"]))
+        self.assertGreater(int(payload["plugin_count"]), 0)
+
+    def test_the_packaged_coverage_payload_is_labelled_snapshot_limited(self) -> None:
+        payload = awesome_hermes_coverage_payload(subsection="Plugins")
+
+        self.assertEqual(payload["coverage_scope"], PACKAGED_COVERAGE_SCOPE)
+        self.assertTrue(payload["items"])
+
+    def test_the_seven_entry_outcome_matrix_still_reads_and_is_labelled(self) -> None:
+        payload = awesome_hermes_plugin_outcomes()
+
+        self.assertEqual(payload["coverage_scope"], PACKAGED_COVERAGE_SCOPE)
+        self.assertIn("plugin_catalog_snapshot/v1", str(payload["coverage_scope_note"]))
+        self.assertTrue(payload["outcomes"])
+
+
+class ReadOnlyAdapterTests(unittest.TestCase):
+    """AC10: the adapter reads a supplied file and does nothing else."""
+
+    def test_the_contract_modules_import_nothing_that_could_fetch_or_execute(self) -> None:
+        from omh.commands import plugin_catalog as adapter
+        from omh.workflows import plugin_catalog_coverage, plugin_catalog_snapshots
+
+        for module in (adapter, plugin_catalog_coverage, plugin_catalog_snapshots):
+            source = Path(str(module.__file__)).read_text(encoding="utf-8")
+            imported = {
+                line.split()[1].split(".")[0]
+                for line in source.splitlines()
+                if line.startswith("import ") or line.startswith("from ")
+            }
+            for forbidden in NETWORK_AND_EXECUTION_MODULES:
+                with self.subTest(module=module.__name__, forbidden=forbidden):
+                    self.assertNotIn(forbidden, imported)
+
+    def test_the_adapter_does_not_read_or_write_the_supplied_file_beyond_reading(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "snapshot.json"
+            payload = snapshot([entry("alpha-provider")])
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            before = path.read_bytes()
+
+            status, stdout, stderr = run_cli(
+                ["ecosystem", "plugin-catalog", "coverage", "--input", str(path), "--now", NOW]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(sorted(item.name for item in Path(directory).iterdir()), ["snapshot.json"])
+            self.assertEqual(json.loads(stdout)["snapshot_state"], "current")
+
+
+class CliSurfaceTests(unittest.TestCase):
+    """The operator entry point, including how it fails."""
+
+    def _write(self, directory: str, name: str, payload: dict[str, object]) -> str:
+        path = Path(directory) / name
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return str(path)
+
+    def test_the_cli_reports_one_added_row_across_two_snapshots(self) -> None:
+        with TemporaryDirectory() as directory:
+            previous = self._write(directory, "previous.json", snapshot([entry("alpha-provider")]))
+            current = self._write(
+                directory,
+                "current.json",
+                snapshot(
+                    [entry("alpha-provider"), entry("beta-connector", declared_capabilities=("connector",))],
+                    catalog_revision="catalog-rev-2",
+                ),
+            )
+
+            status, stdout, stderr = run_cli(
+                [
+                    "ecosystem",
+                    "plugin-catalog",
+                    "coverage",
+                    "--input",
+                    current,
+                    "--previous",
+                    previous,
+                    "--now",
+                    NOW,
+                ]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            self.assertEqual(payload["summary"]["change_class_counts"]["added"], 1)
+            self.assertEqual(payload["snapshot"]["catalog_revision"], "catalog-rev-2")
+
+    def test_the_cli_without_a_snapshot_reports_unavailable_and_exits_non_zero(self) -> None:
+        status, stdout, stderr = run_cli(["ecosystem", "plugin-catalog", "coverage"])
+
+        self.assertEqual(status, 1, stderr)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["snapshot_state"], "unavailable")
+        self.assertEqual(payload["entries"], [])
+
+    def test_the_cli_refuses_a_cross_profile_snapshot(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = self._write(directory, "snapshot.json", snapshot([entry("alpha-provider")], profile_ref="staging"))
+
+            status, stdout, stderr = run_cli(
+                ["ecosystem", "plugin-catalog", "coverage", "--input", path, "--profile", "default", "--now", NOW]
+            )
+
+            self.assertNotEqual(status, 0)
+            self.assertEqual(stdout, "")
+            self.assertIn("different profile", stderr)
+
+    def test_the_plain_text_status_names_the_snapshot_and_the_holds(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = self._write(
+                directory,
+                "snapshot.json",
+                snapshot([entry("alpha-provider", removal_status="removed")]),
+            )
+
+            status, stdout, stderr = run_cli(
+                ["ecosystem", "plugin-catalog", "coverage", "--input", path, "--now", NOW],
+                output_json=False,
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("catalog-rev-1", stdout)
+            self.assertIn("alpha-provider: catalog_removal", stdout)
+            self.assertIn("snapshot_limited", stdout)
+
+    def test_the_packaged_outcome_surfaces_still_answer_and_say_what_they_cover(self) -> None:
+        status, stdout, stderr = run_cli(["ecosystem", "awesome-hermes", "outcomes", "--json"])
+
+        self.assertEqual(status, 0, stderr)
+        self.assertEqual(json.loads(stdout)["coverage_scope"], PACKAGED_COVERAGE_SCOPE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New input contract `plugin_catalog_snapshot/v1` (`src/workflows/plugin_catalog_snapshots.py`): a bounded, closed-key-set record an authorized host or operator exports about its own plugin catalog — producer identity, profile, observation time, catalog revision, and per-entry stable identity, reviewed content revision, tier, declared capabilities, required environment variable **names**, platform limits, host-version constraint plus the host's own enforcement result, and removal status.
- New reconciliation `plugin_catalog_coverage/v1` (`src/workflows/plugin_catalog_coverage.py`): a pure function of one snapshot and, optionally, the prior one. Every entry gets exactly one coverage class (`mapped`, `generic_review`, `incompatible`, `removed`, `unknown`) and exactly one change class (`added`, `changed`, `unchanged`, `removed`), plus its route, holds, advisories, and the evidence OMH does not have.
- New offline CLI adapter `omh ecosystem plugin-catalog coverage` (`src/commands/plugin_catalog.py`), with a concise plain-text chat status and a `--json` machine payload.
- The packaged awesome-hermes catalog and the seven-entry outcome matrix keep working unchanged and now carry `coverage_scope: snapshot_limited` plus a note in words, on every payload and every plain-text surface.
- New contract doc `docs/PLUGIN-CATALOG-COVERAGE.md`, indexed from `docs/README.md`.

### Why This Exists

OMH ecosystem guidance was pinned to a manually maintained catalog snapshot and a small hand-curated outcome matrix, and it did not accept the host's active plugin catalog at all. A newly admitted entry, a reviewed revision change under an existing identity, a withdrawal, or a host-version constraint the host refused stayed invisible until a maintainer added a static alias by hand. A user could ask about a plugin visible in their host catalog and get stale or generic guidance without ever being told which catalog revision OMH actually covered — and the packaged numbers, quoted as-is, read like host coverage.

### User / Operator Impact

A maintainer or host operator can now export their catalog once and ask OMH:

- Which OMH workflow owns each plugin outcome, bound to one producer, one observation time, and one catalog revision.
- What changed since the prior snapshot, with a reviewed content revision change reported as `changed` (both revisions preserved) rather than as a new plugin, and an identical replay producing no new row.
- Which entries are held because the catalog withdrew them or because the host refused their version constraint.
- Which entries OMH has no owner for, routed to a bounded generic review rather than dropped.
- What evidence remains unavailable on every row, always.

Everything the host owns stays with the host. Nothing here installs, enables, updates, or executes a plugin.

### How It Works

Four separations carry the design, and none collapses into another:

**Coverage class is not change class.** They answer different questions and are computed independently. A first sighting of an unmappable entry is `added` *and* `generic_review`, not one merged verdict.

**A rediscovered entry is not a new one.** Change classification keys on `plugin_id`. `changed` requires one of eight tracked metadata fields to have moved and names which in `changed_fields`; `previous_content_revision` and `content_revision` both survive. Replaying an identical snapshot yields `unchanged` for every row.

**Catalog presence is not readiness.** There is deliberately no ready state to reach. `adoption_guidance` is `route_to_owner`, `generic_review`, `host_owned`, or `held`, and the owner workflow's own readiness contract is where an adoption answer comes from. Withdrawal and incompatibility are decided *before* capability mapping, so a withdrawn or refused entry is held and routed to plugin-risk review rather than routed as adoption guidance for something the host will not run. `host_observed_behavior`, `host_permission_grant`, and `plugin_execution` are listed as unavailable evidence on every row; a removal adds `installed_copy_state`, because OMH cannot see installed copies — the removal hold reports a catalog withdrawal and says nothing about an installed copy being disabled or uninstalled.

**Absence does not inherit presence.** With no snapshot the answer is `snapshot_state: unavailable`, no entries, exit 1, and a `packaged_reference` block stamped `used_as_host_coverage: false` so a reader can see OMH declined to substitute the packaged catalog rather than wondering whether it silently did. A stale snapshot holds every row it carries on `stale_snapshot`.

Routing for mapped entries goes to the existing owners: `provider` → `provider-profile-posture`, `connector` → `external-connector-readiness`, `observability` → `ops-observability-card`, `memory` → `memory-sync`, `media` → `media-input-operator`. `host_core` is reported with `owner_boundary: hermes_host` and no OMH lane — loader, transport, permission, and installation mechanics stay outside OMH. Anything else, or nothing declared, reaches `skill-scout` as the bounded generic-review route. Held entries route to `security-safety-review`. A multi-capability entry takes a fixed precedence order for its primary route and lists the rest, so the primary owner is stable across runs.

Fail-closed handling: malformed, oversized (both the file byte cap and the entry-count cap, checked before parsing and before reconciling), duplicate-identity, and cross-profile snapshots are refused outright — a partial coverage report reads exactly like a complete one. Diagnostics are positional: each names an entry index and a field name and never the value that failed, so an untrusted snapshot cannot route its own content through OMH's error output; the list is capped and closed with a count.

Untrusted-input handling: every string is screened as a bounded opaque reference. `required_env_names` is the one field whose honest content reads like a secret (`GITHUB_TOKEN`, `ALPHA_API_KEY`), so it is screened with the narrow issued-credential detector (`is_secret_value_shaped`) instead of the wider sensitive-word one — the name is accepted, an issued key is refused. The key sets are closed, so there is no field a file body, a repository excerpt, or a credential value can arrive in. `host_version_constraint` is carried as opaque text nothing branches on; version enforcement is the host's job and `host_version_status` is where the host reports the result of doing it.

### Files And Contracts Touched

- `src/workflows/plugin_catalog_snapshots.py` (new) — `plugin_catalog_snapshot/v1` validation, bounds, freshness, identity.
- `src/workflows/plugin_catalog_coverage.py` (new) — `plugin_catalog_coverage/v1` reconciliation, routing, holds, chat status renderer.
- `src/commands/plugin_catalog.py` (new) — the offline CLI adapter.
- `src/commands/ecosystem.py` — registers `plugin-catalog`, prints the packaged-scope label on all four plain-text surfaces, adds the scope keys to the `inspect` payload.
- `src/catalogs/awesome_hermes_agent.py` — `PACKAGED_COVERAGE_SCOPE` / `PACKAGED_COVERAGE_SCOPE_NOTE`, attached to the summary and coverage payloads.
- `src/catalogs/awesome_hermes_agent_outcomes.py` — the same label on the outcome-matrix projection. The stored envelope and its closed key set are unchanged.
- `tests/test_plugin_catalog_coverage.py` (new) — 49 cases.
- `tests/test_awesome_hermes_agent_plugin_outcomes.py` — the loader-rejection case now builds its invalid fixture from the stored resource rather than from the projection, since `_parse_plugin_outcomes` validates what is on disk; plus a case pinning the new label.
- `docs/PLUGIN-CATALOG-COVERAGE.md` (new), `docs/README.md`.

No routing corpus, skill catalog, demo card, or generated artifact changed, so no exact-count fixture moved. No global plugin count is pinned anywhere in the new tests — each routing case builds the entries it is about.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `omh ecosystem plugin-catalog coverage` in all three states (current, stale, unavailable) and `omh ecosystem awesome-hermes summary|outcomes`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **Ran 10629 tests in 707s, OK (skipped=1)**, exit 0. The one skip is an environment-conditional skip elsewhere in the suite; the new test file contains no skips.
- Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_plugin_catalog_coverage.py -v` — 49 tests, OK. Cases are grouped by success criterion: snapshot identity and determinism, change classification (one admitted entry → exactly one `added`; identical replay → no new row; revision change → `changed` with both revisions), removal and compatibility holds, outcome routing for every capability shape the issue names, fail-closed inputs, freshness and absence, packaged inputs staying readable, and the read-only adapter.
- `PYTHONPATH=tests uv run python -m unittest tests/test_awesome_hermes_agent_catalog.py tests/test_awesome_hermes_agent_plugin_outcomes.py tests/test_credential_fixture_policy.py` — 41 tests, OK.
- Byte gates: `docs workflows --check` (ok, 206/206 tap skills), `docs roles --check`, `docs claims --check --json` (ok), `docs capability-families --check`, `docs ulw-inventory --check`, `docs ulw-site --check` — all ok.
- `harness validate` → `{"counts":{"harnesses":77,"skills":128},"errors":[],"ok":true}`.
- `drift_report()["ok"]` → `True`, no failing entries.
- Read-only behavior is asserted, not asserted-by-comment: one test scans the three new modules' import lines for `http`, `httpx`, `importlib`, `requests`, `socket`, `ssl`, `subprocess`, `urllib`; another runs the CLI against a snapshot in a temporary directory and asserts the file's bytes are unchanged and no new file appeared.
- Credential handling: the AWS-key-shaped fixture comes from `tests/_credential_fixtures.py`, so no secret-shaped literal is written to disk and `tests/test_credential_fixture_policy.py` stays green.

### Not Tested / Not Applicable

- The install-path command smoke was not run: this change adds no installable artifact, no managed skill, no plugin-bundle tool, and no setup/update path — it adds one read-only subcommand under an existing group, which `omh --help` and the direct CLI runs already cover.
- No manual Hermes/TUI check: the change adds no widget, HUD, awareness, or plugin-tool surface, so there is nothing for a TUI session to render differently.
- The workflow-learning review queue smoke does not apply; no learning contract changed.
- No real host exported a catalog. Every snapshot in the tests and in the manual runs is a constructed fixture. No plugin was installed, enabled, updated, imported, or executed, and no host configuration was read or written.

## Risk

- The declared-capability vocabulary is open on purpose, so a host that names its capabilities differently than the five OMH owns will see those entries in `generic_review` rather than mapped. That is the designed failure mode — visible and routed, not silent — but it means real-world mapping coverage depends on the vocabulary a host actually emits, which no fixture here can predict.
- The freshness horizon is 24 hours. A host that exports less often than daily will see every row held on `stale_snapshot`. That is deliberate (a day-old catalog is not the current one), but it is a tuning decision made without field data.
- `host_version_status` shifts the compatibility judgement onto the host. If a host reports `unknown` for everything, no entry is ever classified `incompatible` — the row instead names `host_version_evaluation` as unavailable evidence. Correct, but it means the `incompatible` class is only as useful as the host's own enforcement reporting.

## Compatibility / Rollout

- Purely additive. The packaged catalog file, the outcome-matrix JSON, and every existing `omh ecosystem awesome-hermes` command behave the same; their payloads gain two keys and their plain-text output gains one line.
- The stored outcome-matrix envelope and its closed key set are unchanged, so no regeneration or byte gate is affected.
- No new dependency, no new network call, no new background task, no new automatic issue creation.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- If a host's real capability vocabulary turns out to differ from the five mapped tokens, the fix is to extend `CAPABILITY_OWNERS` — the `generic_review` bucket in a real report is the signal for which tokens to add, and it is designed to be read that way.
- No `omh_*` plugin tool or chat router trigger was added. The issue's success criteria ask for a deterministic offline CLI or workflow adapter and for routing tests over capability shapes; neither asks for a new chat trigger, and adding one would move exact-count fixtures across five files for no contract requirement. The concise chat status is available to a wrapper through `render_plugin_catalog_coverage` and the CLI's plain-text output.

Closes #1449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8
