### PR TITLE
feat(docs): gate public documentation structure with an offline navigation check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,14 @@ jobs:
       - name: Generated ULW site region check
         if: matrix.shard == 0
         run: python -m omh.cli docs ulw-site --check
+      # Structure, not equality: a page can stay byte-identical to its producer
+      # and still have left the public map. This gate is the one that notices.
+      # The windows leg reaches the same verdict through
+      # tests/test_documentation_navigation.py, which audits this repository --
+      # separator, case, and encoding handling is where the two hosts differ.
+      - name: Documentation navigation check
+        if: matrix.shard == 0
+        run: python -m omh.cli docs navigation --check
       - name: Whitespace and conflict-marker check
         if: matrix.python-version == '3.11' && matrix.shard == 0 && github.event_name == 'pull_request'
         run: git diff --check "origin/${{ github.base_ref }}...HEAD"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,7 @@ uv run python -m compileall -q src tests
 uv run python -m omh.cli docs workflows --check
 uv run python -m omh.cli docs roles --check
 uv run python -m omh.cli docs claims --check --json
+uv run python -m omh.cli docs navigation --check
 uv run python -m omh.cli docs capability-families --check
 uv run python -m omh.cli docs ulw-inventory --check
 uv run python -m omh.cli docs ulw-site --check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ uv run python -m compileall -q src tests                          # syntax gate
 uv run python -m omh.cli docs workflows --check                   # byte gate
 uv run python -m omh.cli docs roles --check                       # byte gate
 uv run python -m omh.cli docs claims --check --json               # selected claims
+uv run python -m omh.cli docs navigation --check                  # docs structure gate
 uv run --group lint ruff check src tests                          # static-analysis gate
 git diff --check
 ```
@@ -162,6 +163,14 @@ Rules:
   with the reason written at the entry: the per-skill Hangul freeze in
   `tests/test_routing_language_policy.py` and
   `FULL_PROFILE_SKILL_BODY_CHAR_LIMIT` in `src/maintenance/release.py`.
+- Adding a page under `docs/` and stopping there. `docs navigation --check`
+  requires every top-level `docs/*.md` to be reachable from a declared root or
+  classified in `src/catalogs/documentation_navigation.py` with a reason and an
+  owner; a page that is neither fails, which is the whole point — an accidental
+  orphan must not pass as an intentional one. Link it from a page a reader
+  actually reaches before reaching for the classification list, and delete the
+  classification entry when a page later becomes reachable (a reachable page
+  still marked exempt is its own failure).
 - Grepping the repo and matching stale strings under `build/lib/` — it is a
   gitignored copy of old sources. Scope searches to `src/`, `tests/`, `docs/`,
   `skills/`.

--- a/docs/DOCUMENTATION-CLAIMS.md
+++ b/docs/DOCUMENTATION-CLAIMS.md
@@ -67,6 +67,16 @@ unchanged; this does not normalize arbitrary content or grant semantic support.
 Run `omh release drift --json` alongside it for the unchanged generated-file,
 count, and budget checks. The audit never pretends that command ran.
 
+`omh docs navigation --check` is the third evidence class and is deliberately
+not folded into this one. It settles documentation *structure* — whether a page
+is still reachable from a declared root, whether local link targets resolve, and
+whether an unreachable page is classified with a reason — and never inspects
+what a page asserts. A claim can be perfectly true on a page nobody can reach,
+and a page can be reachable while every sentence on it has gone stale; the two
+failures are repaired by different people doing different work. See
+[the documentation checks table](README.md#documentation-checks) for which
+command answers which question.
+
 `release checklist` only prepares an audit command (`observed=false`).
 `release product-readiness` runs the deterministic audit and includes its
 observed rows; `release evidence-bundle` packages that same result. The

--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -3,6 +3,10 @@
 Audience: operators, wrappers, and coding agents. Normal users describe the
 goal to Hermes in chat; these commands are the backend surface.
 
+What a dispatched child process is allowed to inherit from the parent
+environment is a separate contract with its own default of least privilege:
+[Fanout child-environment policy](CHILD-ENVIRONMENT-POLICY.md).
+
 ## Lifecycle
 
 1. **Propose** — Hermes (the LLM) proposes the unit split in chat: unit ids,

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,9 @@ references rather than normal user steps.
 | Understand what OMH is and is not | [Direction](DIRECTION.md) |
 | Understand modules, artifacts, and ownership | [Architecture](ARCHITECTURE.md) |
 | Inspect the runtime-readable capability map | [Capabilities](CAPABILITIES.md) |
+| Turn a capability family on or off without uninstalling | [Capability Toggles](CAPABILITY-TOGGLES.md) |
+| Block a Hermes tool call with a rule you wrote | [Toolcall Rules](TOOLCALL-RULES.md) |
+| See which coding work is running, in which session | [Coding Observability](CODING-OBSERVABILITY.md) |
 | Understand measured and unproven impact claims | [Capability Impact](CAPABILITY_IMPACT.md) |
 | Browse all generated skills and harness metadata | [Workflow Reference](WORKFLOWS.md) |
 | Apply Apple UI design/review/improvement guidance | [Apple Design Guidance](APPLE-DESIGN.md) |
@@ -124,6 +127,26 @@ Use [Capabilities](CAPABILITIES.md) for the manifest contract and
 | Public roadmap | [Roadmap](ROADMAP.md) |
 | GitHub Pages source | [Website](../site/index.html) |
 
+## Agent And Operator Contracts
+
+These are control-plane contracts for wrappers, host integrators, connector
+adapters, and operators. Normal chat users never need them; they are listed here
+so that every published contract has a path from this map instead of being
+findable only by knowing its filename.
+
+| Contract | Read |
+| --- | --- |
+| Metadata-only workflow artifact CLI, and the four workflows it dispatches | [Workflow Artifacts](WORKFLOW-ARTIFACTS.md) |
+| Host-supplied browser adapter and bounded browser leases | [Browser Adapter](BROWSER-ADAPTER.md) |
+| Connector ingress for decision-gate answers | [Decision-Gate Connectors](DECISION-GATE-CONNECTORS.md) |
+| Closed ingress for untrusted GitHub tracker evidence | [Tracker Content](TRACKER-CONTENT.md) |
+| Write-ahead records for attempted external tool effects | [Egress Attempts](EGRESS-ATTEMPTS.md) |
+| Opt-in multi-unit work campaigns for the `ulw-work` engine | [Work Campaigns](WORK-CAMPAIGN.md) |
+| Bounded feedback rounds over a closed design-direction set | [Design Direction Iterations](DESIGN-DIRECTION-ITERATIONS.md) |
+| Deterministic comparison of submitted cross-harness machine facts | [Cross-Harness Benchmark](CROSS_HARNESS_BENCHMARK.md) |
+| Freshness identity behind `omh goal checkpoint` and quality-evidence assessment | [Working-Tree Fingerprint](WORKING-TREE-FINGERPRINT.md) |
+| Bounded retry/replan/stop/escalate decisions for an observed error | [Failure Mender](failure-mender.md) |
+
 ## Documentation Checks
 
 When a public claim changes, check the README, site, capabilities, direction,
@@ -133,5 +156,24 @@ architecture, generated workflow reference, and agent contract together.
 PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py -v
 uv run python -m omh.cli harness validate
 uv run python -m omh.cli docs workflows --check
+uv run python -m omh.cli docs navigation --check
 git diff --check
 ```
+
+Three separate evidence classes answer three different questions, and a failure
+in one is repaired differently from a failure in another:
+
+| Question | Command | Repair |
+| --- | --- | --- |
+| Does a generated page still equal its producer? | `docs workflows`/`roles`/`capability-families`/`ulw-*` `--check` | Regenerate from the catalog |
+| Does a reviewed sentence still match implementation? | [`docs claims --check`](DOCUMENTATION-CLAIMS.md) | Fix the prose or the code the claim names |
+| Can a reader still reach every public page, and does every local link resolve? | `docs navigation --check` | Add the missing link, fix the target, or classify the page |
+
+`docs navigation` starts from the roots declared in
+`src/catalogs/documentation_navigation.py` and requires every top-level `docs/`
+page to be either reachable from one of them or classified there with a reason
+and an owner. A page that is neither fails the check, so an accidental orphan
+cannot pass as an intentional one. It reads local files only: no network, no
+subprocess, and no automatic edit to any documentation file. Reachability is
+discoverability through declared links; it is not evidence that a page's content
+is correct, current, or usable.

--- a/docs/WORKFLOW-ARTIFACTS.md
+++ b/docs/WORKFLOW-ARTIFACTS.md
@@ -14,12 +14,14 @@ The command returns `workflow_artifact_operation_result/v1`. It does not echo th
 
 ## Closed operations
 
+Each workflow has its own contract page, linked from the first column.
+
 | Workflow | Operations | Explicit durable operation |
 | --- | --- | --- |
-| `decision-prototype` | `prepare`, `validate`, `observe`, `receipt`, `handoff`, `persist` | `persist` writes the validated existing prototype artifact store. |
-| `lifecycle-growth` | `build`, `prepare`, `validate`, `evaluate`, `readout`, `audience`, `promote`, `graduate` | `build` derives the five prepared artifacts from semantic fields; returned JSON is the durable serializable artifact. |
-| `product-discovery-validation` | `build`, `prepare`, `validate`, `audience-gate`, `evaluate`, `handoff`, `append` | `build` derives the five pre-decision artifacts and their hashes; `append` uses the existing append-only discovery store. |
-| `sales-pipeline-review` | `prepare`, `validate`, `evaluate`, `handoff` | None; returned JSON is the durable serializable artifact. |
+| [`decision-prototype`](DECISION-PROTOTYPES.md) | `prepare`, `validate`, `observe`, `receipt`, `handoff`, `persist` | `persist` writes the validated existing prototype artifact store. |
+| [`lifecycle-growth`](LIFECYCLE-GROWTH.md) | `build`, `prepare`, `validate`, `evaluate`, `readout`, `audience`, `promote`, `graduate` | `build` derives the five prepared artifacts from semantic fields; returned JSON is the durable serializable artifact. |
+| [`product-discovery-validation`](PRODUCT-DISCOVERY-VALIDATION.md) | `build`, `prepare`, `validate`, `audience-gate`, `evaluate`, `handoff`, `append` | `build` derives the five pre-decision artifacts and their hashes; `append` uses the existing append-only discovery store. |
+| [`sales-pipeline-review`](SALES-PIPELINE-REVIEW.md) | `prepare`, `validate`, `evaluate`, `handoff` | None; returned JSON is the durable serializable artifact. |
 
 Unsupported workflow/operation pairs are parser errors. `validate` dispatches to the producer's schema-specific validator: lifecycle has its six artifact schemas, and sales has scope, health, forecast, outcome-learning, renewal-risk, and handoff validators.
 

--- a/src/catalogs/documentation_navigation.py
+++ b/src/catalogs/documentation_navigation.py
@@ -1,0 +1,167 @@
+"""Checked-in navigation policy for public documentation structure.
+
+This declares three things and nothing else: which pages are entry points, which
+pages must be reachable from one of them, and which pages are intentionally not
+reachable and why. Every in-scope page is settled by exactly one of those, so an
+accidentally orphaned page fails instead of blending into a silent allowlist.
+
+Reachability here means discoverability through declared local Markdown links.
+It is not information-architecture quality, accessibility, semantic accuracy, or
+evidence that a page was published anywhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+PAGE_CLASSES = (
+    "public",
+    "generated",
+    "maintainer_procedure",
+    "repo_internal",
+    "working_note",
+)
+REACHABILITY_STATES = ("required", "exempt")
+
+# The publishing surface this policy scopes itself to. GitHub's blob view serves
+# a page at its repository path, so two pages collide only when their paths
+# differ by case alone -- which is exactly what breaks a clone on a
+# case-insensitive filesystem. Static-site generators add slug semantics that
+# this policy deliberately does not claim to model.
+PUBLISHING_SURFACE = "github_repository_blob"
+
+
+@dataclass(frozen=True)
+class NavigationRoot:
+    """A declared entry point. Traversal starts here; roots need no referrer."""
+
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PageClassification:
+    """One in-scope page's declared class and reachability expectation.
+
+    `reachability="required"` states the page must be reachable from a root, and
+    is used to classify a page whose kind might otherwise invite a blanket
+    exclusion -- a generated page is still a public page. `exempt` states the
+    page is intentionally not on a public path, and `reason` must name where a
+    reader actually enters it.
+    """
+
+    path: str
+    page_class: str
+    reachability: str
+    reason: str
+    owner: str
+
+
+def documentation_navigation_roots() -> tuple[NavigationRoot, ...]:
+    return (
+        NavigationRoot(
+            "README.md",
+            "Repository front page; the entry point for someone arriving at the project.",
+        ),
+        NavigationRoot(
+            "docs/README.md",
+            "The public operating map; the entry point for someone looking for a contract.",
+        ),
+    )
+
+
+def documentation_scope_patterns() -> tuple[str, ...]:
+    """Pages whose reachability is required unless classified exempt.
+
+    Top-level `docs/` only. Deeper trees, `skills/` output, and repository-root
+    contracts other than the declared roots are traversed when a link reaches
+    them and their own links are validated, but they are not required to be
+    reachable, because they are not the public documentation surface.
+    """
+    return ("docs/*.md",)
+
+
+def documentation_page_classifications() -> tuple[PageClassification, ...]:
+    return (
+        PageClassification(
+            "docs/ADDING-A-SKILL.md",
+            "repo_internal",
+            "exempt",
+            "Contributor checklist for this repository's catalog. Entered from CLAUDE.md "
+            "Common Pitfalls and REVIEW.md, not from a product reader path.",
+            "docs-specialist",
+        ),
+        PageClassification(
+            "docs/CI-TEST-SHARDING.md",
+            "repo_internal",
+            "exempt",
+            "Describes this repository's own CI workflow shape. Entered from CONTRIBUTING.md; "
+            "it documents nothing a user or integrator of OMH can run.",
+            "release-readiness",
+        ),
+        PageClassification(
+            "docs/CODEGRAPH.md",
+            "repo_internal",
+            "exempt",
+            "Local code-intelligence setup for agents working on this repository. Entered "
+            "from the AGENTS.md CodeGraph section.",
+            "docs-specialist",
+        ),
+        PageClassification(
+            "docs/CONTRACT_SUNSET_CANDIDATES.md",
+            "working_note",
+            "exempt",
+            "A candidate list with no decision attached; it states that each entry needs its "
+            "own goal PR. Publishing it as a contract would imply removals that were never agreed.",
+            "docs-specialist",
+        ),
+        PageClassification(
+            "docs/MODEL-ONBOARDING.md",
+            "maintainer_procedure",
+            "exempt",
+            "Repository-side maintainer procedure. Indexed by the AGENTS.md Repository "
+            "Maintenance Procedures table, which is the single entry point for all three sweeps.",
+            "docs-specialist",
+        ),
+        PageClassification(
+            "docs/REVIEW-SWEEP.md",
+            "maintainer_procedure",
+            "exempt",
+            "Repository-side maintainer procedure. Indexed by the AGENTS.md Repository "
+            "Maintenance Procedures table.",
+            "docs-specialist",
+        ),
+        PageClassification(
+            "docs/TRIAGE-SWEEP.md",
+            "maintainer_procedure",
+            "exempt",
+            "Repository-side maintainer procedure. Indexed by the AGENTS.md Repository "
+            "Maintenance Procedures table.",
+            "docs-specialist",
+        ),
+        PageClassification(
+            "docs/routing-quality.md",
+            "repo_internal",
+            "exempt",
+            "Describes the golden evaluation in tests/test_routing_quality.py and its baseline. "
+            "Entered from docs/ADDING-A-SKILL.md; it is a test-gate note, not a product contract.",
+            "docs-specialist",
+        ),
+        PageClassification(
+            "docs/WORKFLOWS.md",
+            "generated",
+            "required",
+            "Generated from src/skills/catalog.py, and also the public skill catalog readers are "
+            "sent to. Generated is a provenance fact here, not a reason to drop it from the map.",
+            "docs-specialist",
+        ),
+        PageClassification(
+            "docs/ROLES.md",
+            "generated",
+            "required",
+            "Generated from roles_reference_markdown(), and also the public role reference. "
+            "Classified rather than excluded for the same reason as docs/WORKFLOWS.md.",
+            "docs-specialist",
+        ),
+    )

--- a/src/commands/docs.py
+++ b/src/commands/docs.py
@@ -292,6 +292,20 @@ def cmd_docs_claims(args: argparse.Namespace) -> int:
     return 1 if args.check and not payload["ok"] else 0
 
 
+def cmd_docs_navigation(args: argparse.Namespace) -> int:
+    from ..maintenance.documentation_navigation import (
+        documentation_navigation_report,
+        format_documentation_navigation,
+    )
+
+    payload = documentation_navigation_report(root=Path(args.root))
+    if args.json:
+        _print_json(payload)
+    else:
+        print(format_documentation_navigation(payload))
+    return 1 if args.check and not payload["ok"] else 0
+
+
 def _add_docs_commands(sub) -> None:
     docs = sub.add_parser("docs", help="Render or check generated OMH workflow reference docs.")
     docs_sub = docs.add_subparsers(dest="docs_command", required=True)
@@ -305,6 +319,19 @@ def _add_docs_commands(sub) -> None:
     claims.add_argument("--enable-model", action="store_true", help="Explicit advisory opt-in, requires --claim. Core CLI has no provider adapter: reports not_run.")
     claims.add_argument("--model-run-cap", type=int, default=1, help="Advisory run cap (0-3); never a release gate.")
     claims.set_defaults(func=cmd_docs_claims)
+
+    navigation = docs_sub.add_parser(
+        "navigation",
+        help=(
+            "Check public documentation structure offline: reachability from declared roots, "
+            "local link targets, navigation-root uniqueness, public-path collisions, and "
+            "classification of every intentionally non-public page (maintainers)."
+        ),
+    )
+    navigation.add_argument("--check", action="store_true", help="Exit 1 when any structural finding is reported; anchor advisories never block.")
+    navigation.add_argument("--json", action="store_true", help="Print the machine-readable documentation_navigation_audit/v1 payload.")
+    navigation.add_argument("--root", default=".", help="Repository tree to audit.")
+    navigation.set_defaults(func=cmd_docs_navigation)
 
     docs_workflows = docs_sub.add_parser("workflows")
     docs_workflows.add_argument("--output", default=None)

--- a/src/maintenance/documentation_navigation.py
+++ b/src/maintenance/documentation_navigation.py
@@ -1,0 +1,595 @@
+"""Offline documentation-structure audit: reachability, local targets, collisions.
+
+This is a separate evidence class from the two that already exist. Generated-file
+equality (`docs workflows|roles|capability-families|ulw-*`) proves a projection
+still matches its producer; the selected-claim audit (`docs claims`) proves a
+sentence still matches implementation. Neither can see a page that quietly left
+the map, and neither is repaired the same way, so this check does not fold into
+them and does not repeat their assertions.
+
+Everything here is local and deterministic: no network, no subprocess, no
+provider, and no automatic edit to any documentation file. A page being
+structurally reachable says nothing about whether its content is correct.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import re
+from typing import TypedDict
+from urllib.parse import unquote
+
+from ..catalogs.documentation_navigation import (
+    PAGE_CLASSES,
+    PUBLISHING_SURFACE,
+    REACHABILITY_STATES,
+    documentation_navigation_roots,
+    documentation_page_classifications,
+    documentation_scope_patterns,
+)
+
+
+DOCUMENTATION_NAVIGATION_SCHEMA = "documentation_navigation_audit/v1"
+
+# docs/WORKFLOWS.md is ~1 MiB of generated catalog today. The ceiling is set
+# above that with room to grow, and a page that crosses it is reported rather
+# than skipped, so growth stays visible instead of silently losing coverage.
+MAX_PAGE_BYTES = 4 * 1024 * 1024
+MAX_TRAVERSED_PAGES = 500
+MAX_LINKS_PER_PAGE = 4000
+# Diagnostics name paths and link targets only, never document prose. A target
+# is still document-controlled text, so it is length-capped and control
+# characters are escaped before it reaches any output stream.
+MAX_DIAGNOSTIC_CHARS = 200
+
+FAILURE_CLASSES = (
+    "absolute_link_target",
+    "duplicate_classification",
+    "duplicate_navigation_root",
+    "duplicate_public_path",
+    "invalid_classification",
+    "link_escapes_repository",
+    "missing_heading_anchor",
+    "missing_link_target",
+    "missing_navigation_root",
+    "page_over_budget",
+    "required_page_unreachable",
+    "stale_classification",
+    "traversal_budget_exceeded",
+    "unclassified_orphan",
+    "unnecessary_exclusion",
+    "windows_separator_link",
+)
+DEFAULT_OWNER = "docs-specialist"
+
+_FENCE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
+_INLINE_CODE = re.compile(r"`[^`\n]*`")
+_HEADING = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$")
+_INLINE_LINK = re.compile(r"!?\[[^\]\n]*\]\(\s*(<[^>\n]*>|[^)\s]*)(?:\s+(?:\"[^\"\n]*\"|'[^'\n]*'|\([^)\n]*\)))?\s*\)")
+_REFERENCE_DEFINITION = re.compile(r"^\s{0,3}\[[^\]\n]+\]:\s*(<[^>\n]*>|\S+)")
+_MARKDOWN_LINK_TEXT = re.compile(r"!?\[([^\]\n]*)\]\([^)\n]*\)")
+_SCHEME = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*:")
+_WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:[\\/]")
+_SLUG_DROP = re.compile(r"[^a-z0-9 _\-]")
+_CONTROL = re.compile(r"[\x00-\x1f\x7f]")
+
+
+class NavigationFinding(TypedDict):
+    failure_class: str
+    page: str
+    referrer: str | None
+    target: str | None
+    detail: str
+    owner: str
+
+
+class NavigationPageRow(TypedDict):
+    path: str
+    page_class: str
+    reachability: str
+    reachable: bool
+    referrers: list[str]
+    owner: str
+    reason: str
+
+
+class DocumentationNavigationReport(TypedDict):
+    schema_version: str
+    mode: str
+    observed: bool
+    ok: bool
+    publishing_surface: str
+    roots: list[dict[str, str]]
+    scope_patterns: list[str]
+    pages: list[NavigationPageRow]
+    findings: list[NavigationFinding]
+    advisories: list[NavigationFinding]
+    summary: dict[str, int]
+    bounds: dict[str, object]
+    anchor_scope: str
+    structure_boundary: str
+
+
+@dataclass(frozen=True)
+class _Link:
+    """One local link edge, already normalized to a repository-relative path."""
+
+    page: str
+    raw: str
+    target: str
+    fragment: str
+
+
+def _safe_diagnostic(value: str) -> str:
+    """Render document-controlled text as a bounded single-line diagnostic."""
+    cleaned = _CONTROL.sub("�", value)
+    if len(cleaned) > MAX_DIAGNOSTIC_CHARS:
+        return cleaned[:MAX_DIAGNOSTIC_CHARS] + "..."
+    return cleaned
+
+
+def _strip_code(text: str) -> str:
+    """Blank out fenced blocks and inline code spans, keeping line numbering.
+
+    A shell comment inside a fence starts with `#` and would otherwise be read
+    as a heading, and example paths inside fences are not navigation edges.
+    """
+    lines: list[str] = []
+    fence: str | None = None
+    for line in text.splitlines():
+        match = _FENCE.match(line)
+        if match:
+            token = match.group(1)
+            if fence is None:
+                fence = token[0] * 3
+                lines.append("")
+                continue
+            if line.lstrip().startswith(fence):
+                fence = None
+                lines.append("")
+                continue
+        lines.append("" if fence is not None else line)
+    return _INLINE_CODE.sub("", "\n".join(lines))
+
+
+def _heading_slugs(text: str) -> tuple[frozenset[str], bool]:
+    """Return heading anchors this parser can settle, and whether all were settled.
+
+    The declared rule for a settled heading: drop markdown link syntax, lowercase,
+    remove every character outside `[a-z0-9 _-]`, turn spaces into hyphens, and
+    disambiguate repeats with `-1`, `-2`. A heading holding any non-ASCII
+    character is left unsettled, because renderers disagree on how to transliterate
+    it and this parser will not guess on their behalf.
+    """
+    slugs: dict[str, int] = {}
+    settled = True
+    for line in _strip_code(text).splitlines():
+        match = _HEADING.match(line)
+        if not match:
+            continue
+        heading = _MARKDOWN_LINK_TEXT.sub(r"\1", match.group(1)).strip()
+        if not heading.isascii():
+            settled = False
+            continue
+        base = _SLUG_DROP.sub("", heading.lower()).replace(" ", "-")
+        if not base:
+            settled = False
+            continue
+        seen = slugs.get(base, 0)
+        slugs[base] = seen + 1
+    resolved = set()
+    for base, count in slugs.items():
+        resolved.add(base)
+        resolved.update(f"{base}-{index}" for index in range(1, count))
+    return frozenset(resolved), settled
+
+
+def _link_targets(text: str) -> list[str]:
+    """Collect inline-link, image, and reference-definition targets in order."""
+    body = _strip_code(text)
+    targets: list[str] = []
+    for match in _INLINE_LINK.finditer(body):
+        targets.append(match.group(1))
+        if len(targets) >= MAX_LINKS_PER_PAGE:
+            return targets
+    for line in body.splitlines():
+        match = _REFERENCE_DEFINITION.match(line)
+        if match:
+            targets.append(match.group(1))
+            if len(targets) >= MAX_LINKS_PER_PAGE:
+                return targets
+    return targets
+
+
+def _is_external(target: str) -> bool:
+    """True for anything a local filesystem check must not attempt to resolve."""
+    if target.startswith("//"):
+        return True
+    return bool(_SCHEME.match(target)) and not _WINDOWS_DRIVE.match(target)
+
+
+def _normalize_relative(page: str, target: str) -> list[str] | None:
+    """Resolve `target` against `page`'s directory purely lexically.
+
+    Lexical resolution is the point: `Path.resolve()` consults the filesystem and
+    follows symlinks, so it would answer differently per machine and could walk
+    outside the repository through a link. `None` means the path escaped.
+    """
+    parts = page.split("/")[:-1]
+    for segment in target.split("/"):
+        if segment in ("", "."):
+            continue
+        if segment == "..":
+            if not parts:
+                return None
+            parts.pop()
+            continue
+        parts.append(segment)
+    return parts
+
+
+def _exists_exact(root: Path, parts: list[str], cache: dict[str, frozenset[str]]) -> bool:
+    """Case-sensitive existence check, independent of the host filesystem.
+
+    macOS and Windows resolve `docs/readme.md` to `docs/README.md`; Linux does
+    not. Matching against each directory's real entry names keeps the verdict
+    identical everywhere, so a link that only works on a case-insensitive
+    checkout still fails here.
+    """
+    if not parts:
+        return False
+    current = ""
+    for segment in parts:
+        entries = cache.get(current)
+        if entries is None:
+            directory = root if not current else root.joinpath(*current.split("/"))
+            try:
+                with os.scandir(directory) as scan:
+                    entries = frozenset(entry.name for entry in scan)
+            except OSError:
+                # Not a directory, or unreadable: nothing below it can resolve.
+                entries = frozenset()
+            cache[current] = entries
+        if segment not in entries:
+            return False
+        current = segment if not current else f"{current}/{segment}"
+    return True
+
+
+def _read_page(root: Path, page: str) -> tuple[str | None, str | None]:
+    """Read one page within budget. Returns (text, failure_class)."""
+    path = root.joinpath(*page.split("/"))
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return None, "missing_link_target"
+    if size > MAX_PAGE_BYTES:
+        return None, "page_over_budget"
+    try:
+        return path.read_text(encoding="utf-8", errors="replace"), None
+    except OSError:
+        return None, "missing_link_target"
+
+
+def _classification_owner(by_path: dict[str, object], page: str) -> str:
+    entry = by_path.get(page)
+    return getattr(entry, "owner", DEFAULT_OWNER)
+
+
+def _scope_pages(root: Path, patterns: tuple[str, ...]) -> list[str]:
+    pages: set[str] = set()
+    for pattern in patterns:
+        for path in root.glob(pattern):
+            if path.is_file():
+                pages.add(path.relative_to(root).as_posix())
+    return sorted(pages)
+
+
+def public_path_collisions(paths: list[str]) -> list[NavigationFinding]:
+    """Report pages whose public paths differ only by case.
+
+    Exposed as its own function because the condition cannot be staged on a
+    case-insensitive filesystem: macOS and Windows refuse to hold both files at
+    once, which is precisely the breakage this catches when a page pair is
+    created on Linux and then cloned somewhere else.
+    """
+    lowered: dict[str, set[str]] = {}
+    for path in paths:
+        lowered.setdefault(path.lower(), set()).add(path)
+    collisions: list[NavigationFinding] = []
+    for key, group in sorted(lowered.items()):
+        if len(group) > 1:
+            collisions.append({
+                "failure_class": "duplicate_public_path", "page": sorted(group)[0],
+                "referrer": None, "target": key, "owner": DEFAULT_OWNER,
+                "detail": f"Pages differing only by case collide on the {PUBLISHING_SURFACE} "
+                          "surface: " + ", ".join(sorted(group)),
+            })
+    return collisions
+
+
+def documentation_navigation_report(*, root: Path | None = None) -> DocumentationNavigationReport:
+    """Walk declared roots, validate every local link, and settle every in-scope page.
+
+    Findings block; advisories do not. The only advisory class is an anchor this
+    parser refuses to settle, which is a limit of the parser rather than a defect
+    in the page.
+    """
+    resolved_root = (root or Path.cwd()).resolve()
+    roots = documentation_navigation_roots()
+    classifications = documentation_page_classifications()
+    patterns = documentation_scope_patterns()
+
+    findings: list[NavigationFinding] = []
+    advisories: list[NavigationFinding] = []
+
+    by_path: dict[str, object] = {}
+    for entry in classifications:
+        if entry.path in by_path:
+            findings.append({
+                "failure_class": "duplicate_classification", "page": entry.path,
+                "referrer": None, "target": None, "owner": entry.owner,
+                "detail": "Classified more than once; keep exactly one entry per page.",
+            })
+            continue
+        if entry.page_class not in PAGE_CLASSES or entry.reachability not in REACHABILITY_STATES:
+            findings.append({
+                "failure_class": "invalid_classification", "page": entry.path,
+                "referrer": None, "target": None, "owner": entry.owner,
+                "detail": f"page_class must be one of {PAGE_CLASSES} and reachability one of {REACHABILITY_STATES}.",
+            })
+            continue
+        by_path[entry.path] = entry
+
+    root_paths: list[str] = []
+    seen_roots: set[str] = set()
+    dir_cache: dict[str, frozenset[str]] = {}
+    for declared in roots:
+        if declared.path in seen_roots:
+            findings.append({
+                "failure_class": "duplicate_navigation_root", "page": declared.path,
+                "referrer": None, "target": None, "owner": DEFAULT_OWNER,
+                "detail": "Declared as a navigation root more than once.",
+            })
+            continue
+        seen_roots.add(declared.path)
+        if not _exists_exact(resolved_root, declared.path.split("/"), dir_cache):
+            findings.append({
+                "failure_class": "missing_navigation_root", "page": declared.path,
+                "referrer": None, "target": None, "owner": DEFAULT_OWNER,
+                "detail": "Declared navigation root does not exist in the repository.",
+            })
+            continue
+        root_paths.append(declared.path)
+
+    scope = _scope_pages(resolved_root, patterns)
+    reachable: dict[str, list[str]] = {path: [] for path in root_paths}
+    queue: list[str] = list(root_paths)
+    visited: set[str] = set()
+    anchors: dict[str, tuple[frozenset[str], bool]] = {}
+    pending_anchor_checks: list[_Link] = []
+    budget_exceeded = False
+
+    # Traversal reads reachable pages plus every in-scope page: an orphan's own
+    # broken links are the ones nobody is looking at, so they are checked too.
+    parse_order = list(root_paths) + [path for path in scope if path not in reachable]
+    parsed: set[str] = set()
+
+    while queue or parse_order:
+        page = queue.pop(0) if queue else parse_order.pop(0)
+        if page in visited:
+            continue
+        if len(visited) >= MAX_TRAVERSED_PAGES:
+            budget_exceeded = True
+            break
+        visited.add(page)
+        parsed.add(page)
+        text, failure = _read_page(resolved_root, page)
+        if failure == "page_over_budget":
+            findings.append({
+                "failure_class": "page_over_budget", "page": page,
+                "referrer": None, "target": None,
+                "owner": _classification_owner(by_path, page),
+                "detail": f"Page exceeds the {MAX_PAGE_BYTES}-byte parse budget and was not parsed.",
+            })
+            continue
+        if text is None:
+            continue
+        anchors[page] = _heading_slugs(text)
+        for raw in _link_targets(text):
+            target = raw[1:-1] if raw.startswith("<") and raw.endswith(">") else raw
+            if not target or _is_external(target):
+                continue
+            path_part, _, fragment = target.partition("#")
+            if "\\" in path_part:
+                findings.append({
+                    "failure_class": "windows_separator_link", "page": page,
+                    "referrer": None, "target": _safe_diagnostic(target),
+                    "owner": _classification_owner(by_path, page),
+                    "detail": "Link uses a backslash separator; write local paths with '/'.",
+                })
+                continue
+            if not path_part:
+                pending_anchor_checks.append(_Link(page, target, page, unquote(fragment)))
+                continue
+            decoded = unquote(path_part)
+            if decoded.startswith("/") or _WINDOWS_DRIVE.match(decoded):
+                findings.append({
+                    "failure_class": "absolute_link_target", "page": page,
+                    "referrer": None, "target": _safe_diagnostic(target),
+                    "owner": _classification_owner(by_path, page),
+                    "detail": "Absolute local path does not resolve in a repository view; use a relative path.",
+                })
+                continue
+            parts = _normalize_relative(page, decoded)
+            if parts is None:
+                findings.append({
+                    "failure_class": "link_escapes_repository", "page": page,
+                    "referrer": None, "target": _safe_diagnostic(target),
+                    "owner": _classification_owner(by_path, page),
+                    "detail": "Link resolves above the repository root.",
+                })
+                continue
+            if not _exists_exact(resolved_root, parts, dir_cache):
+                findings.append({
+                    "failure_class": "missing_link_target", "page": page,
+                    "referrer": None, "target": _safe_diagnostic(target),
+                    "owner": _classification_owner(by_path, page),
+                    "detail": "Local target does not exist (matched case-sensitively).",
+                })
+                continue
+            resolved_target = "/".join(parts)
+            if fragment and resolved_target.endswith(".md"):
+                pending_anchor_checks.append(_Link(page, target, resolved_target, unquote(fragment)))
+            if not resolved_target.endswith(".md"):
+                continue
+            if page in reachable or page in root_paths:
+                referrers = reachable.setdefault(resolved_target, [])
+                if page not in referrers and resolved_target not in root_paths:
+                    referrers.append(page)
+                if resolved_target not in visited:
+                    queue.append(resolved_target)
+
+    if budget_exceeded:
+        findings.append({
+            "failure_class": "traversal_budget_exceeded", "page": "",
+            "referrer": None, "target": None, "owner": DEFAULT_OWNER,
+            "detail": f"Traversal stopped after {MAX_TRAVERSED_PAGES} pages; results are incomplete.",
+        })
+
+    for link in pending_anchor_checks:
+        known = anchors.get(link.target)
+        if known is None:
+            text, _ = _read_page(resolved_root, link.target)
+            if text is None:
+                continue
+            known = _heading_slugs(text)
+            anchors[link.target] = known
+        slugs, settled = known
+        if link.fragment in slugs:
+            continue
+        row: NavigationFinding = {
+            "failure_class": "missing_heading_anchor", "page": link.target,
+            "referrer": link.page, "target": _safe_diagnostic(link.raw),
+            "owner": _classification_owner(by_path, link.target),
+            "detail": "No heading on the target page produces this anchor.",
+        }
+        if settled:
+            findings.append(row)
+        else:
+            advisories.append({
+                **row,
+                "detail": "Anchor unsettled: the target page has a heading this parser will not slug.",
+            })
+
+    findings.extend(public_path_collisions(scope + root_paths))
+
+    for entry in classifications:
+        if by_path.get(entry.path) is not entry:
+            continue
+        if entry.path not in scope and entry.path not in root_paths:
+            findings.append({
+                "failure_class": "stale_classification", "page": entry.path,
+                "referrer": None, "target": None, "owner": entry.owner,
+                "detail": "Classified page is not in scope; remove the entry or restore the page.",
+            })
+
+    pages: list[NavigationPageRow] = []
+    for page in scope:
+        entry = by_path.get(page)
+        is_reachable = page in reachable or page in root_paths
+        page_class = getattr(entry, "page_class", "public")
+        expectation = getattr(entry, "reachability", "required")
+        reason = getattr(entry, "reason", "")
+        owner = getattr(entry, "owner", DEFAULT_OWNER)
+        if expectation == "exempt" and is_reachable:
+            findings.append({
+                "failure_class": "unnecessary_exclusion", "page": page,
+                "referrer": sorted(reachable.get(page, []))[0] if reachable.get(page) else None,
+                "target": None, "owner": owner,
+                "detail": "Page is reachable but still classified exempt; drop the classification entry.",
+            })
+        elif not is_reachable and expectation == "required":
+            failure_class = "required_page_unreachable" if entry is not None else "unclassified_orphan"
+            detail = (
+                "Classified as reachability=required but no declared root reaches it; "
+                "add the link or change the classification."
+                if entry is not None else
+                "Not reachable from any declared root and not classified; link it from a root "
+                "or add a reasoned entry to documentation_page_classifications()."
+            )
+            findings.append({
+                "failure_class": failure_class, "page": page,
+                "referrer": None, "target": None, "owner": owner, "detail": detail,
+            })
+        pages.append({
+            "path": page, "page_class": page_class, "reachability": expectation,
+            "reachable": is_reachable, "referrers": sorted(reachable.get(page, [])),
+            "owner": owner, "reason": reason,
+        })
+
+    findings.sort(key=lambda row: (row["failure_class"], row["page"], row["referrer"] or "", row["target"] or ""))
+    advisories.sort(key=lambda row: (row["failure_class"], row["page"], row["referrer"] or "", row["target"] or ""))
+    return {
+        "schema_version": DOCUMENTATION_NAVIGATION_SCHEMA,
+        "mode": "observed_structure",
+        "observed": True,
+        "ok": not findings,
+        "publishing_surface": PUBLISHING_SURFACE,
+        "roots": [{"path": item.path, "reason": item.reason} for item in roots],
+        "scope_patterns": list(patterns),
+        "pages": pages,
+        "findings": findings,
+        "advisories": advisories,
+        "summary": {
+            "scope_pages": len(pages),
+            "reachable_pages": sum(row["reachable"] for row in pages),
+            "exempt_pages": sum(row["reachability"] == "exempt" for row in pages),
+            "parsed_pages": len(parsed),
+            "finding_count": len(findings),
+            "advisory_count": len(advisories),
+        },
+        "bounds": {
+            "max_page_bytes": MAX_PAGE_BYTES,
+            "max_traversed_pages": MAX_TRAVERSED_PAGES,
+            "max_links_per_page": MAX_LINKS_PER_PAGE,
+            "network": False,
+            "subprocess": False,
+            "automatic_doc_edits": False,
+        },
+        "anchor_scope": (
+            "Local heading anchors are settled only against headings this parser slugs: ASCII "
+            "heading text, lowercased, characters outside [a-z0-9 _-] removed, spaces hyphenated, "
+            "repeats suffixed -1/-2. Anything else is reported as an advisory, never a failure. "
+            "This claims no equivalence with GitHub, a static-site generator, or any other renderer."
+        ),
+        "structure_boundary": (
+            "Structure only: reachability through declared local links, local target existence, "
+            "navigation-root uniqueness, and case-collision on the declared publishing surface. "
+            "A reachable page is not evidence that its content is current, accurate, or usable, "
+            "and this is not generated-artifact equality, claim auditing, review, CI, or merge evidence."
+        ),
+    }
+
+
+def format_documentation_navigation(report: DocumentationNavigationReport) -> str:
+    summary = report["summary"]
+    lines = ["Documentation navigation: " + ("PASS" if report["ok"] else "NEEDS ATTENTION")]
+    lines.append(
+        f"  roots={len(report['roots'])} scope={summary['scope_pages']} "
+        f"reachable={summary['reachable_pages']} exempt={summary['exempt_pages']} "
+        f"parsed={summary['parsed_pages']}"
+    )
+    for row in report["findings"]:
+        lines.append(f"{row['failure_class']} {row['page']} owner={row['owner']}")
+        if row["referrer"] or row["target"]:
+            lines.append(f"  referrer={row['referrer'] or '-'} target={row['target'] or '-'}")
+        lines.append(f"  {row['detail']}")
+    for row in report["advisories"]:
+        lines.append(f"advisory {row['failure_class']} {row['page']} referrer={row['referrer'] or '-'}")
+        lines.append(f"  {row['detail']}")
+    lines.append(report["anchor_scope"])
+    lines.append(report["structure_boundary"])
+    return "\n".join(lines)

--- a/src/maintenance/release.py
+++ b/src/maintenance/release.py
@@ -987,6 +987,16 @@ def release_readiness_checklist(
             "This checklist prepares the command, not its result. Generated drift is separate evidence; optional model judgments never block release.",
         ),
         ReleaseChecklistItem(
+            "documentation_navigation",
+            "Check public documentation structure",
+            "uv run python -m omh.cli docs navigation --check",
+            "contract-quality",
+            True,
+            False,
+            "Every in-scope page is reachable from a declared root or classified with a reason, every local target resolves, and navigation roots are unique, in an observed documentation_navigation_audit/v1 report.",
+            "Structure only. A reachable page is not evidence that its content is current or usable, and this is a separate evidence class from generated-artifact equality and from the semantic claim audit.",
+        ),
+        ReleaseChecklistItem(
             "source_checkout_command_smoke",
             "Check source-checkout console command importability",
             'uv run --no-editable omh recommend "risky refactor" --limit 1 --json',

--- a/tests/test_documentation_navigation.py
+++ b/tests/test_documentation_navigation.py
@@ -1,0 +1,613 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from _cli_harness import run_cli
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.catalogs.documentation_navigation import (
+    NavigationRoot,
+    PageClassification,
+    documentation_navigation_roots,
+    documentation_page_classifications,
+    documentation_scope_patterns,
+)
+from omh.maintenance.documentation_navigation import (
+    DOCUMENTATION_NAVIGATION_SCHEMA,
+    FAILURE_CLASSES,
+    documentation_navigation_report,
+    format_documentation_navigation,
+    public_path_collisions,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE = "omh.maintenance.documentation_navigation"
+
+
+def write(root: Path, relative: str, text: str) -> Path:
+    path = root.joinpath(*relative.split("/"))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class FixtureRepository:
+    """A synthetic tree plus the navigation policy that should govern it.
+
+    The checked-in policy names real repository pages, so a fixture supplies its
+    own roots, scope, and classifications through the same three entry points the
+    report reads. Nothing about the production signature changes.
+    """
+
+    def __init__(
+        self,
+        *,
+        roots: tuple[NavigationRoot, ...] = (NavigationRoot("README.md", "fixture root"),),
+        patterns: tuple[str, ...] = ("docs/*.md",),
+        classifications: tuple[PageClassification, ...] = (),
+    ) -> None:
+        self.roots = roots
+        self.patterns = patterns
+        self.classifications = classifications
+        self._temp = tempfile.TemporaryDirectory()
+        self.path = Path(self._temp.name).resolve()
+
+    def __enter__(self) -> FixtureRepository:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._temp.cleanup()
+
+    def write(self, relative: str, text: str) -> Path:
+        return write(self.path, relative, text)
+
+    def report(self) -> dict:
+        with (
+            patch(f"{MODULE}.documentation_navigation_roots", return_value=self.roots),
+            patch(f"{MODULE}.documentation_scope_patterns", return_value=self.patterns),
+            patch(f"{MODULE}.documentation_page_classifications", return_value=self.classifications),
+        ):
+            return documentation_navigation_report(root=self.path)
+
+    def classes(self) -> set[str]:
+        return {row["failure_class"] for row in self.report()["findings"]}
+
+
+class RepositoryNavigationTests(unittest.TestCase):
+    """The live repository under the checked-in policy."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.report = documentation_navigation_report(root=ROOT)
+
+    def test_repository_documentation_graph_has_no_structural_findings(self) -> None:
+        self.assertEqual(self.report["schema_version"], DOCUMENTATION_NAVIGATION_SCHEMA)
+        self.assertTrue(self.report["observed"])
+        self.assertEqual(
+            self.report["findings"], [],
+            "\n" + format_documentation_navigation(self.report),
+        )
+        self.assertTrue(self.report["ok"])
+
+    def test_every_in_scope_page_is_reachable_or_classified_with_a_reason_and_owner(self) -> None:
+        # Success criterion 4: no top-level docs page may be settled by silence.
+        for row in self.report["pages"]:
+            with self.subTest(page=row["path"]):
+                if row["reachable"]:
+                    self.assertTrue(row["referrers"] or row["path"] in {"README.md", "docs/README.md"})
+                    continue
+                self.assertEqual(row["reachability"], "exempt")
+                self.assertGreater(len(row["reason"]), 40, "an exclusion must explain itself")
+                self.assertTrue(row["owner"])
+
+    def test_generated_public_pages_are_classified_but_still_required_to_be_reachable(self) -> None:
+        rows = {row["path"]: row for row in self.report["pages"]}
+        for page in ("docs/WORKFLOWS.md", "docs/ROLES.md"):
+            with self.subTest(page=page):
+                self.assertEqual(rows[page]["page_class"], "generated")
+                self.assertEqual(rows[page]["reachability"], "required")
+                self.assertTrue(rows[page]["reachable"])
+
+    def test_declared_roots_exist_and_are_unique(self) -> None:
+        declared = [item.path for item in documentation_navigation_roots()]
+        self.assertEqual(len(declared), len(set(declared)))
+        for path in declared:
+            self.assertTrue(ROOT.joinpath(*path.split("/")).is_file())
+
+    def test_classifications_are_unique_and_name_pages_that_exist(self) -> None:
+        seen: set[str] = set()
+        for entry in documentation_page_classifications():
+            with self.subTest(page=entry.path):
+                self.assertNotIn(entry.path, seen)
+                seen.add(entry.path)
+                self.assertTrue(ROOT.joinpath(*entry.path.split("/")).is_file())
+
+    def test_report_is_deterministic_and_stably_ordered(self) -> None:
+        again = documentation_navigation_report(root=ROOT)
+        self.assertEqual(json.dumps(self.report, sort_keys=True), json.dumps(again, sort_keys=True))
+        self.assertEqual([row["path"] for row in again["pages"]], sorted(row["path"] for row in again["pages"]))
+
+    def test_bounds_are_declared_and_no_side_channel_is_claimed(self) -> None:
+        bounds = self.report["bounds"]
+        self.assertFalse(bounds["network"])
+        self.assertFalse(bounds["subprocess"])
+        self.assertFalse(bounds["automatic_doc_edits"])
+        self.assertGreater(bounds["max_page_bytes"], 1_048_576)
+
+    def test_structure_evidence_does_not_claim_content_correctness(self) -> None:
+        boundary = self.report["structure_boundary"]
+        self.assertIn("not evidence that its content", boundary)
+        self.assertIn("not generated-artifact equality", boundary)
+        self.assertIn("claim auditing", boundary)
+        self.assertIn("no equivalence with GitHub", self.report["anchor_scope"])
+
+    def test_scope_stays_the_declared_top_level_docs_surface(self) -> None:
+        self.assertEqual(documentation_scope_patterns(), ("docs/*.md",))
+        expected = sorted(path.name for path in (ROOT / "docs").glob("*.md"))
+        self.assertEqual(sorted(Path(row["path"]).name for row in self.report["pages"]), expected)
+
+
+class LinkResolutionTests(unittest.TestCase):
+    """Path handling: the shapes that break differently per platform."""
+
+    def test_nested_relative_link_resolves_through_directories(self) -> None:
+        with FixtureRepository(patterns=("docs/*.md", "docs/*/*.md")) as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "[child](guides/CHILD.md)\n")
+            repo.write("docs/guides/CHILD.md", "[back up](../../README.md)\n[sibling](../SIB.md)\n")
+            repo.write("docs/SIB.md", "# Sibling\n")
+
+            report = repo.report()
+
+            self.assertEqual(report["findings"], [], format_documentation_navigation(report))
+            reachable = {row["path"] for row in report["pages"] if row["reachable"]}
+            self.assertEqual(reachable, {"docs/README.md", "docs/guides/CHILD.md", "docs/SIB.md"})
+
+    def test_url_encoded_path_resolves_to_the_decoded_file(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "[spaced](release%20notes.md)\n[plus](c%2B%2B.md)\n")
+            repo.write("docs/release notes.md", "# Release notes\n")
+            repo.write("docs/c++.md", "# C++\n")
+
+            report = repo.report()
+
+            self.assertEqual(report["findings"], [], format_documentation_navigation(report))
+            self.assertEqual(report["summary"]["reachable_pages"], 3)
+
+    def test_windows_separator_link_is_rejected_rather_than_silently_resolved(self) -> None:
+        # This must fail identically on POSIX and Windows. A backslash is not a
+        # separator in a repository view, and letting the host filesystem decide
+        # would make the same tree pass on one runner and fail on the other.
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "[win](sub\\CHILD.md)\n[ok](CHILD.md)\n")
+            repo.write("docs/CHILD.md", "# Child\n")
+            repo.write("docs/sub/CHILD.md", "# Nested child\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["windows_separator_link"])
+            self.assertEqual(findings[0]["page"], "docs/README.md")
+            self.assertIn("sub\\CHILD.md", findings[0]["target"])
+
+    def test_link_escaping_the_repository_is_rejected(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "[out](../../secrets.md)\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["link_escapes_repository"])
+            self.assertEqual(findings[0]["target"], "../../secrets.md")
+
+    def test_absolute_local_path_is_rejected(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "[abs](/docs/CHILD.md)\n[drive](C:/docs/CHILD.md)\n")
+            repo.write("docs/CHILD.md", "# Child\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual({row["failure_class"] for row in findings},
+                             {"absolute_link_target", "unclassified_orphan"})
+
+    def test_missing_local_target_fails_with_the_referring_page(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "[gone](REMOVED.md)\n![shot](../assets/missing.png)\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual({row["failure_class"] for row in findings}, {"missing_link_target"})
+            self.assertEqual({row["page"] for row in findings}, {"docs/README.md"})
+            self.assertEqual({row["target"] for row in findings}, {"REMOVED.md", "../assets/missing.png"})
+
+    def test_case_only_difference_does_not_resolve(self) -> None:
+        # The host filesystem may fold case; the verdict must not.
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "[wrong case](child.md)\n[right](CHILD.md)\n")
+            repo.write("docs/CHILD.md", "# Child\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["missing_link_target"])
+            self.assertEqual(findings[0]["target"], "child.md")
+
+    def test_external_and_mailto_links_are_never_resolved_locally(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write(
+                "docs/README.md",
+                "[web](https://example.invalid/x.md)\n[mail](mailto:a@example.invalid)\n"
+                "[scheme-relative](//example.invalid/y.md)\n",
+            )
+
+            self.assertEqual(repo.report()["findings"], [])
+
+    def test_code_fences_and_inline_code_are_not_navigation_edges(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write(
+                "docs/README.md",
+                "Example only: `[x](GONE.md)`\n\n"
+                "```sh\n# Heading inside a fence\n[y](ALSO-GONE.md)\n```\n\n"
+                "~~~\n[z](STILL-GONE.md)\n~~~\n",
+            )
+
+            self.assertEqual(repo.report()["findings"], [])
+
+
+class AnchorTests(unittest.TestCase):
+    def test_valid_cross_page_and_same_page_anchors_pass(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write(
+                "docs/README.md",
+                "# Docs\n\n## Guided Model Setup\n\n[same](#guided-model-setup)\n"
+                "[cross](CHILD.md#deep-section-two)\n",
+            )
+            repo.write("docs/CHILD.md", "# Child\n\n## Deep: section two\n")
+
+            self.assertEqual(repo.report()["findings"], [])
+
+    def test_missing_anchor_on_a_fully_settled_page_fails(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n\n[cross](CHILD.md#not-a-heading)\n")
+            repo.write("docs/CHILD.md", "# Child\n\n## Real heading\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["missing_heading_anchor"])
+            self.assertEqual(findings[0]["page"], "docs/CHILD.md")
+            self.assertEqual(findings[0]["referrer"], "docs/README.md")
+
+    def test_repeated_headings_get_disambiguated_anchors(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n\n[second](CHILD.md#notes-1)\n")
+            repo.write("docs/CHILD.md", "# Child\n\n## Notes\n\ntext\n\n## Notes\n")
+
+            self.assertEqual(repo.report()["findings"], [])
+
+    def test_unresolved_anchor_on_a_page_with_non_ascii_headings_is_advisory(self) -> None:
+        # The parser refuses to guess how a renderer transliterates a non-ASCII
+        # heading, so it reports the limit instead of asserting a defect.
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n\n[cross](CHILD.md#01-per-model-tuning)\n")
+            repo.write("docs/CHILD.md", "# Child\n\n### 01 \u00b7 Per-model tuning\n")
+
+            report = repo.report()
+
+            self.assertEqual(report["findings"], [])
+            self.assertEqual([row["failure_class"] for row in report["advisories"]], ["missing_heading_anchor"])
+            self.assertIn("unsettled", report["advisories"][0]["detail"])
+            self.assertTrue(report["ok"])
+
+    def test_headings_inside_code_fences_do_not_create_anchors(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n\n[cross](CHILD.md#shell-comment)\n")
+            repo.write("docs/CHILD.md", "# Child\n\n```sh\n# Shell comment\n```\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["missing_heading_anchor"])
+
+
+class ClassificationTests(unittest.TestCase):
+    def test_unclassified_orphan_fails(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n")
+            repo.write("docs/ORPHAN.md", "# Orphan\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["unclassified_orphan"])
+            self.assertEqual(findings[0]["page"], "docs/ORPHAN.md")
+            self.assertIn("documentation_page_classifications()", findings[0]["detail"])
+
+    def test_classified_exclusion_passes_and_carries_its_reason_forward(self) -> None:
+        with FixtureRepository(classifications=(
+            PageClassification(
+                "docs/ORPHAN.md", "maintainer_procedure", "exempt",
+                "Maintainer procedure entered from the agent contract.", "docs-specialist",
+            ),
+        )) as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n")
+            repo.write("docs/ORPHAN.md", "# Orphan\n")
+
+            report = repo.report()
+            row = next(item for item in report["pages"] if item["path"] == "docs/ORPHAN.md")
+
+            self.assertEqual(report["findings"], [])
+            self.assertFalse(row["reachable"])
+            self.assertEqual(row["page_class"], "maintainer_procedure")
+            self.assertIn("agent contract", row["reason"])
+            self.assertEqual(report["summary"]["exempt_pages"], 1)
+
+    def test_a_reachable_page_may_not_stay_classified_exempt(self) -> None:
+        with FixtureRepository(classifications=(
+            PageClassification("docs/LINKED.md", "repo_internal", "exempt", "stale reason", "docs-specialist"),
+        )) as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n\n[linked](LINKED.md)\n")
+            repo.write("docs/LINKED.md", "# Linked\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["unnecessary_exclusion"])
+            self.assertEqual(findings[0]["referrer"], "docs/README.md")
+
+    def test_a_generated_page_declared_required_still_has_to_be_reachable(self) -> None:
+        # Generated is a provenance fact, not an excuse to drop a public page.
+        with FixtureRepository(classifications=(
+            PageClassification("docs/GENERATED.md", "generated", "required", "Rendered from the catalog.", "docs-specialist"),
+        )) as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n")
+            repo.write("docs/GENERATED.md", "# Generated\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["required_page_unreachable"])
+            self.assertIn("change the classification", findings[0]["detail"])
+
+    def test_classification_naming_a_removed_page_is_stale(self) -> None:
+        with FixtureRepository(classifications=(
+            PageClassification("docs/DELETED.md", "repo_internal", "exempt", "gone", "docs-specialist"),
+        )) as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["stale_classification"])
+
+    def test_duplicate_and_invalid_classifications_fail(self) -> None:
+        entry = PageClassification("docs/A.md", "repo_internal", "exempt", "reason", "docs-specialist")
+        with FixtureRepository(classifications=(
+            entry, entry,
+            PageClassification("docs/B.md", "not-a-class", "exempt", "reason", "docs-specialist"),
+            PageClassification("docs/C.md", "repo_internal", "maybe", "reason", "docs-specialist"),
+        )) as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n")
+            for name in ("A", "B", "C"):
+                repo.write(f"docs/{name}.md", f"# {name}\n")
+
+            classes = repo.classes()
+
+            self.assertIn("duplicate_classification", classes)
+            self.assertIn("invalid_classification", classes)
+
+
+class NavigationRootTests(unittest.TestCase):
+    def test_duplicate_navigation_root_fails(self) -> None:
+        with FixtureRepository(roots=(
+            NavigationRoot("README.md", "front page"),
+            NavigationRoot("README.md", "declared twice"),
+        )) as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual([row["failure_class"] for row in findings], ["duplicate_navigation_root"])
+
+    def test_missing_navigation_root_fails_rather_than_emptying_the_graph(self) -> None:
+        with FixtureRepository(roots=(
+            NavigationRoot("README.md", "front page"),
+            NavigationRoot("HANDBOOK.md", "removed page"),
+        )) as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n")
+
+            classes = repo.classes()
+
+            self.assertIn("missing_navigation_root", classes)
+
+    def test_public_path_collision_is_reported(self) -> None:
+        collisions = public_path_collisions(["docs/Guide.md", "docs/guide.md", "docs/other.md"])
+
+        self.assertEqual(len(collisions), 1)
+        self.assertEqual(collisions[0]["failure_class"], "duplicate_public_path")
+        self.assertIn("docs/Guide.md", collisions[0]["detail"])
+        self.assertIn("docs/guide.md", collisions[0]["detail"])
+        self.assertEqual(public_path_collisions(["docs/a.md", "docs/b.md"]), [])
+
+    def test_public_path_collision_is_reported_end_to_end_where_the_filesystem_allows_it(self) -> None:
+        with FixtureRepository(classifications=(
+            PageClassification("docs/Guide.md", "repo_internal", "exempt", "fixture", "docs-specialist"),
+            PageClassification("docs/guide.md", "repo_internal", "exempt", "fixture", "docs-specialist"),
+        )) as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n")
+            repo.write("docs/Guide.md", "# Guide\n")
+            repo.write("docs/guide.md", "# guide\n")
+            if len(list((repo.path / "docs").glob("*uide.md"))) < 2:
+                self.skipTest("case-insensitive filesystem cannot hold both pages at once")
+
+            classes = repo.classes()
+
+            self.assertIn("duplicate_public_path", classes)
+
+
+class BudgetAndDiagnosticTests(unittest.TestCase):
+    def test_a_page_over_the_parse_budget_is_reported_not_skipped(self) -> None:
+        with FixtureRepository() as repo, patch(f"{MODULE}.MAX_PAGE_BYTES", 64):
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "# Docs\n\n" + "filler line\n" * 40)
+
+            classes = repo.classes()
+
+            self.assertIn("page_over_budget", classes)
+
+    def test_traversal_budget_stops_and_says_the_results_are_incomplete(self) -> None:
+        with FixtureRepository() as repo, patch(f"{MODULE}.MAX_TRAVERSED_PAGES", 3):
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "".join(f"[p{i}](P{i}.md)\n" for i in range(10)))
+            for index in range(10):
+                repo.write(f"docs/P{index}.md", f"# Page {index}\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertIn("traversal_budget_exceeded", {row["failure_class"] for row in findings})
+
+    def test_diagnostics_name_paths_and_never_quote_page_prose(self) -> None:
+        secret = "internal-only-sentence-that-must-not-escape"
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", f"{secret}\n\n[gone](REMOVED.md)\n")
+
+            report = repo.report()
+            rendered = json.dumps(report) + format_documentation_navigation(report)
+
+            self.assertNotIn(secret, rendered)
+            self.assertIn("REMOVED.md", rendered)
+
+    def test_an_overlong_link_target_is_truncated_and_control_characters_are_escaped(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "[long](" + "a" * 900 + ".md)\n")
+
+            findings = repo.report()["findings"]
+
+            self.assertEqual(findings[0]["failure_class"], "missing_link_target")
+            self.assertLess(len(findings[0]["target"]), 250)
+            self.assertTrue(findings[0]["target"].endswith("..."))
+
+    def test_findings_are_stably_ordered_for_ci(self) -> None:
+        with FixtureRepository() as repo:
+            repo.write("README.md", "[docs](docs/README.md)\n")
+            repo.write("docs/README.md", "[b](B-GONE.md)\n[a](A-GONE.md)\n")
+            repo.write("docs/ZORPHAN.md", "# Z\n")
+            repo.write("docs/AORPHAN.md", "# A\n")
+
+            findings = repo.report()["findings"]
+            keys = [(row["failure_class"], row["page"], row["referrer"] or "", row["target"] or "") for row in findings]
+
+            self.assertEqual(keys, sorted(keys))
+            self.assertTrue(set(FAILURE_CLASSES) >= {row["failure_class"] for row in findings})
+
+
+class NavigationCommandTests(unittest.TestCase):
+    def test_check_passes_on_the_repository_and_prints_a_machine_readable_payload(self) -> None:
+        status, stdout, _ = run_cli(["docs", "navigation", "--check", "--json"], output_json=False)
+        payload = json.loads(stdout)
+
+        self.assertEqual(status, 0)
+        self.assertEqual(payload["schema_version"], DOCUMENTATION_NAVIGATION_SCHEMA)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["findings"], [])
+
+    def test_check_exits_one_on_a_tree_with_an_orphan(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            tree = Path(temp)
+            write(tree, "README.md", "[docs](docs/README.md)\n")
+            write(tree, "docs/README.md", "# Docs\n")
+            write(tree, "docs/ORPHAN.md", "# Orphan\n")
+
+            status, stdout, _ = run_cli(
+                ["docs", "navigation", "--check", "--root", str(tree)], output_json=False
+            )
+
+        self.assertEqual(status, 1)
+        self.assertIn("unclassified_orphan docs/ORPHAN.md", stdout)
+        self.assertIn("NEEDS ATTENTION", stdout)
+
+    def test_human_output_is_the_default_and_names_the_boundary(self) -> None:
+        status, stdout, _ = run_cli(["docs", "navigation"], output_json=False)
+
+        self.assertEqual(status, 0)
+        self.assertIn("Documentation navigation: PASS", stdout)
+        self.assertIn("no equivalence with GitHub", stdout)
+
+    def test_without_check_a_failing_tree_still_exits_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            tree = Path(temp)
+            write(tree, "README.md", "# Only a root\n")
+            write(tree, "docs/README.md", "# Docs\n")
+            write(tree, "docs/ORPHAN.md", "# Orphan\n")
+
+            status, stdout, _ = run_cli(["docs", "navigation", "--root", str(tree)], output_json=False)
+
+        self.assertEqual(status, 0)
+        self.assertIn("unclassified_orphan", stdout)
+
+
+class EvidenceSeparationTests(unittest.TestCase):
+    def test_navigation_is_registered_in_the_documented_workflow_and_release_evidence(self) -> None:
+        from omh.maintenance.release import release_readiness_checklist
+
+        docs_index = (ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+        agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        claude = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+        ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        items = {item["id"]: item for item in release_readiness_checklist(version="1.0.0")["items"]}
+
+        self.assertIn("omh.cli docs navigation --check", docs_index)
+        self.assertIn("omh.cli docs navigation --check", agents)
+        self.assertIn("omh.cli docs navigation --check", claude)
+        self.assertIn("docs navigation --check", ci)
+        self.assertIn("documentation_navigation", items)
+        self.assertEqual(
+            items["documentation_navigation"]["command"],
+            "uv run python -m omh.cli docs navigation --check",
+        )
+        self.assertIn("reachable", items["documentation_navigation"]["evidence_required"])
+        self.assertIn("not", items["documentation_navigation"]["proof_boundary"])
+
+    def test_navigation_stays_a_separate_evidence_class_from_claims_and_drift(self) -> None:
+        from omh.maintenance.documentation_claims import DOCUMENTATION_CLAIM_AUDIT_SCHEMA
+
+        self.assertNotEqual(DOCUMENTATION_NAVIGATION_SCHEMA, DOCUMENTATION_CLAIM_AUDIT_SCHEMA)
+        payload = documentation_navigation_report(root=ROOT)
+        self.assertNotIn("claims", payload)
+        self.assertNotIn("generated_artifact_drift", payload)
+
+    def test_the_existing_documentation_gates_still_pass_unchanged(self) -> None:
+        for args in (
+            ["docs", "workflows", "--check"],
+            ["docs", "roles", "--check"],
+            ["docs", "capability-families", "--check"],
+        ):
+            with self.subTest(args=args):
+                status, _, stderr = run_cli(args, output_json=False)
+                self.assertEqual(status, 0, stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New input contract `plugin_catalog_snapshot/v1` (`src/workflows/plugin_catalog_snapshots.py`): a bounded, closed-key-set record an authorized host or operator exports about its own plugin catalog — producer identity, profile, observation time, catalog revision, and per-entry stable identity, reviewed content revision, tier, declared capabilities, required environment variable **names**, platform limits, host-version constraint plus the host's own enforcement result, and removal status.
- New reconciliation `plugin_catalog_coverage/v1` (`src/workflows/plugin_catalog_coverage.py`): a pure function of one snapshot and, optionally, the prior one. Every entry gets exactly one coverage class (`mapped`, `generic_review`, `incompatible`, `removed`, `unknown`) and exactly one change class (`added`, `changed`, `unchanged`, `removed`), plus its route, holds, advisories, and the evidence OMH does not have.
- New offline CLI adapter `omh ecosystem plugin-catalog coverage` (`src/commands/plugin_catalog.py`), with a concise plain-text chat status and a `--json` machine payload.
- The packaged awesome-hermes catalog and the seven-entry outcome matrix keep working unchanged and now carry `coverage_scope: snapshot_limited` plus a note in words, on every payload and every plain-text surface.
- New contract doc `docs/PLUGIN-CATALOG-COVERAGE.md`, indexed from `docs/README.md`.

### Why This Exists

OMH ecosystem guidance was pinned to a manually maintained catalog snapshot and a small hand-curated outcome matrix, and it did not accept the host's active plugin catalog at all. A newly admitted entry, a reviewed revision change under an existing identity, a withdrawal, or a host-version constraint the host refused stayed invisible until a maintainer added a static alias by hand. A user could ask about a plugin visible in their host catalog and get stale or generic guidance without ever being told which catalog revision OMH actually covered — and the packaged numbers, quoted as-is, read like host coverage.

### User / Operator Impact

A maintainer or host operator can now export their catalog once and ask OMH:

- Which OMH workflow owns each plugin outcome, bound to one producer, one observation time, and one catalog revision.
- What changed since the prior snapshot, with a reviewed content revision change reported as `changed` (both revisions preserved) rather than as a new plugin, and an identical replay producing no new row.
- Which entries are held because the catalog withdrew them or because the host refused their version constraint.
- Which entries OMH has no owner for, routed to a bounded generic review rather than dropped.
- What evidence remains unavailable on every row, always.

Everything the host owns stays with the host. Nothing here installs, enables, updates, or executes a plugin.

### How It Works

Four separations carry the design, and none collapses into another:

**Coverage class is not change class.** They answer different questions and are computed independently. A first sighting of an unmappable entry is `added` *and* `generic_review`, not one merged verdict.

**A rediscovered entry is not a new one.** Change classification keys on `plugin_id`. `changed` requires one of eight tracked metadata fields to have moved and names which in `changed_fields`; `previous_content_revision` and `content_revision` both survive. Replaying an identical snapshot yields `unchanged` for every row.

**Catalog presence is not readiness.** There is deliberately no ready state to reach. `adoption_guidance` is `route_to_owner`, `generic_review`, `host_owned`, or `held`, and the owner workflow's own readiness contract is where an adoption answer comes from. Withdrawal and incompatibility are decided *before* capability mapping, so a withdrawn or refused entry is held and routed to plugin-risk review rather than routed as adoption guidance for something the host will not run. `host_observed_behavior`, `host_permission_grant`, and `plugin_execution` are listed as unavailable evidence on every row; a removal adds `installed_copy_state`, because OMH cannot see installed copies — the removal hold reports a catalog withdrawal and says nothing about an installed copy being disabled or uninstalled.

**Absence does not inherit presence.** With no snapshot the answer is `snapshot_state: unavailable`, no entries, exit 1, and a `packaged_reference` block stamped `used_as_host_coverage: false` so a reader can see OMH declined to substitute the packaged catalog rather than wondering whether it silently did. A stale snapshot holds every row it carries on `stale_snapshot`.

Routing for mapped entries goes to the existing owners: `provider` → `provider-profile-posture`, `connector` → `external-connector-readiness`, `observability` → `ops-observability-card`, `memory` → `memory-sync`, `media` → `media-input-operator`. `host_core` is reported with `owner_boundary: hermes_host` and no OMH lane — loader, transport, permission, and installation mechanics stay outside OMH. Anything else, or nothing declared, reaches `skill-scout` as the bounded generic-review route. Held entries route to `security-safety-review`. A multi-capability entry takes a fixed precedence order for its primary route and lists the rest, so the primary owner is stable across runs.

Fail-closed handling: malformed, oversized (both the file byte cap and the entry-count cap, checked before parsing and before reconciling), duplicate-identity, and cross-profile snapshots are refused outright — a partial coverage report reads exactly like a complete one. Diagnostics are positional: each names an entry index and a field name and never the value that failed, so an untrusted snapshot cannot route its own content through OMH's error output; the list is capped and closed with a count.

Untrusted-input handling: every string is screened as a bounded opaque reference. `required_env_names` is the one field whose honest content reads like a secret (`GITHUB_TOKEN`, `ALPHA_API_KEY`), so it is screened with the narrow issued-credential detector (`is_secret_value_shaped`) instead of the wider sensitive-word one — the name is accepted, an issued key is refused. The key sets are closed, so there is no field a file body, a repository excerpt, or a credential value can arrive in. `host_version_constraint` is carried as opaque text nothing branches on; version enforcement is the host's job and `host_version_status` is where the host reports the result of doing it.

### Files And Contracts Touched

- `src/workflows/plugin_catalog_snapshots.py` (new) — `plugin_catalog_snapshot/v1` validation, bounds, freshness, identity.
- `src/workflows/plugin_catalog_coverage.py` (new) — `plugin_catalog_coverage/v1` reconciliation, routing, holds, chat status renderer.
- `src/commands/plugin_catalog.py` (new) — the offline CLI adapter.
- `src/commands/ecosystem.py` — registers `plugin-catalog`, prints the packaged-scope label on all four plain-text surfaces, adds the scope keys to the `inspect` payload.
- `src/catalogs/awesome_hermes_agent.py` — `PACKAGED_COVERAGE_SCOPE` / `PACKAGED_COVERAGE_SCOPE_NOTE`, attached to the summary and coverage payloads.
- `src/catalogs/awesome_hermes_agent_outcomes.py` — the same label on the outcome-matrix projection. The stored envelope and its closed key set are unchanged.
- `tests/test_plugin_catalog_coverage.py` (new) — 49 cases.
- `tests/test_awesome_hermes_agent_plugin_outcomes.py` — the loader-rejection case now builds its invalid fixture from the stored resource rather than from the projection, since `_parse_plugin_outcomes` validates what is on disk; plus a case pinning the new label.
- `docs/PLUGIN-CATALOG-COVERAGE.md` (new), `docs/README.md`.

No routing corpus, skill catalog, demo card, or generated artifact changed, so no exact-count fixture moved. No global plugin count is pinned anywhere in the new tests — each routing case builds the entries it is about.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [x] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [x] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [x] Relevant dry-run or smoke command: `omh ecosystem plugin-catalog coverage` in all three states (current, stale, unavailable) and `omh ecosystem awesome-hermes summary|outcomes`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **Ran 10629 tests in 707s, OK (skipped=1)**, exit 0. The one skip is an environment-conditional skip elsewhere in the suite; the new test file contains no skips.
- Targeted: `PYTHONPATH=tests uv run python -m unittest tests/test_plugin_catalog_coverage.py -v` — 49 tests, OK. Cases are grouped by success criterion: snapshot identity and determinism, change classification (one admitted entry → exactly one `added`; identical replay → no new row; revision change → `changed` with both revisions), removal and compatibility holds, outcome routing for every capability shape the issue names, fail-closed inputs, freshness and absence, packaged inputs staying readable, and the read-only adapter.
- `PYTHONPATH=tests uv run python -m unittest tests/test_awesome_hermes_agent_catalog.py tests/test_awesome_hermes_agent_plugin_outcomes.py tests/test_credential_fixture_policy.py` — 41 tests, OK.
- Byte gates: `docs workflows --check` (ok, 206/206 tap skills), `docs roles --check`, `docs claims --check --json` (ok), `docs capability-families --check`, `docs ulw-inventory --check`, `docs ulw-site --check` — all ok.
- `harness validate` → `{"counts":{"harnesses":77,"skills":128},"errors":[],"ok":true}`.
- `drift_report()["ok"]` → `True`, no failing entries.
- Read-only behavior is asserted, not asserted-by-comment: one test scans the three new modules' import lines for `http`, `httpx`, `importlib`, `requests`, `socket`, `ssl`, `subprocess`, `urllib`; another runs the CLI against a snapshot in a temporary directory and asserts the file's bytes are unchanged and no new file appeared.
- Credential handling: the AWS-key-shaped fixture comes from `tests/_credential_fixtures.py`, so no secret-shaped literal is written to disk and `tests/test_credential_fixture_policy.py` stays green.

### Rebase Onto `1e2ffc85`

Rebased after #1450 and #1442 merged. One conflict, in `docs/WORKFLOW-ARTIFACTS.md`: `main` had added `audience`, `promote`, and `graduate` to the `lifecycle-growth` operations row while this branch turned the first column into links. Neither side was right alone; the resolution keeps `main`'s operation lists and re-applies the four links onto them. `.github/workflows/ci.yml` merged cleanly with both #1448's `fail-fast: false` on the Windows matrix and this branch's gate step intact.

The interesting part is what did *not* need resolving. The two merged PRs brought four new `docs/` pages — `AGENT-BOARD.md`, `FANOUT-CODEX-BUILD-PROVENANCE.md`, `FANOUT-EXECUTOR-EVIDENCE.md`, `PLUGIN-CATALOG-COVERAGE.md` — and the gate passes on all four without a single new classification entry, because their authors linked them: three from `README.md` or `docs/README.md` directly, and `FANOUT-CODEX-BUILD-PROVENANCE.md` from `FANOUT-EXECUTOR-EVIDENCE.md`, its parent. That is the check meeting pages it had never seen and confirming they were already fine, which is the outcome it should produce. No page from another PR was classified exempt to reach green.

### Not Tested / Not Applicable

- The install-path command smoke was not run: this change adds no installable artifact, no managed skill, no plugin-bundle tool, and no setup/update path — it adds one read-only subcommand under an existing group, which `omh --help` and the direct CLI runs already cover.
- No manual Hermes/TUI check: the change adds no widget, HUD, awareness, or plugin-tool surface, so there is nothing for a TUI session to render differently.
- The workflow-learning review queue smoke does not apply; no learning contract changed.
- No real host exported a catalog. Every snapshot in the tests and in the manual runs is a constructed fixture. No plugin was installed, enabled, updated, imported, or executed, and no host configuration was read or written.

## Risk

- The declared-capability vocabulary is open on purpose, so a host that names its capabilities differently than the five OMH owns will see those entries in `generic_review` rather than mapped. That is the designed failure mode — visible and routed, not silent — but it means real-world mapping coverage depends on the vocabulary a host actually emits, which no fixture here can predict.
- The freshness horizon is 24 hours. A host that exports less often than daily will see every row held on `stale_snapshot`. That is deliberate (a day-old catalog is not the current one), but it is a tuning decision made without field data.
- `host_version_status` shifts the compatibility judgement onto the host. If a host reports `unknown` for everything, no entry is ever classified `incompatible` — the row instead names `host_version_evaluation` as unavailable evidence. Correct, but it means the `incompatible` class is only as useful as the host's own enforcement reporting.

## Compatibility / Rollout

- Purely additive. The packaged catalog file, the outcome-matrix JSON, and every existing `omh ecosystem awesome-hermes` command behave the same; their payloads gain two keys and their plain-text output gains one line.
- The stored outcome-matrix envelope and its closed key set are unchanged, so no regeneration or byte gate is affected.
- No new dependency, no new network call, no new background task, no new automatic issue creation.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- If a host's real capability vocabulary turns out to differ from the five mapped tokens, the fix is to extend `CAPABILITY_OWNERS` — the `generic_review` bucket in a real report is the signal for which tokens to add, and it is designed to be read that way.
- No `omh_*` plugin tool or chat router trigger was added. The issue's success criteria ask for a deterministic offline CLI or workflow adapter and for routing tests over capability shapes; neither asks for a new chat trigger, and adding one would move exact-count fixtures across five files for no contract requirement. The concise chat status is available to a wrapper through `render_plugin_catalog_coverage` and the CLI's plain-text output.

Closes #1449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8
