### PR TITLE
test(five-issues): discover the native Hermes host instead of hardcoding it

### DIFF
--- a/tests/five_issue_cases/kanban_native.py
+++ b/tests/five_issue_cases/kanban_native.py
@@ -3,6 +3,14 @@
 The normal host hook timeout configuration is deliberately preserved. A broken
 prepare/observation bridge blocks the scenario; calling callbacks directly or
 turning off host guards to obtain a receipt would invalidate this evidence.
+
+The host is discovered, never hardcoded: `HERMES_HOME` (default `~/.hermes`)
+names the Hermes home whose `hermes-agent` checkout is the host, `hermes` is
+resolved on `PATH`, and `OMH_QA_HERMES_AGENT` / `OMH_QA_HERMES_PYTHON` /
+`OMH_QA_HERMES_CLI` override each part for a non-default layout. Discovery is
+presence-only. When any part is missing the cases stay blocked with
+`native_normal_loop_and_review_dispatch_not_observed`; an unavailable host is
+never a pass.
 """
 from __future__ import annotations
 
@@ -25,9 +33,27 @@ from typing import Protocol, runtime_checkable
 from . import CaseResult, JsonValue, unavailable_case
 
 _ROOT = Path(__file__).resolve().parents[2]
-_HOST = Path('/Users/khope@sionic.ai/.hermes/hermes-agent')
-_PYTHON = _HOST / 'venv/bin/python'
-_CLI = Path('/Users/khope@sionic.ai/.local/bin/hermes')
+def _host_root() -> Path:
+    """The Hermes Agent checkout under the resolved Hermes home."""
+    override = os.environ.get('OMH_QA_HERMES_AGENT')
+    home = os.environ.get('HERMES_HOME')
+    return Path(override) if override else Path(home or Path.home() / '.hermes') / 'hermes-agent'
+
+
+def _host_python(host: Path) -> Path:
+    """The host checkout's own interpreter, not this suite's."""
+    override = os.environ.get('OMH_QA_HERMES_PYTHON')
+    if override:
+        return Path(override)
+    return host / 'venv' / ('Scripts/python.exe' if os.name == 'nt' else 'bin/python')
+
+
+# A path that resolves to nothing keeps the blocked branch below: an
+# undiscoverable host is reported as unavailable, never as a pass.
+_HOST = _host_root()
+_PYTHON = _host_python(_HOST)
+_CLI = Path(os.environ.get('OMH_QA_HERMES_CLI') or shutil.which('hermes')
+            or _HOST.parent / 'bin/hermes')
 _PROOF = _ROOT / '.omc/artifacts/five-issues/phases/C/parent-kanban-native'
 _CASES = frozenset({'K1', 'K4', 'K6', 'K8'})
 _CONFIG = '''plugins:


### PR DESCRIPTION
## Feature Report

### What Changed

`tests/five_issue_cases/kanban_native.py` no longer hardcodes one developer's
machine. The isolated native Hermes QA host — the `hermes-agent` checkout, its
interpreter and the `hermes` CLI — is now discovered instead of pinned:

- `HERMES_HOME` (default `~/.hermes`) carries the `hermes-agent` checkout
- `hermes` is resolved on `PATH`
- `OMH_QA_HERMES_AGENT`, `OMH_QA_HERMES_PYTHON` and `OMH_QA_HERMES_CLI`
  override each part individually for a non-default layout

Discovery stays presence-only: it checks that the files exist and are
executable, and reads no profile and initializes no database.

### Why This Exists

The three paths were absolute literals under `/Users/<user>`:

```python
_HOST = Path('/Users/<user>/.hermes/hermes-agent')
_PYTHON = _HOST / 'venv/bin/python'
_CLI = Path('/Users/<user>/.local/bin/hermes')
```

Three consequences, in order of how much they matter:

1. **A developer-identifying path ships in the repository.** It is the only
   `/Users/` literal anywhere under `src/`, `tests/`, `docs/` or `skills/`.
2. **The native lane can never run anywhere else.** K1, K4, K6 and K8 are
   permanently blocked in CI and on every machine but one.
3. **Native evidence from those cases is unreproducible.** A reviewer cannot
   re-run the case that produced it.

### User / Operator Impact

Anyone with a Hermes Agent install can now run the native Kanban QA cases
against their own host, either by having it in the default location or by
naming a non-default layout through the three overrides. Previously only one
machine could.

### How It Works

`_host_root()` reads `OMH_QA_HERMES_AGENT`, else `HERMES_HOME`, else
`~/.hermes`, and appends `hermes-agent`. `_host_python()` reads
`OMH_QA_HERMES_PYTHON`, else the checkout's own `venv` interpreter, picking the
`Scripts`/`bin` layout by platform. The CLI reads `OMH_QA_HERMES_CLI`, else
`shutil.which('hermes')`, else a path that resolves to nothing — which keeps
the blocked branch below rather than inventing a host.

**The blocked path is unchanged and stays honest.** With any part missing,
`native_host_available()` is `False` and K1/K4/K6/K8 return `pass: False` with
`blocked_reason: native_normal_loop_and_review_dispatch_not_observed`, pinned
by `tests/test_agent_board_kanban.py`. An unavailable host is never a pass, and
that property is what makes this change safe: the worst case for a machine
without the host is the same honest block it had before.

### Files And Contracts Touched

- `tests/five_issue_cases/kanban_native.py` — host discovery and the module
  docstring that documents the three environment variables

No product code, no schema, no generated artifact.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

Observed on this branch:

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests`
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_agent_board_kanban.py` — 40 tests
- [x] `uv run --group lint ruff check src tests tools packaging`
- [x] `uv run python -m compileall -q src tests`
- [x] `docs workflows --check`, `docs roles --check`,
      `docs capability-families --check`, `docs ulw-inventory --check`,
      `docs ulw-site --check`, `docs claims --check --json`
- [x] `uv run python -m omh.cli release drift --json` — `drift_count: 0`
- [x] `git diff --check origin/main...HEAD`

### Observed Evidence

Both directions were exercised on this branch, because a discovery change is
only safe if the not-found path still behaves:

- **Host present.** On a machine with the host installed, discovery resolves it
  and `K1` still passes natively with `provenance.kind == 'native'`.
- **Host absent.** With `OMH_QA_HERMES_AGENT` and `OMH_QA_HERMES_CLI` pointed at
  a missing path, `native_host_available()` is `False` and all four cases return
  `pass: False` with `blocked_reason:
  native_normal_loop_and_review_dispatch_not_observed`.
- No `/Users/` literal remains under `src/`, `tests/`, `docs/` or `skills/`.

### Not Tested

- A Windows or Linux host layout. No machine available here can supply one; the
  platform branch for the interpreter path is written but only the POSIX side is
  observed.
- The overrides are exercised only by pointing them at a missing path, not by
  pointing them at a second real host.

## Risk

Low and bounded. Test-only, no product code. The failure mode of bad discovery
is the pre-existing honest block, not a false pass — pinned by a test this
change does not touch.

## Compatibility / Rollout

A machine with the host in the default location behaves exactly as before with
no configuration. No new dependency; `shutil` and `os` were already imported.

## Release / Claims

- [x] Release-channel impact considered
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8
