### PR TITLE
test(browser): force the mid-resume replay instead of racing it

### DIFF
--- a/tests/test_browser_effect_attempts.py
+++ b/tests/test_browser_effect_attempts.py
@@ -20,6 +20,32 @@ from omh.workflows.browser_effect_attempts_contract import approval_scope, class
 from omh.workflows.external_effect_receipts import receipt_satisfies_success_claim
 
 
+def _outcome(call):
+    try:
+        return ('returned', call())
+    except BaseException as exc:  # Re-raised by the joining thread; see run_on_second_thread.
+        return ('raised', exc)
+
+
+def run_on_second_thread(call):
+    """Run `call` on another thread and hand its outcome back, joining without a deadline.
+
+    A deadline here would be a wall clock masquerading as a contract: the thread's
+    only work is one `execute`, whose sole blocking primitive is SQLite's own busy
+    budget, so it always terminates and `join()` cannot expire. A loaded shared
+    runner therefore delays this helper instead of failing it, and an exception is
+    re-raised in the caller rather than dying unread inside the thread.
+    """
+    outcome = []
+    thread = Thread(target=lambda: outcome.append(_outcome(call)))
+    thread.start()
+    thread.join()
+    disposition, payload = outcome[0]
+    if disposition == 'raised':
+        raise payload
+    return payload
+
+
 class EffectAdapter:
     """Stateful held-byte surface; real SQLite is checked at the send boundary."""
     adapter_id = Adapter.adapter_id
@@ -38,6 +64,7 @@ class EffectAdapter:
         self.confirmation = None
         self.resume_entered = Event()
         self.resume_proceed: Event | None = None
+        self.during_resume = None
 
     def preview(self, lease_id, handle, operation):
         self.calls['preview'] += 1
@@ -59,6 +86,11 @@ class EffectAdapter:
         self.resume_entered.set()
         if self.resume_proceed is not None and not self.resume_proceed.wait(5):
             raise TimeoutError('barrier')
+        # Mid-resume seam: the durable attempt and its unknown binding are committed,
+        # and this send has not yet been permitted. A caller hooking here reaches that
+        # window by construction rather than by winning a race against a barrier.
+        if self.during_resume is not None:
+            self.during_resume()
         self.send_count += 1
         if self.mode in {'timeout', 'disconnect', 'crash'}:
             raise {'timeout': TimeoutError, 'disconnect': ConnectionError, 'crash': RuntimeError}[self.mode]('PRIVATE ERROR')
@@ -408,21 +440,37 @@ class BrowserEffectAttemptsTests(unittest.TestCase):
             self.assertNotIn(raw, content)
 
     def test_concurrent_replay_returns_unknown_then_stable_result(self):
+        """A replay landing mid-resume is forced by the call graph, never raced on a clock.
+
+        The engine's guard is durable state, not thread identity: `execute` commits the
+        unknown binding row before `_resume` permits the adapter to send. So the second
+        `execute` is issued from inside `resume`, on its own thread, while the first is
+        suspended on that stack -- the same interleaving the old two-event barrier tried
+        to reach by timed rendezvous, now reached by construction. Nothing waits on a
+        deadline, so a loaded runner cannot report this contract as broken, and no worker
+        can outlive the test method holding the temporary directory's SQLite handle open.
+        """
         preview = self.prepare()
         self.approve(preview)
-        self.adapter.resume_proceed = Event()
-        results = []
-        thread = Thread(target=lambda: results.append(self.engine.execute('owner', preview['intent_digest'], 'event')))
-        thread.start()
-        try:
-            self.assertTrue(self.adapter.resume_entered.wait(5))
-            replay = self.engine.execute('owner', preview['intent_digest'], 'event')
-            self.assertEqual(replay['status'], 'unknown')
-        finally:
-            self.adapter.resume_proceed.set()
-            thread.join(5)
-        self.assertFalse(thread.is_alive())
-        self.assertEqual(self.engine.execute('owner', preview['intent_digest'], 'event'), results[0])
+        replays = []
+
+        def replay_mid_resume():
+            self.adapter.during_resume = None  # One-shot: a second resume stays countable.
+            before = dict(self.adapter.calls)
+            replays.append(dict(sends_before=self.adapter.send_count, host_calls_before=before,
+                                result=run_on_second_thread(lambda: self.engine.execute(
+                                    'owner', preview['intent_digest'], 'event')),
+                                host_calls_after=dict(self.adapter.calls)))
+
+        self.adapter.during_resume = replay_mid_resume
+        result = self.engine.execute('owner', preview['intent_digest'], 'event')
+        self.assertEqual(len(replays), 1)
+        self.assertEqual(replays[0]['sends_before'], 0)
+        self.assertEqual(replays[0]['result']['status'], 'unknown')
+        self.assertEqual(replays[0]['result']['attempt_id'], result['attempt_id'])
+        # A replay never reobserves, reapproves or resends: it reads the durable row only.
+        self.assertEqual(replays[0]['host_calls_after'], replays[0]['host_calls_before'])
+        self.assertEqual(self.engine.execute('owner', preview['intent_digest'], 'event'), result)
         self.assertEqual(self.adapter.send_count, 1)
 
     def test_abort_cannot_be_executed(self):


### PR DESCRIPTION
## Feature Report

### What Changed

- `test_concurrent_replay_returns_unknown_then_stable_result` no longer reaches
  its interleaving by timed rendezvous. The two-event barrier and the two
  five-second deadlines (`resume_entered.wait(5)`, `thread.join(5)`) are gone;
  the second `execute` is now issued from inside the adapter's `resume`, on a
  thread joined without a deadline.
- The guard it proves is unchanged and one assertion sharper: the mid-resume
  replay must return `unknown` carrying the first attempt's id, must arrive
  before any send, must not touch the host adapter at all, and the completed
  result must still replay identically with exactly one send.
- `EffectAdapter` gains one seam, `during_resume`, invoked after the durable
  attempt and its `unknown` binding are committed and before the single send.

### Why This Exists

`test-windows (0)` reported this test three times today (main at `1efb9089`,
and PR #1448's first run), each time as an `ERROR` **and** a `FAIL` for the same
test method, `AssertionError: False is not true`, clean on rerun and never on
ubuntu or macOS.

Both halves trace to the same wall clock:

- `AssertionError: False is not true` can only come from `assertTrue` —
  `assertFalse(thread.is_alive())` prints `True is not false` (verified). So the
  failing assertion is `self.assertTrue(self.adapter.resume_entered.wait(5))`:
  the worker had not reached `resume` within five seconds.
- The paired `ERROR` is the consequence. When that wait expires, `finally` joins
  for five more seconds and the test method returns; a worker slow enough to
  miss both budgets is still running when `addCleanup(self.temp.cleanup)` fires.
  Measured on this branch, the worker holds an open SQLite handle under that
  `TemporaryDirectory` for 65.2% of its life (6 connections, 2.24 ms of 3.44 ms).
  Windows refuses to unlink an open file, so `TemporaryDirectory.cleanup()`
  raises `PermissionError [WinError 32]` — and unittest records a cleanup
  exception as an `ERROR` beside the body's `FAIL` under one test id (verified),
  which is exactly the reported `failures=1, errors=1` shape. POSIX unlinks open
  files happily, which is why ubuntu and macOS never saw it.

This is the failure class the repo has already fixed twice — #1440 replaced
wall-clock promptness assertions with mechanism assertions, and #1442's
`223861f1` removed an external timing dependency rather than widening a budget —
so the budget was not widened here either.

### User / Operator Impact

- None at runtime. Test-only change; no `src/` file is touched.
- CI stops reporting a healthy concurrency contract as broken on Windows.

### How It Works

The engine's guard is durable state, not thread identity. `execute` commits the
`unknown` binding row inside its transaction and closes it *before* `_resume`
runs (`src/workflows/browser_effect_attempts.py:126-130`); a later `execute`
short-circuits on that row at line 100 and returns it without reobserving,
reapproving or resending. So the window the test needs is a point in the call
graph, not a moment on a clock, and it can be entered directly: the adapter's
`resume` calls `during_resume`, which runs one `execute` on a second thread and
joins it.

That join cannot expire. The thread's only work is that one `execute`, whose
sole blocking primitive is SQLite's busy budget — and at the hook there is no
writer to wait on, so even that is unreachable. Instrumented, at the hook:
`open handles at hook: []`. At cleanup: `threads at cleanup: []`,
`handles at cleanup: []` — so the Windows precondition for the paired `ERROR` is
gone as well.

**Windows, stated plainly:** not observed — no Windows runner is available here.
What is reasoned, traced to the end rather than stopped at the premise: the
`FAIL` had exactly one source, a five-second `Event.wait`, and no timed wait
remains in this test's path; the `ERROR` required a worker alive at cleanup
holding a handle open, and the probe above shows zero threads and zero handles
at that point on every run. Neither depends on platform timing, so neither
should be reachable on Windows. Windows CI on this PR is the check.

### Files And Contracts Touched

- `tests/test_browser_effect_attempts.py` — only file changed.
  - new `run_on_second_thread(call)` / `_outcome(call)`: run a call on another
    thread, join without a deadline, re-raise its exception in the caller.
  - `EffectAdapter.during_resume`: optional callable at the mid-resume seam,
    defaults to `None`, so every other test and the `PluginAdapter` subclass in
    `tests/test_browser_effects_plugin.py` are unaffected.
  - `EffectAdapter.resume_entered` / `resume_proceed` are left in place: the
    sibling `test_browser_effects_plugin.py` still uses them.
- No `src/` change. No new dependency. No routing case, skill or demo card, so
  no exact-count total moved.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke ... release hermes-smoke ...`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite: `Ran 10885 tests in 832.229s` — `OK (skipped=2)`.
- Byte gates beyond the template list, all `"ok":true`:
  `docs claims --check --json`, `docs ulw-inventory --check`,
  `docs ulw-site --check`. `docs workflows --check` also reports
  `tap_skills: checked 206, expected 206, missing [], stale [], extra []`.
- **Repetition:** `tests.test_browser_effect_attempts` 50 consecutive runs —
  `pass=50 fail=0`, 34 tests each.
- **Under contention:** 50 more runs with 56 `nice -n 19` busy processes on a
  14-CPU host; load average rose 14.60 → 31.50 during the run — `pass=50 fail=0`.
- **The guard still bites.** Two deliberate breaks in
  `src/workflows/browser_effect_attempts.py`, each run then reverted (`git diff
  --stat src/` empty afterwards, and the module green again):
  - replay allowed to proceed past the stored result (`if result: return result`
    disabled) → red at the host-calls assertion, naming the cause:
    `AssertionError: {'capabilities': 1, 'start': 1, 'observe': 4, 'preview': 3}
    != {'capabilities': 1, 'start': 1, 'observe': 3, 'preview': 2}`
  - adapter permitted to send twice (`self.adapter.resume(...)` duplicated in
    `_resume`) → red at `self.assertEqual(self.adapter.send_count, 1)`,
    `AssertionError: 2 != 1`
- **Diagnosis probes** (scratch scripts, not committed):
  - `assertTrue(False)` → `False is not true`; `assertFalse(True)` →
    `True is not false`, fixing the failing line as `resume_entered.wait(5)`.
  - a body `FAIL` plus a raising `addCleanup` → unittest reports one `ERROR` and
    one `FAIL` under the same test id, `testsRun: 1`.
  - pre-fix worker: 6 SQLite connections, 65.2% of its wall time with one open
    under the temp dir; with a stall past both budgets, `thread alive at
    cleanup: True`.
  - post-fix: `open handles at hook: []`, `threads at cleanup: []`,
    `handles at cleanup: []`.

### Not Tested / Not Applicable

- **Windows.** No Windows runner is available in this environment. The change is
  reasoned above to remove both failure modes by construction; Windows CI on this
  PR is the observation.
- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`,
  the packaged smoke and the manual Hermes/TUI check: this change is one test
  file and touches no installable surface, CLI, catalog, generated artifact or
  release contract, so none of them exercise it.
- Workflow-learning review queue smoke: no learning contract changed.

## Risk

- Low, and bounded to one test file. The three contract legs are unchanged and
  one is stronger (the replay must now leave the host adapter untouched).
- The mid-resume replay is no longer parallel with the first `execute`; it runs
  while the first is suspended inside `resume`. The barrier version was not
  parallel either — it suspended the worker at the same seam and ran the replay
  on the main thread — so the interleaving under test is identical, minus the
  race to arrange it.
- `join()` without a deadline could in principle hang. It cannot here: the joined
  thread does one `execute` that short-circuits on the committed row, and the
  probe shows no writer holds the database at that moment.

## Compatibility / Rollout

- Test-only; nothing to roll out. `during_resume` defaults to `None`, so
  `PluginAdapter` and every other test in both browser modules behave exactly as
  before (`tests.test_browser_effects_plugin`: 24 tests, OK).

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; test-only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- `tests/test_browser_effects_plugin.py`,
  `test_concurrent_registered_replays_share_one_attempt` (around line 325) is the
  same flake class and was deliberately left alone to keep this change scoped: it
  still uses `resume_entered.wait(5)`, `replay_entered.wait(5)`, `first.join(5)`,
  `second.join(5)` and `assertFalse(first.is_alive())`, over a
  `TemporaryDirectory` held by an `ExitStack` — so it can produce the identical
  Windows `ERROR` + `FAIL` pair. The `during_resume` seam added here is what that
  test would need; it has not been reported failing yet.
- `EffectAdapter.resume` keeps `resume_proceed.wait(5)` only because that sibling
  still drives it. It can be deleted with the follow-up above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8
