### PR TITLE
docs(claude): record the two traps that cost a day of diagnosis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,34 @@ Rules:
 - Grepping the repo and matching stale strings under `build/lib/` — it is a
   gitignored copy of old sources. Scope searches to `src/`, `tests/`, `docs/`,
   `skills/`.
+- Trusting a red run before clearing `build/`. A `ModuleNotFoundError` whose
+  traceback names a `build/__editable__…` path is the gitignored editable
+  install, not the tree you are editing: your venv's copy predates a module the
+  branch now has. It is not a real failure and it is not the other branch's
+  regression. Clear it before you diagnose anything:
+
+  ```sh
+  rm -rf build && uv sync --reinstall-package oh-my-hermes
+  ```
+
+  This is worth its own entry because of how it lies. Bisecting across the
+  commit that adds the module produces green-then-red — the exact shape of a
+  genuine regression — since before that commit the stale copy is adequate and
+  after it the import fails. It cost several agents hours in one afternoon and
+  produced one false attribution of a defect to another contributor's branch.
+  If a checkout ever aborts with "local changes would be overwritten", stop:
+  every run after that measured the same dirty tree. `git reset --hard &&
+  git clean -fdx` first, then re-measure.
+- Concluding a platform fact settles a call site. Windows and POSIX differ in
+  ways this repo keeps rediscovering — `Path.write_text` without `newline=`
+  emits CRLF; a child process's stdout arrives CRLF-terminated; CR is a control
+  character to a text guard; and Windows will not unlink a file another thread
+  still holds open, so a leaked worker turns a test failure into a failure plus
+  a cleanup error. Each of those is true, and none of them is a conclusion on
+  its own. One prediction here reasoned correctly that `os.open` without
+  `O_BINARY` returns a text-mode descriptor, and missed that the next line's
+  `os.fdopen(fd, 'rb')` re-sets the descriptor to binary before a byte is read.
+  Trace the composition to the end, or say the claim is untested.
 - Regenerating docs but forgetting the demo cards (or vice versa) when catalog
   data changes — the parse-equality test catches it late; regenerate all four
   artifact families together.


### PR DESCRIPTION
## Feature Report

### What Changed

- `CLAUDE.md` gains two entries under **Common Pitfalls**: the stale editable install under `build/`, and the rule that a platform fact is a premise rather than a verdict on a call site.

### Why This Exists

Both come from one afternoon of agent work on this repository, and both are about a failure that *lies* rather than one that is merely hard.

**The stale editable install** reports `ModuleNotFoundError` for a module that genuinely exists in the tree being edited, because the venv's copy predates it. The existing `build/lib` entry warns about grepping stale sources; this is a different failure with the same root, and it earns its own entry because of how it misleads: bisecting across the commit that introduces the module yields green-then-red, which is indistinguishable by shape from a real regression. Before that commit the stale copy is adequate; after it the import fails.

It cost several agents hours in a single afternoon and produced one false attribution of a defect to another contributor's open branch. That attribution was caught and retracted before it was published, but only because someone re-checked on a clean install rather than trusting a bisect that "argued" it was real.

The dirty-tree sentence rides along because the same session's first re-check silently measured an unchanged tree four times: a `git checkout` had aborted with "local changes would be overwritten", the abort was in the output, and the results below it looked like answers.

**The platform entry** lists the Windows and POSIX differences this repo keeps rediscovering — CRLF on `write_text`, CRLF from a child's stdout, CR as a control character to a text guard, and Windows refusing to unlink a file another thread holds open, which turns a test failure into a failure plus a cleanup error. Each is true. The useful half is that none of them is a conclusion.

The worked example is a prediction made in this repository that reasoned correctly that `os.open` without `O_BINARY` returns a text-mode descriptor on Windows, and never read the next line of the same function, where `os.fdopen(fd, 'rb')` re-sets the descriptor to binary before a byte is read. CI falsified it. That was the cheap outcome, and it was cheap only because the prediction named the exact assertions it expected to fail — one CI run instead of an argument.

### User / Operator Impact

None at runtime. This is guidance for whoever debugs here next, placed where they already look.

### How It Works

Two list entries in the existing **Common Pitfalls** section. Each states the symptom first, because the symptom is what a reader arrives with, then the mechanism, then the command or the rule.

### Files And Contracts Touched

- `CLAUDE.md` — Common Pitfalls, +28 lines. No code, no contract, no generated artifact.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run python -m omh.cli docs navigation --check` — ok
- [x] `PYTHONPATH=tests uv run python -m unittest tests/test_router_content.py tests/test_documentation_navigation.py` — `Ran 156 tests`, `OK (skipped=1)`
- [x] `uv run --group lint ruff check src tests` — `All checks passed!`
- [x] `git diff --check`
- [ ] Full suite — not run. The change is a documentation-only edit to a file outside `docs/`, and the two modules that read repository prose are run above.
- [ ] Other docs byte gates, `harness validate`, `release checklist`, `release hermes-smoke`, installed-CLI smoke — not run; no catalog, skill, generated artifact, installer or release surface is touched.
- [ ] Manual Hermes/TUI check — not applicable, no TUI surface.

### Observed Evidence

- The navigation gate merged in #1451 passes: `CLAUDE.md` is not a `docs/` page, so it is outside that gate's scope, and no `docs/` page moved.
- The two prose-reading test modules pass together at 156 tests.

### Not Tested / Not Applicable

- Nothing executable changed, so there is no behaviour to observe. The claims in the added text are drawn from failures observed earlier today in this repository, not reproduced again for this PR.

## Risk

None to the product. The risk this addresses is diagnostic: a reader who does not know the `build/` trap will spend the same hours, and one already spent them concluding another contributor's branch was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)