### PR TITLE
docs(readme): point model routing to /omh-model-setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -127,6 +127,11 @@ omh update
 omh doctor
 ```
 
+```sh
+# モデルのオンボーディングやモデルルーティングの設定には、Hermes でこのスキルを使ってください:
+/omh-model-setup
+```
+
 <details>
 <summary><b>その他のインストール方法</b> — Homebrew、Bun、npm、Hermes skill tap、手動フォールバック</summary>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -127,6 +127,11 @@ omh update
 omh doctor
 ```
 
+```sh
+# 모델을 온보딩하거나 모델 라우팅을 설정하려면 Hermes에서 이 스킬을 사용하세요:
+/omh-model-setup
+```
+
 <details>
 <summary><b>다른 설치 경로</b> — Homebrew, Bun, npm, Hermes skill tap, 수동 대체 경로</summary>
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ registration.
 omh doctor
 ```
 
+```sh
+# To onboard models or configure model routing, use this skill in Hermes:
+/omh-model-setup
+```
+
 <details>
 <summary><b>Other installation paths</b> — Homebrew, Bun, npm, Hermes skill tap, manual fallback</summary>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -124,6 +124,11 @@ omh update
 omh doctor
 ```
 
+```sh
+# 如需接入模型或配置模型路由，请在 Hermes 中使用此技能：
+/omh-model-setup
+```
+
 <details>
 <summary><b>其他安装方式</b> — Homebrew、Bun、npm、Hermes skill tap、手动回退</summary>
 

--- a/tests/test_readme_highlights.py
+++ b/tests/test_readme_highlights.py
@@ -109,6 +109,23 @@ class ReadmeHighlightsTests(unittest.TestCase):
                 self.assertEqual(lines[details_index - 1], "")
                 self.assertEqual(lines[fence_index - 1], "")
 
+    def test_quick_start_points_model_routing_users_to_the_model_setup_skill(self) -> None:
+        comments = {
+            "README.md": "# To onboard models or configure model routing, use this skill in Hermes:",
+            "README.ko.md": "# 모델을 온보딩하거나 모델 라우팅을 설정하려면 Hermes에서 이 스킬을 사용하세요:",
+            "README.ja.md": "# モデルのオンボーディングやモデルルーティングの設定には、Hermes でこのスキルを使ってください:",
+            "README.zh.md": "# 如需接入模型或配置模型路由，请在 Hermes 中使用此技能：",
+        }
+        for rel, comment in comments.items():
+            text = Path(rel).read_text(encoding="utf-8")
+            expected = (
+                "```sh\nomh doctor\n```\n\n"
+                f"```sh\n{comment}\n/omh-model-setup\n```"
+            )
+            with self.subTest(readme=rel):
+                self.assertIn(expected, text)
+                self.assertNotIn("](", expected)
+
     def test_the_workflow_engines_are_advertised_with_their_ulw_label(self) -> None:
         # The ulw engines moved out of the Highlights table into a dedicated
         # Ultra-Skills section (one per README language). Every engine must be

--- a/tests/test_router_content.py
+++ b/tests/test_router_content.py
@@ -3730,9 +3730,10 @@ class RouterContentTests(unittest.TestCase):
             # owner-directed) landed in every language, and from 450 when the
             # Quick Start took the English shape (script installers, setup,
             # doctor, then an "other installation paths" toggle, ~45 lines,
-            # owner-directed) in every language; it still sits below
-            # README.md's length.
-            self.assertLess(len(localized_readme.splitlines()), 490)
+            # owner-directed) in every language, and from 494 when a separate
+            # model-setup routing block was added to each localized Quick
+            # Start; it still sits below README.md's length.
+            self.assertLess(len(localized_readme.splitlines()), 495)
             # The trust surface is the evidence table, not the wire token that
             # used to stand in for it. Pinning the token meant a README could
             # satisfy this by naming a value no reader could decode; pinning
@@ -3821,7 +3822,7 @@ class RouterContentTests(unittest.TestCase):
         self.assertIn("curl -fsSL https://raw.githubusercontent.com/rlaope/oh-my-hermes/main/install.sh | sh", quick_start)
         self.assertIn("omh setup", quick_start)
         # `omh doctor` belongs in its own block, never bundled into the install
-        # step: a first-time reader must not read a health check as part of setup.
+        # step: model setup guidance follows in a separate shell block.
         self.assertIn("```sh\nomh setup\n```", quick_start)
         self.assertIn("```sh\nomh update\n```", quick_start)
         self.assertIn("```sh\nomh doctor\n```", quick_start)


### PR DESCRIPTION
## Feature Report

### What Changed

- Kept the existing `omh doctor` block unchanged and added a new shell block directly below it in the English, Korean, Japanese, and Chinese READMEs.
- The new block uses a localized `#` comment followed by `/omh-model-setup` for model onboarding and model-routing configuration.
- Added regression coverage for the separate-block placement, exact localized text, and no-link contract in all four READMEs.

### Why This Exists

The Quick Start diagnostics step did not expose the Hermes workflow that owns model onboarding and model-routing configuration.

### User / Operator Impact

Users can discover and copy `/omh-model-setup` from its own block directly below `omh doctor`.

### How It Works

Documentation only. `omh doctor` stays in its own block; each localized README adds a second block containing a localized shell comment and `/omh-model-setup`. No documentation link is added.

### Files And Contracts Touched

- `README.md`, `README.ko.md`, `README.ja.md`, `README.zh.md`
- `tests/test_readme_highlights.py`

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] Relevant dry-run or smoke command
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `git diff --check`

### Observed Evidence

- 171 targeted README, router-content, model-recommendation, explicit-invocation, and distribution tests passed.
- The focused localization/placement regression failed for all four READMEs before the correction, then passed afterward.
- The first current-head CI run exposed stale exact-block assertions in `test_router_content`; those assertions and the localized README line budget were updated, and all 111 router-content tests now pass locally.
- Ruff and compileall passed for the changed test.
- Workflow docs and all 206 tap skills were current.
- `/omh-model-setup` selected `model-setup` and returned `setup_guide` through the real chat interaction adapter.

### Not Tested / Not Applicable

- Full repository suite and live Hermes UI were not run; this is a localized README-only behavior change with focused coverage and a route smoke.

## Risk

The installed skill label or localized wording could drift. The regression pins the current label, placement, languages, and no-link requirement.

## Compatibility / Rollout

Additive documentation-only change; no runtime or schema behavior changes.

## Release / Claims

- [x] Release-channel impact considered
- [x] Runtime/native capability claims are backed by evidence
- [x] Evidence contains no credentials or private data

## Follow-Up

- Keep all four Quick Start blocks aligned if the model-setup skill label changes.
