### PR TITLE
test(installer): bind the update contract's junction seam instead of the host's

### DIFF
--- a/tests/test_atomic_installer_update.py
+++ b/tests/test_atomic_installer_update.py
@@ -10,21 +10,63 @@ from argparse import Namespace
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
+from typing import Literal
 from unittest.mock import patch
 
 from omh.commands.setup import _run_command_package_self_update
+from omh.install.self_update_platform import SelfUpdatePlatform
+
+
+def _linking_platform(*, is_windows: bool) -> SelfUpdatePlatform:
+    """Keep the host pointer strategy, but model the junction call with a link.
+
+    `SelfUpdatePlatform` carries its own runner, bound to the real
+    `subprocess.run` when the dataclass field default is evaluated, so the
+    runner this contract injects into `_run_command_package_self_update` never
+    reaches it. On POSIX that is invisible -- `create_directory_link` calls
+    `os.symlink` and starts nothing -- but on Windows it made this test spawn
+    four real `powershell.exe` junction processes it never asked for: two for
+    the legacy migration's links, one for the migration pointer, one for the
+    activation switch. Each carries a 15s timeout, and a spawn that times out
+    or is refused surfaces only as the transaction's exit code, which is how a
+    Windows runner read `AssertionError: 1 != 0` here while both POSIX lanes
+    stayed green. `StagedSelfUpdateTests._platform` binds the same seam for
+    the same reason; the junction command itself is covered by the dedicated
+    Windows adapter tests, which inject their runner too.
+    """
+
+    def junction_runner(
+        command: list[str],
+        *,
+        shell: bool,
+        cwd: str,
+        env: dict[str, str],
+        text: Literal[True],
+        stdout: int,
+        stderr: int,
+        timeout: float,
+    ) -> subprocess.CompletedProcess[str]:
+        _ = shell, text, stdout, stderr, timeout
+        link = Path(env["OMH_JUNCTION_LINK"])
+        link.symlink_to(Path(cwd) / env["OMH_JUNCTION_TARGET"], target_is_directory=True)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    return SelfUpdatePlatform(is_windows=is_windows, runner=junction_runner)
 
 
 class AtomicInstallerUpdateContractTests(unittest.TestCase):
-    def test_installer_update_stages_outside_the_active_interpreter_and_reports_phases(self) -> None:
+    def _run_update(self, platform: SelfUpdatePlatform) -> tuple[int, list[list[str]], dict[str, object]]:
         captured: list[list[str]] = []
 
         def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
             captured.append(command)
             if command[1:3] == ["-m", "venv"]:
                 candidate = Path(command[-1]).parent
-                (candidate / "venv" / "bin").mkdir(parents=True, exist_ok=True)
-                (candidate / "venv" / "bin" / "python").touch()
+                # The candidate venv the installer probes is `Scripts/` on
+                # Windows and `bin/` on POSIX; build the one this run means.
+                scripts = platform.scripts_dir(candidate / "venv")
+                scripts.mkdir(parents=True, exist_ok=True)
+                (scripts / ("python.exe" if platform.is_windows else "python")).touch()
             if "update" in command:
                 generation = Path(str(dict(kwargs["env"])["OMH_SELF_UPDATE_GENERATION"]))
                 (generation / "skills").mkdir(parents=True, exist_ok=True)
@@ -39,6 +81,7 @@ class AtomicInstallerUpdateContractTests(unittest.TestCase):
             with (
                 patch(f"{_run_command_package_self_update.__module__}.subprocess.run", side_effect=fake_run),
                 patch(f"{_run_command_package_self_update.__module__}.sys.argv", ["omh", "update", "--json"]),
+                patch.object(SelfUpdatePlatform, "host", return_value=platform),
                 contextlib.redirect_stdout(output),
                 patch.dict(
                     "os.environ",
@@ -50,22 +93,37 @@ class AtomicInstallerUpdateContractTests(unittest.TestCase):
                     },
                 ),
             ):
-                self.assertEqual(
-                    _run_command_package_self_update(
-                        Namespace(json=True),
-                        {
-                            "method": "installer",
-                            "release": SimpleNamespace(package_url="https://example.invalid/omh.whl"),
-                            "python": sys.executable,
-                            "venv_dir": str(root / "venv"),
-                        },
-                    ),
-                    0,
+                exit_code = _run_command_package_self_update(
+                    Namespace(json=True),
+                    {
+                        "method": "installer",
+                        "release": SimpleNamespace(package_url="https://example.invalid/omh.whl"),
+                        "python": sys.executable,
+                        "venv_dir": str(root / "venv"),
+                    },
                 )
+        return exit_code, captured, json.loads(output.getvalue() or "{}")
 
+    def _assert_contract(self, exit_code: int, captured: list[list[str]], payload: dict[str, object]) -> None:
+        # The exit code alone reported `1 != 0` and nothing else; the phase and
+        # its recorded reason are the only things that say which step stopped.
+        self.assertEqual(exit_code, 0, f"update stopped in phase {payload.get('phase')!r}: {payload}")
         pip_command = next(command for command in captured if command[1:4] == ["-m", "pip", "install"])
-        payload = json.loads(output.getvalue() or "{}")
         with self.subTest("active interpreter is never the pip target"):
             self.assertNotEqual(pip_command[0], sys.executable)
         with self.subTest("machine output records activation or rollback"):
             self.assertTrue(payload.get("activation") or payload.get("rollback"))
+
+    def test_installer_update_stages_outside_the_active_interpreter_and_reports_phases(self) -> None:
+        platform = _linking_platform(is_windows=SelfUpdatePlatform.host().is_windows)
+
+        self._assert_contract(*self._run_update(platform))
+
+    def test_installer_update_holds_on_the_windows_pointer_strategy_without_starting_processes(self) -> None:
+        with patch.object(
+            subprocess, "Popen", side_effect=AssertionError("unexpected self-update subprocess")
+        ) as spawn:
+            results = self._run_update(_linking_platform(is_windows=True))
+
+        self._assert_contract(*results)
+        spawn.assert_not_called()


### PR DESCRIPTION
## Feature Report

### What Changed

- `tests/test_atomic_installer_update.py` now binds the `SelfUpdatePlatform` seam it drives instead of inheriting the host's, so the atomic installer-update contract no longer starts real `powershell.exe` junction processes on Windows.
- The candidate venv the fixture builds is the layout the platform actually probes (`venv/Scripts/python.exe` on Windows, `venv/bin/python` on POSIX) rather than a fixed POSIX layout.
- The exit-code assertion now carries the transaction's failing phase and its recorded reason, so a recurrence names the step that stopped instead of printing `AssertionError: 1 != 0`.
- A second case runs the same contract with the Windows pointer strategy forced on every platform and asserts that no process is started.

### Why This Exists

`test-windows (1)` failed on `main` at `f28ece49` with a bare `AssertionError: 1 != 0` while both POSIX lanes passed. Re-running the identical commit passed (run 34482386346 attempt 2, `test-windows (1)` success in 18m39s), so the failure is intermittent on Windows, not a deterministic platform contract break.

Root cause: `SelfUpdatePlatform` is a frozen dataclass whose `runner` field default is bound to the real `subprocess.run` when the class body is evaluated. The runner this test injects into `_run_command_package_self_update` reaches `run_installer_self_update`, but never reaches the platform seam. On POSIX that is invisible, because `create_directory_link` calls `os.symlink` and starts nothing. On Windows the same run spawned four real `powershell.exe` junction processes the contract never asked for:

| # | link | why |
| --- | --- | --- |
| 1 | `generations/bootstrap-legacy/venv` | legacy migration |
| 2 | `generations/bootstrap-legacy/skills` | legacy migration |
| 3 | `.current.<pid>.tmp` | migration pointer switch |
| 4 | `.current.<pid>.tmp` | activation pointer switch |

Each carries `JUNCTION_TIMEOUT_SECONDS = 15.0`. A spawn that times out or is refused raises `OmhError`, which `run_installer_self_update` records as a failed `migration` or `activation` phase and returns as `ok: false` — exit code 1. Because the test runs under `--json` with stdout redirected into a buffer, that reason never reached the CI log; only the exit code did.

### User / Operator Impact

- None at runtime. Test-only change; no product file is touched.
- CI stops losing Windows runs to an incidental subprocess this contract never meant to exercise, and a future failure here reports its phase and reason.

### How It Works

`_linking_platform(is_windows=...)` returns a `SelfUpdatePlatform` that keeps the requested pointer strategy but replaces the junction subprocess with a runner that creates a real link, then `patch.object(SelfUpdatePlatform, "host", ...)` installs it for the duration of the transaction. This is the seam `StagedSelfUpdateTests._platform` already binds, for the same reason, and the same pattern as `test_fixture_uses_windows_pointer_strategy_without_starting_processes`.

The Windows pointer branch still runs for real: `_replace_windows_pointer`, `link_target` with its `\\?\` namespace stripping, and the `os.replace` backup/restore pair are all unchanged. Only the process spawn is replaced. The junction command itself keeps its dedicated coverage in `tests/test_staged_self_update.py` and `tests/test_handoff_safety_contract_enforcement.py`, both of which inject a runner rather than spawning PowerShell — no test anywhere spawned it deliberately, so no intended coverage is removed.

### Files And Contracts Touched

- `tests/test_atomic_installer_update.py` — only file changed. Both original assertions (`active interpreter is never the pip target`, `machine output records activation or rollback`) are preserved verbatim; nothing is skipped, xfailed, quarantined, widened, or weakened.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli harness validate`
- [x] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite on the committed tree: `Ran 10931 tests in 865.104s` / `OK (skipped=3)` (macOS, Python 3.13). An earlier full run on the same change before a trailing `if __name__ == "__main__"` guard was dropped: `Ran 10931 tests in 867.950s` / `OK (skipped=3)`.
- `tests/test_atomic_installer_update.py` run 1030 consecutive times on the committed file (1060 counting 30 runs of an identical-but-for-a-dropped-`__main__`-guard version), every one `OK`, 0 failures.
- Neighbouring self-update surfaces: `tests/test_staged_self_update.py` + `tests/test_handoff_safety_contract_enforcement.py` + `tests/test_cli.py` — `Ran 417 tests` / `OK`.
- Byte gates: `docs workflows|roles|capability-families|ulw-inventory|ulw-site --check` all pass; `docs claims --check --json` returns `"ok": true`; `harness validate` returns `"ok": true` (77 harnesses, 128 skills); `release drift --json` returns `"drift_count": 0, "ok": true`.
- Cause reproduced locally, not assumed: forcing `is_windows=True` through the real seam shows exactly four junction spawns with `timeout=15.0`. Timing out each one in turn reproduces the observed symptom precisely — spawns 1–3 give exit 1 with `phase="migration"`, spawn 4 gives exit 1 with `phase="activation"`, and in every case the reason is `cannot create Windows directory junction: ... timed out after 15.0 seconds`.
- Intermittency established from CI, not inferred: run 34482386346, `test-windows (1)`, attempt 1 failed and attempt 2 on the identical commit succeeded (2026-09-10T22:20:28Z → 22:39:07Z). `test-windows (0)` and both POSIX lanes passed on both attempts.
- Guard proven to bite, twice: pointing `_stage`'s pip install at the active interpreter turns both cases red on `active interpreter is never the pip target`; reverting the new Windows case to `SelfUpdatePlatform(is_windows=True)` with its default runner turns it red on `unexpected self-update subprocess`. Both breaks reverted.

### Not Tested / Not Applicable

- Native Windows rerun of the fixed test: no Windows host is available here, and the failure is intermittent there, so a single green Windows run would not have proven anything either way. CI adjudicates. The change removes the only element of this test that is unique to Windows, and the new phase-and-reason message makes any recurrence self-describing instead of a bare exit code.
- `release hermes-smoke`, `omh --help`, and the installed-command smoke: this change is test-only and touches no installed surface, catalog, or CLI output.
- Workflow-learning and dry-run smokes: no learning contract, routing case, skill, or demo card is involved. No exact-count assertion moves.

## Risk

- Low, and bounded to one test file. The residual risk is that the intermittency has a second cause in the Windows pointer path that this change does not remove — `os.replace` on a junction can in principle lose a race to a virus scanner. That path is exercised repeatedly by `tests/test_staged_self_update.py`, which is green on Windows CI, while the PowerShell spawn was exercised only by this one test; the failing one is the unshared element. If the failure recurs, the new assertion message names the phase and reason directly, which the previous bare exit code did not.

## Compatibility / Rollout

- No product behaviour, schema, or artifact changes. Nothing to roll out.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`) — none; test-only.
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Reported, deliberately not fixed here: `SelfUpdatePlatform.runner` is a dataclass field default, so it is bound to the real `subprocess.run` at class-definition time. `patch("omh.install.self_update_platform.subprocess.run", ...)` therefore cannot reach it, and a future test can inherit a live PowerShell spawn exactly the way this one did. A `default_factory` or a `None` sentinel resolved at call time would make module-level patching work as authors expect. Product change, out of scope for a test fix.
- Also reported, not fixed: `migrate_legacy` computes its junction target with `os.path.relpath` between an unresolved state root and a resolved `omh_home`. When those differ by a symlink (macOS `/var` → `/private/var`, or a Windows 8.3 short path) the relative target walks up to the filesystem root and back down. It is caught (`ValueError` is handled at the `migrate_legacy` call site) and it works, but on Windows it consumes `MAX_PATH` budget for no reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8

