### PR TITLE
fix(store): retry the Windows sharing denial that silently drops a record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,19 @@ Rules:
   `O_BINARY` returns a text-mode descriptor, and missed that the next line's
   `os.fdopen(fd, 'rb')` re-sets the descriptor to binary before a byte is read.
   Trace the composition to the end, or say the claim is untested.
+- Letting a best-effort `except OSError` decide what a failure was. The swallow
+  in `append_sidecar_line` is deliberate — the sidecar is the record of last
+  resort and must not raise — but it covers every step under it, and
+  `FileLockTimeout` is a `TimeoutError`, hence an `OSError` too. So "the write
+  failed", "the lock timed out" and "Windows denied the chmod while another
+  waiter held the file open" all leave one trace: a line missing and nothing
+  raised. The barrier test above it then reports `13 != 16`, which is exactly
+  what a lock that failed to hold would report, and the Windows run that
+  produced it is over. Two rules follow. A swallow is only as good as what
+  still records the failure, so widen the *report*, not the `except`. And when
+  a guard can fail two ways, put the discriminator in the assertion message —
+  here, whether any surviving line failed to parse, since only an interleave
+  splices one. A count is not a diagnosis.
 - Regenerating docs but forgetting the demo cards (or vice versa) when catalog
   data changes — the parse-equality test catches it late; regenerate all four
   artifact families together.

--- a/src/system/local_store.py
+++ b/src/system/local_store.py
@@ -40,7 +40,7 @@ def utc_now() -> str:
 def ensure_dir(path: Path, *, private: bool = False) -> None:
     path.mkdir(parents=True, exist_ok=True)
     if private:
-        path.chmod(0o700)
+        _with_windows_retry(lambda: path.chmod(0o700))
 
 
 def is_junction(path: Path) -> bool:
@@ -96,10 +96,17 @@ def discard_path(path: Path, *, ignore_errors: bool = False) -> None:
 
 
 def ensure_file(path: Path, *, private: bool = False) -> None:
+    # The chmod goes through the same Windows retry `atomic_write_text` uses,
+    # and for the same recorded reason: chmod opens the file and races the
+    # sharing window, so it is denied while a concurrent holder has the file
+    # open. `file_lock` calls this on its lock sidecar *before* taking the
+    # lock, so every waiter runs it at once against a file the other waiters
+    # already hold open -- the one place in this module where that window is
+    # not merely possible but structural.
     if not path.exists():
         path.touch(mode=0o600 if private else 0o666)
     if private:
-        path.chmod(0o600)
+        _with_windows_retry(lambda: path.chmod(0o600))
 
 
 def can_write_dir(path: Path, *, probe_name: str = ".write-test", private: bool = False) -> bool:

--- a/tests/test_append_only_store.py
+++ b/tests/test_append_only_store.py
@@ -20,8 +20,10 @@ from __future__ import annotations
 import json
 import threading
 import unittest
+from json import JSONDecodeError
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from _credential_fixtures import AWS_ACCESS_KEY_ID
 from _local_package import load_local_package
@@ -45,6 +47,7 @@ from omh.system.append_only_store import (
     store_errors,
     supersede_chain_errors,
 )
+from omh.system import local_store
 from omh.system.local_store import read_jsonl_objects
 
 LABEL = "test_record"
@@ -56,6 +59,27 @@ def _record(record_id: str, *, run_id: str = "run-1", supersedes: str = "") -> d
 
 def _no_errors(record: dict) -> list[str]:
     return []
+
+
+def _writers_that_landed(path: Path) -> tuple[list[int], int]:
+    """The writer indices on disk, and how many lines did not parse.
+
+    Splitting the two is what tells an interleave from a dropped append: only
+    an interleave leaves a spliced line behind.
+    """
+    landed: list[int] = []
+    unparseable = 0
+    if not path.exists():
+        # Every append was dropped before it created the store: no lines, and
+        # nothing raised. Reporting that as zero landed keeps the assertion
+        # message the diagnosis instead of a FileNotFoundError from the probe.
+        return landed, unparseable
+    for line in path.read_text(encoding="utf-8").splitlines():
+        try:
+            landed.append(json.loads(line)["writer"])
+        except (JSONDecodeError, KeyError, TypeError):
+            unparseable += 1
+    return landed, unparseable
 
 
 class TornTailTests(unittest.TestCase):
@@ -156,12 +180,69 @@ class ConcurrentAppendTests(unittest.TestCase):
                 thread.join()
 
             self.assertEqual(raised, [])
-            lines = path.read_text(encoding="utf-8").splitlines()
-            self.assertEqual(len(lines), writers)
-            self.assertEqual(
-                sorted(json.loads(line)["writer"] for line in lines),
-                sorted(range(writers)),
-            )
+            landed, unparseable = _writers_that_landed(path)
+            # A short count has two causes the count alone cannot tell apart,
+            # and a bare `13 != 16` left a Windows failure with three live
+            # theories. An interleave splices records and leaves unparseable
+            # lines behind; a swallowed OSError inside `append_sidecar_line`
+            # means the append never happened and every surviving line is
+            # intact. Report both, so the next failure says which it was.
+            detail = f"missing={sorted(set(range(writers)) - set(landed))} unparseable={unparseable}"
+            self.assertEqual(len(landed) + unparseable, writers, detail)
+            self.assertEqual(sorted(landed), sorted(range(writers)), detail)
+
+    def test_a_denied_chmod_on_the_lock_sidecar_never_costs_a_line(self) -> None:
+        """Windows denies the sidecar's chmod; the record must still land.
+
+        `file_lock` prepares its lock sidecar through `ensure_file` before it
+        takes the lock, so barrier-synchronized writers all run that chmod at
+        once against a file the others already hold open. Windows refuses it
+        for that window and POSIX never does. Unretried, the denial escapes
+        `file_lock` into `append_sidecar_line`, whose documented best-effort
+        swallow drops it without a word: the line is gone, nothing is raised,
+        and the count comes back short with no way to tell that apart from a
+        lock that failed to hold.
+        """
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "store.jsonl"
+            writers = 16
+            barrier = threading.Barrier(writers)
+            raised: list[Exception] = []
+            denials: dict[int, int] = {}
+            guard = threading.Lock()
+            real_chmod = Path.chmod
+
+            def denied_while_shared(target: Path, mode: int, *args: object, **kwargs: object) -> None:
+                if target.name.endswith(".lock"):
+                    with guard:
+                        thread = threading.get_ident()
+                        denials[thread] = denials.get(thread, 0) + 1
+                        seen = denials[thread]
+                    if seen <= 2:
+                        raise PermissionError(32, "used by another process")
+                real_chmod(target, mode, *args, **kwargs)
+
+            def append(index: int) -> None:
+                barrier.wait()
+                try:
+                    append_sidecar_line(path, {"writer": index, "payload": "x" * 64})
+                except Exception as exc:  # reported on the main thread, never silently dropped
+                    raised.append(exc)
+
+            threads = [threading.Thread(target=append, args=(index,)) for index in range(writers)]
+            with (
+                patch.object(local_store.os, "name", "nt"),
+                patch.object(Path, "chmod", denied_while_shared),
+            ):
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+            self.assertEqual(raised, [])
+            landed, unparseable = _writers_that_landed(path)
+            self.assertEqual(unparseable, 0)
+            self.assertEqual(sorted(landed), sorted(range(writers)))
 
 
 class SidecarTests(unittest.TestCase):

--- a/tests/test_local_store_locking.py
+++ b/tests/test_local_store_locking.py
@@ -18,6 +18,7 @@ from omh.local_store import (
     locked_json_update,
     read_json_object,
 )
+from omh.system import local_store
 
 try:
     import fcntl as _fcntl  # noqa: F401 - import used only to probe platform availability
@@ -216,6 +217,55 @@ class WindowsFileLockTests(unittest.TestCase):
 
             # A lock that was never taken leaves no sidecar behind either.
             self.assertFalse((Path(tmp) / ".state.json.lock").exists())
+
+    def test_preparing_the_lock_sidecar_survives_a_windows_sharing_denial(self) -> None:
+        """A denied chmod must not abandon the lock the caller is about to take.
+
+        `file_lock` prepares its sidecar through `ensure_file` *before* it takes
+        the lock, so every waiter runs that chmod at once against a file the
+        other waiters already hold open. Windows denies chmod for exactly that
+        window -- the same one `atomic_write_text` was taught to retry -- and
+        POSIX never does, so the denial only ever escaped there.
+        """
+        attempts: list[int] = []
+        real_chmod = Path.chmod
+
+        def denied_twice(self_path: Path, mode: int, *args: object, **kwargs: object) -> None:
+            if self_path.name.endswith(".lock"):
+                attempts.append(mode)
+                if len(attempts) <= 2:
+                    raise PermissionError(32, "used by another process")
+            real_chmod(self_path, mode, *args, **kwargs)
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            with (
+                mock.patch.object(local_store.os, "name", "nt"),
+                mock.patch.object(Path, "chmod", denied_twice),
+            ):
+                with file_lock(path, private=True) as acquired:
+                    self.assertTrue(acquired["enforced"])
+
+            self.assertEqual(len(attempts), 3)
+
+    def test_a_posix_permission_error_on_chmod_is_still_an_error(self) -> None:
+        """The retry is a Windows branch, not a swallow: POSIX must still fail."""
+        real_chmod = Path.chmod
+
+        def denied(self_path: Path, mode: int, *args: object, **kwargs: object) -> None:
+            if self_path.name.endswith(".lock"):
+                raise PermissionError(13, "permission denied")
+            real_chmod(self_path, mode, *args, **kwargs)
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "state.json"
+            with (
+                mock.patch.object(local_store.os, "name", "posix"),
+                mock.patch.object(Path, "chmod", denied),
+                self.assertRaises(PermissionError),
+            ):
+                with file_lock(path, private=True):
+                    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- `ensure_file` and `ensure_dir` now route their private-mode `chmod` through `_with_windows_retry`, the helper `atomic_write_text` in the same module already uses for the identical call.
- `test_barrier_synced_appends_do_not_interleave` keeps both of its assertions and gains the discriminator its count never carried: whether any surviving line failed to parse.
- A new case drives sixteen barrier-synchronized writers through a denied sidecar `chmod` under Windows semantics and requires all sixteen records to land.
- A new case pins that the retry is a Windows branch and not a swallow: a POSIX `PermissionError` on the same `chmod` must still fail.
- One `Common Pitfalls` entry recording why this took three theories to diagnose.

### Why This Exists

`test-windows (1)` failed on PR #1460 — a docs-only change touching one Markdown file — with `AssertionError: 13 != 16`: three of sixteen barrier-synchronized appends missing, under a lock that exists to prevent exactly that. Run 34536412085, attempt 1 failed and attempt 2 on the identical commit `1359189c` passed, so it is intermittent, established from CI rather than assumed.

`file_lock` prepares its lock sidecar through `ensure_file` **before** it takes the lock:

```python
lock_path = path.with_name(f".{path.name}.lock")
ensure_dir(lock_path.parent, private=private)      # chmod 0o700
...
ensure_file(lock_path, private=private)            # chmod 0o600
handle = lock_path.open("a+")                      # the lock is taken after this
```

So every waiter runs that `chmod` at once, against a file the other waiters already hold open. Windows denies `chmod` for exactly that window. This repo has already observed it and fixed it once, in `9191f9a6`:

> Retry herd: 24 barrier-synchronized writers re-collide in lockstep on deterministic backoff delays, exhausting the retry budget. The retry is now jittered, longer … and also wraps the post-replace chmod that private writes perform — **chmod opens the file and races the same sharing window**.

That fix landed on `atomic_write_text`. `ensure_file` and `ensure_dir` kept the bare call — and `file_lock` is the one place in the module where the sharing window is structural rather than merely possible.

Unretried, the denial escapes `file_lock` into `append_sidecar_line`, whose documented best-effort swallow drops every `OSError` without a word. The record is gone, nothing is raised, and the count comes back short — indistinguishable from a lock that failed to hold.

### User / Operator Impact

- A sidecar record — the log that exists to survive when the store beside it could not be written — could be lost silently on Windows under ordinary concurrency. It no longer can be lost to this cause.
- POSIX behaviour is unchanged in every respect.

### How It Works

`_with_windows_retry` retries a `PermissionError` seven times with jittered backoff **only** when `os.name == "nt"`, and re-raises immediately otherwise. Wrapping the two `chmod` calls therefore closes the Windows window and leaves POSIX byte-identical; the second new test pins that boundary so the fix cannot later be widened into a general swallow.

### Files And Contracts Touched

- `src/system/local_store.py` — `ensure_dir`, `ensure_file`. No signature, no return value, no new dependency.
- `tests/test_append_only_store.py` — `_writers_that_landed` helper, discriminating assertion message, one new case.
- `tests/test_local_store_locking.py` — two new cases in `WindowsFileLockTests`.
- `CLAUDE.md` — one `Common Pitfalls` entry.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite on the committed tree: `Ran 10934 tests in 913.956s` / `OK (skipped=3)` — three more than main's 10931, matching the three cases added.
- `tests/test_append_only_store.py` + `tests/test_local_store_locking.py` run 60 consecutive times: 60 `OK`, 0 failures.
- Byte gates: `docs workflows|roles|capability-families|ulw-inventory|ulw-site --check` all pass; `docs claims --check --json` `"ok": true`; `docs navigation --check` passes; `tests/test_router_content.py` + `tests/test_documentation_navigation.py` `Ran 156 tests` / `OK (skipped=1)` after the `CLAUDE.md` edit.
- Intermittency established from CI: run 34536412085 on `1359189c`, attempt 1 `test-windows (1)` failure, attempt 2 success on the identical commit. The failing job's log shows the failure at `test_append_only_store.py` line 160, which is the `len(lines)` assertion — so the preceding `assertEqual(raised, [])` passed and **no writer reported an exception**.
- **Guard bites**, both cases, by reverting each `chmod` to the bare call: `test_preparing_the_lock_sidecar_survives_a_windows_sharing_denial` errors with `PermissionError: [Errno 32]` escaping `file_lock`, and `test_a_denied_chmod_on_the_lock_sidecar_never_costs_a_line` fails with `Lists differ: [] != [0, 1, … 15]` — every record silently lost, `raised` still empty. Both breaks reverted.
- Discriminator demonstrated: driven through an unlocked appender, a genuine interleave leaves spliced lines behind (`unparseable=2`, `3`, `3` across four runs, one run `0`); driven through a denied `chmod`, every survivor is intact (`unparseable=0`). The new assertion message reports both, so the next failure says which mechanism it was.

### Not Tested / Not Applicable

- Native Windows. No Windows host is available here, and the failure is intermittent there, so one green run would not settle it. The Windows denial is modelled deterministically (`PermissionError(32)` on the first two `chmod` attempts per thread, with `os.name` patched to `"nt"`), not observed. CI adjudicates.
- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`, installed-command smoke: no catalog, skill, routing case, CLI output or installed surface is touched. No exact-count assertion moves.

## Risk

- Low. The change adds a retry that is unreachable on POSIX and wraps two calls that previously had none. The behavioural change on Windows is strictly "a denial that used to abort now retries for up to ~2.4s", after which the original exception is raised exactly as before.
- Residual: if the Windows failure was in fact an interleave rather than a dropped append, this does not fix it. See the honest reading below.

### Which mechanism, honestly

Three readings were possible — three writes lost, three overwritten, or three never started. The recorded evidence does not settle it on its own, because the test failed at the `len(lines)` assertion before it ever parsed a line, so CI never recorded whether the survivors were intact. The weight of evidence is on **never started**:

- Mutual exclusion on the msvcrt branch is separately proven by `test_msvcrt_lock_serializes_concurrent_updates`, whose fake keys locks by `(st_dev, st_ino)` exactly as real `msvcrt.locking` conflicts across handles. An interleave would require that guarantee to fail.
- A documented, previously-observed Windows failure mode sits in the exact path, unretried, with its result swallowed.
- Reproduced locally, an interleave at sixteen writers loses four to eight writers and usually leaves spliced lines; the observed loss was exactly three, which fits a transient denial hitting a few waiters.

I did not manufacture certainty here: the fix addresses a defect that is real independently of which mechanism fired, and the discriminator now in the assertion message means the question is answerable the next time rather than re-argued.

### Do the three Windows flakes share a root

No — three different roots, but a shared reporting failure worth recording, which is the `CLAUDE.md` entry.

| Flake | Root | Family |
| --- | --- | --- |
| Browser replay (#1459) | a timed-wait barrier raced its own interleaving; a worker outlived the test method holding a SQLite handle | Windows mandatory sharing (WinError 32) |
| Installer update (#1464) | a subprocess seam the test believed it had injected but had not, spawning four real PowerShell processes | Windows-only process spawn |
| Append store (this) | `ensure_file`'s unretried `chmod` inside `file_lock`, swallowed by `append_sidecar_line` | Windows mandatory sharing (WinError 32) |

Two of the three share the WinError-32 mechanism but not the root — one is a test holding a handle too long, the other is product code not retrying a documented denial. All three surfaced as a misleading symptom (`False is not true`, `1 != 0`, `13 != 16`) because the failing operation's reason was discarded before it reached the log. That, not a common root, is the pattern.

They were also not contending with each other: `tools/test_sharding/run.py` executes a shard with `unittest.TextTestRunner` in one process, serially, and the two shards are separate matrix jobs on separate runners. Same shard is coincidence of the timing-based plan, not a cause.

## Compatibility / Rollout

- No schema, artifact, or CLI change. Nothing to roll out.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

Three findings reported, deliberately not fixed here:

- **`append_sidecar_line` cannot distinguish a lost write from a lost lock.** `FileLockTimeout` subclasses `TimeoutError`, which subclasses `OSError`, so the swallow covers "the write failed", "the lock timed out" and "the lock could not be prepared" identically. The swallow itself is right — the sidecar is the record of last resort and must not raise — but nothing anywhere records that the last-resort record was dropped. The fix is a report channel, not a narrower `except`, and it is a contract change that does not belong in a flake fix.
- **The concurrent `file_lock` coverage is POSIX-only.** `test_concurrent_locked_updates_do_not_lose_writes` is `@skipUnless(HAS_FCNTL, …)`, yet `file_lock` uses `msvcrt` on Windows and works there. That guard is why the defect survived: before this PR, `test_barrier_synced_appends_do_not_interleave` was the *only* test exercising the lock path concurrently on Windows, and it was the one that flaked. Widening those guards is its own goal, with its own flake risk.
- **`_acquire_os_file_lock` polls on a deterministic `poll_interval`** — the same lockstep re-collision `_with_windows_retry`'s comment was changed to avoid. Nothing in this failure implicates it (the lock budget is a 10s deadline, not a finite retry count), so jittering it here would have been speculative. Noted for whoever touches that loop next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8
