### PR TITLE
test(platform): gate mutual exclusion on the lock, not on fcntl

### DIFF
--- a/tests/_platform_support.py
+++ b/tests/_platform_support.py
@@ -1,11 +1,21 @@
 """Shared platform-capability probes and skip decorators (issue #781).
 
 Windows lacks the POSIX primitives several OMH surfaces are built on
-(O_NOFOLLOW / O_DIRECTORY dirfd-anchored opens, fcntl advisory locks,
-mode-bit enforcement, mkfifo, killpg). Product code fails closed on such
-platforms by design; these decorators keep the corresponding tests scoped
-to hosts where the exercised contract can hold, following the guard
-conventions established by #771 and #778.
+(O_NOFOLLOW / O_DIRECTORY dirfd-anchored opens, mode-bit enforcement, mkfifo,
+killpg). Product code fails closed on such platforms by design; these
+decorators keep the corresponding tests scoped to hosts where the exercised
+contract can hold, following the guard conventions established by #771 and
+#778.
+
+Mutual exclusion is deliberately *not* on that list. `fcntl` is POSIX-only,
+but the capability built on it is not: `local_store.file_lock` falls back to
+`msvcrt.locking` and reports `enforced: True` either way, so a concurrency
+contract holds on both platforms. Pick the gate that names the capability
+under test, not the primitive the POSIX half happens to use --
+`requires_enforced_file_lock` for mutual exclusion, `requires_fcntl_locks`
+only where the test asserts something about `fcntl` itself. Gating mutual
+exclusion on `fcntl` left Windows with no concurrent coverage of the lock
+path at all, and that is where a silent data-loss defect lived until #1467.
 """
 
 from __future__ import annotations
@@ -19,6 +29,22 @@ except ImportError:
     HAS_FCNTL = False
 else:
     HAS_FCNTL = True
+
+try:  # the Windows half of the same capability
+    import msvcrt as _msvcrt  # noqa: F401
+except ImportError:
+    HAS_MSVCRT = False
+else:
+    HAS_MSVCRT = True
+
+# `file_lock` takes a real OS lock through fcntl on POSIX and msvcrt on
+# Windows, and reports `enforced: True` for either. Mutual exclusion is
+# therefore a cross-platform property, and gating a concurrency test on
+# `HAS_FCNTL` skips it on the one platform where the product has no second
+# backend to fall back on. That gate hid a Windows-only data-loss defect in
+# `ensure_file` (PR #1467): the only test reaching the lock path concurrently
+# on Windows was one nobody had gated, and it was the one that failed.
+HAS_ENFORCED_FILE_LOCK = HAS_FCNTL or HAS_MSVCRT
 
 HAS_SECURE_DIR_IO = bool(
     getattr(os, "O_NOFOLLOW", 0)
@@ -46,6 +72,10 @@ requires_symlinks = unittest.skipUnless(
 requires_fcntl_locks = unittest.skipUnless(
     HAS_FCNTL,
     "fcntl advisory locking is POSIX-only",
+)
+requires_enforced_file_lock = unittest.skipUnless(
+    HAS_ENFORCED_FILE_LOCK,
+    "mutual exclusion requires an enforced OS file lock (fcntl or msvcrt)",
 )
 requires_secure_dir_io = unittest.skipUnless(
     HAS_SECURE_DIR_IO,

--- a/tests/test_local_store_locking.py
+++ b/tests/test_local_store_locking.py
@@ -9,6 +9,7 @@ from tempfile import TemporaryDirectory
 from unittest import mock
 
 from _local_package import load_local_package
+from _platform_support import HAS_FCNTL, requires_enforced_file_lock
 
 load_local_package()
 from omh.local_store import (
@@ -19,14 +20,6 @@ from omh.local_store import (
     read_json_object,
 )
 from omh.system import local_store
-
-try:
-    import fcntl as _fcntl  # noqa: F401 - import used only to probe platform availability
-
-    HAS_FCNTL = True
-except ImportError:
-    HAS_FCNTL = False
-
 
 class FakeMsvcrt:
     """Stand-in for the Windows locking API, exercised on every platform.
@@ -65,7 +58,7 @@ class FakeMsvcrt:
 
 
 class LocalStoreLockingTests(unittest.TestCase):
-    @unittest.skipUnless(HAS_FCNTL, "fcntl advisory locking is POSIX-only")
+    @requires_enforced_file_lock
     def test_concurrent_locked_updates_do_not_lose_writes(self) -> None:
         worker_count = 24
         with TemporaryDirectory() as tmp:
@@ -113,7 +106,7 @@ class LocalStoreLockingTests(unittest.TestCase):
             leftover = list(Path(tmp).glob(".target.json.*.tmp"))
             self.assertEqual(leftover, [])
 
-    @unittest.skipUnless(HAS_FCNTL, "fcntl advisory locking is POSIX-only")
+    @requires_enforced_file_lock
     def test_file_lock_times_out_when_already_held(self) -> None:
         with TemporaryDirectory() as tmp:
             path = Path(tmp) / "contended.json"

--- a/tests/test_loop_cycle.py
+++ b/tests/test_loop_cycle.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from _local_package import load_local_package
-from _platform_support import requires_fcntl_locks
+from _platform_support import requires_enforced_file_lock
 
 load_local_package()
 import omh.goal_loop as goal_loop_module
@@ -2452,7 +2452,7 @@ class LoopCycleMutationGuardTests(unittest.TestCase):
             self.assertIn("loop_cycle record_revision must be a non-negative integer", revision_errors)
             self.assertIn("loop_cycle applied_mutations must be an object", applied_errors)
 
-    @requires_fcntl_locks
+    @requires_enforced_file_lock
     def test_concurrent_feedback_does_not_revert_a_guarded_queue_observation(self) -> None:
         # The confirmed probe: a guarded observation was reverted by a stale
         # record_loop_feedback write, after which the observation's own

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from _local_package import load_local_package
-from _platform_support import requires_fcntl_locks, requires_symlinks
+from _platform_support import requires_enforced_file_lock, requires_symlinks
 
 load_local_package()
 from omh.paths import resolve_paths
@@ -1546,7 +1546,7 @@ class MemoryBatchTests(TestCase):
 
             self.assertEqual(item["replay_evaluation"]["reason_code"], "review_required_legacy")
 
-    @requires_fcntl_locks
+    @requires_enforced_file_lock
     def test_two_process_apply_serializes_same_scope_and_preserves_different_scopes(self) -> None:
         for distinct_scopes in (False, True):
             with self.subTest(distinct_scopes=distinct_scopes), TemporaryDirectory() as home:

--- a/tests/test_memory_operations.py
+++ b/tests/test_memory_operations.py
@@ -9,7 +9,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 from _local_package import load_local_package
-from _platform_support import requires_fcntl_locks, requires_symlinks
+from _platform_support import requires_enforced_file_lock, requires_symlinks
 
 load_local_package()
 from omh.local_store import atomic_write_json, ensure_dir, read_json_object_result
@@ -473,7 +473,7 @@ class MemoryOperationTests(unittest.TestCase):
                 run_memory_operation(paths, operation_id="op-bad", operation_type="write", steps=[{"name": "bad", "action": "copy", "source": "staging/a.json", "target": "records/a.json", "summary": "private"}], now=NOW)
             self.assertFalse(paths.memory_operations_dir.exists())
 
-    @requires_fcntl_locks
+    @requires_enforced_file_lock
     def test_two_processes_serialize_same_target_without_lost_updates(self) -> None:
         with TemporaryDirectory() as tmp:
             context = multiprocessing.get_context("spawn")

--- a/tests/test_record_revision.py
+++ b/tests/test_record_revision.py
@@ -9,6 +9,7 @@ from tempfile import TemporaryDirectory
 from unittest import mock
 
 from _local_package import load_local_package
+from _platform_support import requires_enforced_file_lock
 
 load_local_package()
 from omh.goal_ledger import (
@@ -70,14 +71,6 @@ from omh.wrapper_sessions import (
     record_plan_decision,
     select_wrapper_session_executor,
 )
-
-try:
-    import fcntl as _fcntl  # noqa: F401 - import used only to probe platform availability
-
-    HAS_FCNTL = True
-except ImportError:
-    HAS_FCNTL = False
-
 
 def _bump(current: dict[str, object]) -> dict[str, object]:
     return {**current, "value": int(current.get("value", 0)) + 1}
@@ -969,7 +962,7 @@ class RequireNotTerminalTests(unittest.TestCase):
 
 
 class GuardedUpdateConcurrencyTests(unittest.TestCase):
-    @unittest.skipUnless(HAS_FCNTL, "fcntl advisory locking is POSIX-only")
+    @requires_enforced_file_lock
     def test_concurrent_guarded_updates_do_not_lose_writes(self) -> None:
         worker_count = 24
         with TemporaryDirectory() as tmp:
@@ -1006,7 +999,7 @@ class GuardedUpdateConcurrencyTests(unittest.TestCase):
             for index in range(worker_count):
                 self.assertEqual(final.get(f"key-{index}"), index)
 
-    @unittest.skipUnless(HAS_FCNTL, "fcntl advisory locking is POSIX-only")
+    @requires_enforced_file_lock
     def test_concurrent_same_mutation_id_retries_apply_exactly_once(self) -> None:
         worker_count = 16
         with TemporaryDirectory() as tmp:
@@ -1497,7 +1490,7 @@ class WorkflowStateRevisionTests(unittest.TestCase):
             self.assertEqual(finished[RECORD_REVISION_KEY], 2)
             self.assertFalse(finished["active"])
 
-    @unittest.skipUnless(HAS_FCNTL, "fcntl advisory locking is POSIX-only")
+    @requires_enforced_file_lock
     def test_concurrent_starts_do_not_both_become_active(self) -> None:
         from omh.workflow_state import WorkflowStateError, active_workflow_states, start_workflow_state
 

--- a/tests/test_status_board_auto_surface.py
+++ b/tests/test_status_board_auto_surface.py
@@ -25,7 +25,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from _local_package import load_local_package
-from _platform_support import requires_fcntl_locks
+from _platform_support import requires_enforced_file_lock
 
 load_local_package()
 
@@ -206,7 +206,7 @@ class RunningWorkBoardReaderTests(unittest.TestCase):
 
 
 class RunningWorkBoardSuppressionLedgerTests(unittest.TestCase):
-    @requires_fcntl_locks
+    @requires_enforced_file_lock
     def test_mixed_process_writers_preserve_every_bucket_count_and_latest_fingerprint(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Feature Report

### What Changed

- `tests/_platform_support.py` gains `HAS_MSVCRT`, `HAS_ENFORCED_FILE_LOCK` and `requires_enforced_file_lock`.
- Nine concurrency tests whose subject is mutual exclusion move from the `fcntl` gate to the new one, so they run on Windows for the first time.
- One test stays on `requires_fcntl_locks`, because it asserts something about `fcntl` rather than about locking.
- The module docstring now says which gate to reach for and why.

### Why This Exists

`file_lock` takes a real OS lock through `fcntl` on POSIX and `msvcrt.locking` on Windows, and reports `enforced: True` for either. Mutual exclusion is therefore a cross-platform property. Nine concurrency tests were nevertheless gated on `HAS_FCNTL`, which skipped them on the one platform where the product has no second backend to fall back on.

That gap was not theoretical. It is why the silent Windows data-loss defect fixed in #1467 survived: before that PR, the only test reaching the lock path concurrently on Windows was `test_barrier_synced_appends_do_not_interleave`, which nobody had gated — and it was the one that failed. A coverage gate was standing in front of a product defect.

### User / Operator Impact

- None at runtime; no product file is touched.
- The next regression in the locked read-modify-write path is caught on the platform it breaks, instead of being skipped there.

### How It Works

`requires_enforced_file_lock` skips only where neither backend exists — the case `file_lock` itself reports as `enforced: False`. On both supported platforms it is open.

### Enumeration, as requested — which can move and which cannot

All ten `fcntl`-gated tests, classified by what each one actually asserts:

| Test | Subject | Verdict |
| --- | --- | --- |
| `test_local_store_locking::test_concurrent_locked_updates_do_not_lose_writes` | 24 threads through `locked_json_update` | moved |
| `test_local_store_locking::test_file_lock_times_out_when_already_held` | `file_lock` timeout while held | moved |
| `test_local_store_locking::test_fcntl_lock_reports_itself_as_enforced` | `mechanism == "fcntl"` | **stays gated** |
| `test_record_revision::test_concurrent_guarded_updates_do_not_lose_writes` | 24 threads through `guarded_record_update` | moved |
| `test_record_revision::test_concurrent_same_mutation_id_retries_apply_exactly_once` | 16 threads, idempotent mutation id | moved |
| `test_record_revision::test_concurrent_starts_do_not_both_become_active` | 8 threads, one-active-workflow invariant | moved |
| `test_loop_cycle::test_concurrent_feedback_does_not_revert_a_guarded_queue_observation` | 2 threads, observation not reverted | moved |
| `test_memory_operations::test_two_processes_serialize_same_target_without_lost_updates` | 2 spawned processes, same scope | moved |
| `test_memory_batches::test_two_process_apply_serializes_same_scope_and_preserves_different_scopes` | 2 spawned processes, scope isolation | moved |
| `test_status_board_auto_surface::test_mixed_process_writers_preserve_every_bucket_count_and_latest_fingerprint` | 2 spawned processes, ledger buckets | moved |

`test_fcntl_lock_reports_itself_as_enforced` is the only genuinely POSIX-only one: the mechanism *name* is a statement about the primitive, and its Windows half already exists as `test_msvcrt_takes_the_lock_when_fcntl_is_unavailable`.

The three spawn-based tests already use `multiprocessing.get_context("spawn")` with module-level targets, so their process model is Windows-native as written — `spawn` is the only Windows start method, and the targets are picklable. Their gate was about the lock, not the process model.

I also swept for equivalent markers, since `HAS_FCNTL` is not the only POSIX gate. Two other things turned up and both are correct as they stand:

- `requires_posix` on concurrency-shaped tests in `test_cross_harness_adapter_security.py` and `test_prompt_compatibility.py` — these are `mkfifo`, device-node and process-group tests. Genuinely POSIX-only.
- `test_journal_lock_portability.py` uses `HAS_FCNTL` to derive an *expectation*, not a gate: it asserts the domain-intelligence store capability reports `available`/`missing` to match the host. That store really does need POSIX `O_NOFOLLOW`/`O_DIRECTORY` dirfd primitives, so `missing` on Windows is the honest answer, and the test already runs on both platforms.

### Files And Contracts Touched

- `tests/_platform_support.py` — two new probes, one new decorator, docstring. `requires_fcntl_locks` kept and still used.
- `tests/test_local_store_locking.py`, `tests/test_record_revision.py` — local `try: import fcntl` probes removed in favour of the shared ones.
- `tests/test_loop_cycle.py`, `tests/test_memory_batches.py`, `tests/test_memory_operations.py`, `tests/test_status_board_auto_surface.py` — decorator swap only.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite on the committed tree: `Ran 10944 tests in 909.702s` / `OK (skipped=3)`.
- The six touched suites together: `Ran 238 tests` / `OK`.
- **Rehearsed the msvcrt branch on this host.** With `local_store.fcntl` patched to `None` and a `msvcrt` stand-in installed — the same seam `WindowsFileLockTests` already patches, modelling the byte-range conflict across handles that real `msvcrt.locking` has — all six lifted thread-based tests pass: `ran=6 failures=0 errors=0 skipped=0`, with 79 lock/unlock pairs and **209 denied acquisitions**. The denial count is the part that matters: contention was really exercised, not short-circuited.
- Gate logic checked directly: `HAS_ENFORCED_FILE_LOCK == (HAS_FCNTL or HAS_MSVCRT)`, so a host with `msvcrt` and no `fcntl` is open where the old gate was shut.
- Byte gates: all five `docs … --check` pass; `docs claims --check --json` `"ok": true`; `release drift --json` `"drift_count": 0, "ok": true`.
- Spawn-based cases timed on this host: 0.13s, 0.44s and 0.22s wall, against join/barrier deadlines of 10s and 20s.

### Not Tested / Not Applicable

- **Native Windows.** No Windows host here; CI adjudicates, and that is the point of the PR.
- **The three spawn-based cases in the msvcrt branch.** Their children are fresh interpreters that import the real `fcntl`, so no local harness reaches them. Their move is reasoned from the start method and the target picklability, not observed.
- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`, installed-command smoke: no catalog, skill, routing case, CLI output or installed surface is touched. No exact-count assertion moves; the suite total is unchanged by re-gating, and there is no pinned suite-level skip count.

## Risk

Moderate, and deliberately so — nine tests start running on a platform they have never run on. The two reds I would expect first, neither of which I have pre-empted:

1. `test_concurrent_locked_updates_do_not_lose_writes` runs 24 writers on `locked_json_update`'s **default 10s** lock timeout. Its siblings in `test_record_revision` pass `timeout_seconds=30.0` explicitly, and so does `test_msvcrt_lock_serializes_concurrent_updates`. On Windows each critical section additionally carries `atomic_write_text`'s jittered sharing retry, up to ~2.4s worst case. If that budget is short there, a `FileLockTimeout` is the finding — a statement about lock fairness under contention on Windows — and I have deliberately not widened it, because sizing a budget for a platform I cannot measure would hide exactly the evidence this PR exists to collect.
2. The three spawn-based cases join with 10s/20s deadlines. Windows process creation is slower than POSIX `spawn` even though the start method is identical. Observed usage here is 0.13–0.44s, i.e. 20–75x headroom, so I expect this to hold; if it does not, that is again a budget sized on one platform, reported rather than widened.

Per the brief, if either goes red I will report it as a finding rather than accommodate it. I am also not assuming a red here shares a root with any of today's three — those had three different roots, and this one would most likely be a third thing again.

## Compatibility / Rollout

No product change. Nothing to roll out.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- If Windows CI is green, the useful next step is the inverse sweep: find product code that reports a capability as unavailable because `fcntl` is missing, where `file_lock` would in fact serve it. `_domain_intelligence_store_capability` is correctly `missing` there, but it is worth confirming nothing else conflates "no fcntl" with "no lock".
- Still open from #1467, unchanged by this PR: `append_sidecar_line` cannot distinguish a lost write from a lost lock, because `FileLockTimeout` subclasses `TimeoutError` subclasses `OSError`. The swallow is right; the missing piece is a report channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8
