### PR TITLE
fix(hud): approximate the cost of a gateway child the host could not price, and read the model and provider the host observed

### DIFF
--- a/MODEL_OPTI.md
+++ b/MODEL_OPTI.md
@@ -895,8 +895,15 @@ gate requires a completed paired run on the intended execution surface.
   instead of relying on projection.
 - **Cost approximation** — `APPROX_PRICE_PER_MTOK` in
   `src/plugin_bundle/omh/hermes_delegation.py` supplies `~$` estimates only
-  when the host recorded no cost; models absent from the table show no
-  approximation (never a fabricated number). Cache reads are priced at a
+  when the host recorded no cost — no per-call figure at all, or Hermes' own
+  `unknown` no-figure status (`agent/usage_pricing.py:549`, persisted into
+  the usage table by `agent/turn_usage.py:236,257`), which says its pricing
+  produced no amount rather than naming a billing outcome. That second case
+  is what every child served through a custom gateway provider lands in. A
+  row where the host DID record an outcome keeps its figure exactly,
+  and models absent from the table show no approximation at all — a
+  gateway child on an unpriced model still renders `$0.0000 (unknown)`,
+  never a fabricated number. Cache reads are priced at a
   tenth of input unless `APPROX_CACHE_READ_RATIO` names the model: Claude
   Fable 5.1 lists $10 / $50 per MTok with cache reads at $0.25 (0.025x) and
   cache writes at $12.50 (5-minute TTL) / $20 (1-hour TTL); Opus 5 reads at

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -420,6 +420,18 @@ approximated figure still renders with its `~` marker. A row whose figure
 came from your own rate is marked `cost_override` beside `cost_approximate`,
 so a number you chose can be told apart from our shipped ballpark.
 
+"Nothing was recorded" covers two shapes, both of them the host declining to
+state a cost: no cost provenance at all, and Hermes' own `unknown` status,
+which it stamps whenever its pricing produced no amount
+(`agent/usage_pricing.py:549`, persisted into the usage table by
+`agent/turn_usage.py:236,257`). Every child served through a custom gateway
+provider carries that status, because Hermes prices only the routes it has
+rates for. A row where the host did record an outcome — `included`, a billed
+zero, any word it chose — keeps that figure untouched, and in a session whose
+rows mix the two the recorded outcome is what the row reports. When the model
+has no rate on either side, the row keeps rendering `$0.0000 (unknown)` rather
+than gaining a figure OMH cannot support.
+
 Every shipped rate carries the vendor page it was read from and the month, so
 a reader can tell a current price from one that drifted.
 

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -161,6 +161,18 @@ export default function register(sdk) {
   // host recorded. A zero with no provenance renders nothing: the reader
   // only sends a bare zero it can vouch for, but the check stays so this
   // surface never states a billing fact the row does not carry.
+  //
+  // A child the host could not price (a custom gateway provider, where
+  // Hermes' pricing produces no amount and stamps its `unknown` no-figure
+  // status -- `agent/usage_pricing.py:549`, persisted into the usage table
+  // by `agent/turn_usage.py:236,257`) reaches this function one of two
+  // ways, and the reader decides which. When OMH knows a rate for the
+  // model it sends the token-derived figure with the approximate flag, so
+  // the row reads `~$0.0431`. When it does not, the recorded zero and the
+  // host's own word arrive untouched and the row still reads
+  // `$0.0000 (unknown)`. Nothing here matches on that word -- the rule is
+  // the one above, and only a successful approximation changes what
+  // renders.
   function costSegmentText(row) {
     if (!Number.isFinite(row.cost_usd)) return ''
     if (row.cost_usd > 0) return `${row.cost_approximate ? '~' : ''}$${row.cost_usd.toFixed(4)}`

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -786,11 +786,16 @@ def _child_is_inherit(
     parent_models: Mapping[str, str],
     provider_routes: Mapping[str, tuple[str, str]],
 ) -> bool:
-    """Mirror the projection's inherit test: child alias == parent model."""
+    """Mirror the projection's inherit test: child alias == parent model.
+
+    The projection routes the model it resolved, so this reads the same
+    resolved model; testing the raw `sessions.model` made the two disagree
+    on a child whose model is only recorded in its usage rows.
+    """
     parent_model = _text(parent_models.get(child.get("parent_id", ""), ""))
     if not parent_model:
         return False
-    alias, _ = configured_route_for_wire(child["model"], provider_routes)
+    alias, _ = configured_route_for_wire(_observed_wire_model(child), provider_routes)
     return _text(alias).casefold() == parent_model.casefold()
 
 
@@ -1327,6 +1332,77 @@ def _conversation_session_ids(connection: sqlite3.Connection, session_ref: str) 
     return {row[0] for row in rows}
 
 
+def _informative_cost_row_sql(columns: set[str]) -> str:
+    """One SQL predicate: does this usage row say anything about cost?
+
+    OMH still does not enumerate a host's BILLING words -- "included",
+    "billed_zero" and the rest stay unknown to this reader, and any of them
+    vouches for the zero it annotates. The one word named here is not a
+    billing word at all: `unknown` is the host's own NO-FIGURE status, the
+    one `usage_pricing._unknown_cost` stamps whenever it produced no amount
+    (`agent/usage_pricing.py:549`, returning `amount_usd=None`), whether the
+    route had no pricing entry at all (`:565`, paired with source `none`) or
+    only a partial rate (`:583`, which pairs it with an informative source).
+    The status is what carries the "no figure" meaning, so the source is not
+    part of the test. `agent/turn_usage.py:236,257` is what persists the pair
+    into `session_model_usage`; `agent/agent_init.py:2140` only seeds the
+    session attribute default.
+
+    Treating that status as provenance is what made every child on a custom
+    gateway provider render `$0.0000 (unknown)` -- a stated zero the host
+    never claimed. Evaluating it PER ROW instead of reducing with MAX is what
+    keeps a MIXED group safe: one row carrying a real billing word is enough
+    to stop the approximation, exactly as before.
+    """
+    status = "COALESCE(cost_status, '')" if "cost_status" in columns else "''"
+    source = "COALESCE(cost_source, '')" if "cost_source" in columns else "''"
+    return f"({status} <> '' OR {source} <> '') AND {status} <> 'unknown'"
+
+
+def _preferred_provenance_sql(column: str, informative: str, columns: set[str]) -> str:
+    """Read one provenance column from an informative row when the group has one.
+
+    `MAX` over a mixed group answers alphabetically, so a session with one
+    `included` row beside one `unknown` row reported `unknown` and rendered a
+    vouched zero as `$0.0000 (unknown)`. Prefer the informative rows; with
+    none, the host's no-figure status is the honest answer and `MAX` supplies
+    it unchanged.
+    """
+    if column not in columns:
+        return "NULL"
+    return f"COALESCE(MAX(CASE WHEN {informative} THEN {column} END), MAX({column}))"
+
+
+def _sole_distinct_value(value: Any, *, limit: int = 80) -> str:
+    """The single value a `GROUP_CONCAT(DISTINCT ...)` returned, else "".
+
+    `GROUP_CONCAT` joins distinct values with a comma, so more than one
+    arrives as a list this reader cannot resolve into a single row field. The
+    comma test runs on the WHOLE string: truncating first could cut the list
+    down to its first element and pass it off as the only one.
+    """
+    text = str(value or "").strip()
+    if not text or "," in text:
+        return ""
+    return text[:limit]
+
+
+def _observed_wire_model(child: Mapping[str, Any]) -> str:
+    """The model a child ran: recorded on the session, else observed in usage.
+
+    Hermes leaves `sessions.model` empty on a child whose session row was
+    created before the model was known, and the label then had nothing to
+    print. `session_model_usage.model` is written per call from the model
+    that actually answered, so one distinct value there names it. Two
+    distinct values (a child that switched models) or none leave the row
+    exactly as recorded -- this reads an observation, it never infers one.
+    """
+    recorded = _text(child.get("model"))
+    if recorded:
+        return recorded
+    return _text((child.get("usage") or {}).get("model"))
+
+
 def _query_state_db(state_db: Path, *, now: float, session_ref: str | None = None) -> dict[str, Any]:
     """Read child sessions, usage tallies, and delegation states, read-only."""
     result: dict[str, Any] = {"children": [], "delegation_states": {}, "parent_models": {}, "scope": "global"}
@@ -1401,15 +1477,29 @@ def _query_state_db(state_db: Path, *, now: float, session_ref: str | None = Non
                     'PRAGMA table_info("session_model_usage")'
                 ).fetchall()
             }
-            cost_status = "MAX(cost_status)" if "cost_status" in columns else "NULL"
-            cost_source = "MAX(cost_source)" if "cost_source" in columns else "NULL"
+            informative = _informative_cost_row_sql(columns)
+            cost_status = _preferred_provenance_sql("cost_status", informative, columns)
+            cost_source = _preferred_provenance_sql("cost_source", informative, columns)
+            # One distinct value, or nothing. `billing_provider` is part of
+            # the table's primary key, so a session that reached two
+            # providers has two rows and no single answer to give a row.
+            # `NULLIF` drops the column's own empty default first: a real
+            # provider beside an unattributed row is still one provider.
+            billing_provider = (
+                "GROUP_CONCAT(DISTINCT NULLIF(billing_provider, ''))"
+                if "billing_provider" in columns
+                else "NULL"
+            )
             cursor = connection.execute(
                 f"""
                 SELECT session_id, SUM(api_call_count), SUM(input_tokens),
                        SUM(output_tokens), SUM(cache_read_tokens),
                        SUM(actual_cost_usd), SUM(estimated_cost_usd),
                        {cost_status}, {cost_source},
-                       MIN(first_seen), MAX(last_seen)
+                       MIN(first_seen), MAX(last_seen),
+                       SUM(CASE WHEN {informative} THEN 1 ELSE 0 END),
+                       {billing_provider},
+                       GROUP_CONCAT(DISTINCT NULLIF(model, ''))
                 FROM session_model_usage
                 WHERE session_id IN ({placeholders})
                 GROUP BY session_id
@@ -1429,6 +1519,9 @@ def _query_state_db(state_db: Path, *, now: float, session_ref: str | None = Non
                     "cost_source": _text(row[8]) or None,
                     "first_seen": _finite(row[9]),
                     "last_seen": _finite(row[10]),
+                    "informative_cost_rows": int(_finite(row[11]) or 0.0),
+                    "billing_provider": _sole_distinct_value(row[12]),
+                    "model": _sole_distinct_value(row[13]),
                 }
             for child in children:
                 child["usage"] = usage.get(child["session_id"], {})
@@ -1576,6 +1669,10 @@ def read_hermes_native_subagents(
             row_state = "failed"
             failure_hint = "no model usage observed"
 
+        # An empty `sessions.model` is filled from the one model the child's
+        # usage rows observed, never from a guess; see `_observed_wire_model`.
+        wire_model = _observed_wire_model(child)
+
         input_tokens = usage.get("input_tokens") or 0.0
         output_tokens = usage.get("output_tokens") or 0.0
         cache_read = usage.get("cache_read_tokens") or 0.0
@@ -1599,7 +1696,16 @@ def read_hermes_native_subagents(
         # rows) collapse to a fake zero when MAX(cost_status) surfaced the
         # hardcoded word, and let a host's confirmed billed-zero get
         # approximated over because its status was not that word.
+        #
+        # The single exception is the host's own no-figure status, tested per
+        # usage row by `_informative_cost_row_sql`: `unknown` is what Hermes
+        # stamps when its pricing produced no amount at all, so it says the
+        # host has no figure rather than naming a billing outcome.
+        # `informative_cost_rows` is therefore the count of rows carrying
+        # provenance that IS a claim about cost; zero means every row either
+        # recorded nothing or recorded that it knows nothing.
         cost_provenance = cost_status or cost_source
+        informative_cost_rows = int(usage.get("informative_cost_rows") or 0)
         # A positive observed aggregate always stands as recorded; only a
         # zero consults provenance at all.
         cost = usage.get("actual_cost_usd") or usage.get("estimated_cost_usd")
@@ -1613,33 +1719,37 @@ def read_hermes_native_subagents(
         # this line as the same 0.0 -- cost_status/cost_source are the only
         # fields that tell them apart, and they are nullable, so unlike the
         # summed costs they CAN distinguish "recorded" from "absent". The
-        # approximation therefore fires only on a zero with NO provenance.
+        # approximation therefore fires on a zero that no usage row made an
+        # informative claim about -- none recorded, or every one of them the
+        # host's no-figure status.
         # What must NOT happen is the third case: no recorded cost, no
         # provenance, AND no price for the model (`_approximate_cost_usd`
         # returns None for an unpriced model, and for a run with no tokens).
         # That left `cost` at 0.0 with no approximate flag, so the row
         # claimed the run was free. An unknown cost is unknown: send None and
         # let the surface say nothing rather than state a zero it cannot
-        # support.
+        # support. A no-figure row is the one place the bare zero stays: the
+        # host wrote a word for it, so the surface can still render
+        # `$0.0000 (unknown)` instead of falling silent.
         cost_approximate = False
         # A figure derived from the operator's own rate and one derived from
         # our shipped ballpark are both approximations, but they are not
         # equally arguable: only the first is a number the operator chose.
         # The row says which, so a surface can tell them apart.
-        cost_override = bool(_model_price_override_key(child["model"], price_overrides))
-        if not cost and cost_provenance is None:
+        cost_override = bool(_model_price_override_key(wire_model, price_overrides))
+        if not cost and not informative_cost_rows:
             approx = _approximate_cost_usd(
-                child["model"], input_tokens, output_tokens, cache_read, price_overrides
+                wire_model, input_tokens, output_tokens, cache_read, price_overrides
             )
             if approx is not None:
                 cost = approx
                 cost_approximate = True
-            else:
+            elif cost_provenance is None:
                 cost = None
 
         parent_model = state.get("parent_models", {}).get(child["parent_id"], "")
         route_alias, route_provider = configured_route_for_wire(
-            child["model"],
+            wire_model,
             provider_routes,
         )
         session_tail = child["session_id"].rsplit("_", 1)[-1][:8]
@@ -1655,7 +1765,7 @@ def read_hermes_native_subagents(
             "action": _text(task.get("goal", ""), limit=_ACTION_LIMIT),
             "alias": route_alias,
             "provider": route_provider,
-            "model": child["model"],
+            "model": wire_model,
             "effort": child["effort"],
             # A terminal row's zero is observed, not missing: the failure
             # hint above is derived from this same absence, so sending `None`
@@ -1675,16 +1785,31 @@ def read_hermes_native_subagents(
         }
         if route_provider:
             row["provider_source"] = "model_provider_routes"
+        elif usage.get("billing_provider"):
+            # No `model-providers.json` row names this wire model, so OMH has
+            # no configured provider of its own -- but the host recorded which
+            # provider it billed the calls under, which answers the same
+            # question. This fills the payload field for the `read_omh_hud`
+            # JSON payload; the TUI widget renders the model, not the
+            # provider, so nothing on screen changes. The source marker keeps
+            # an observed billing fact distinguishable from OMH's own
+            # configuration.
+            row["provider"] = usage["billing_provider"]
+            row["provider_source"] = "hermes_billing_provider"
         # Prepared-route provenance is a best-effort label upgrade, never
         # row identity: when the child's identity matches the newest route
         # prepared before its dispatch, a fallback lane says so and an
         # exhausted chain keeps its category with an `inherit` model token
         # (`category(model inherit)`) instead of converging into plain
-        # inherit. The upgrade carries its own source marker.
+        # inherit. The upgrade carries its own source marker. The model that
+        # matches here is the same observed wire model the alias and category
+        # above were derived from, so the three stay one identity; a child
+        # whose model the host never recorded and never used matches nothing,
+        # which is the safe degradation.
         provenance = _provenance_for_dispatch(
             route_provenance,
             started_at=child["started_at"],
-            wire_model=child["model"],
+            wire_model=wire_model,
             alias=route_alias,
             is_inherit=row["category"] == "inherit",
             session_id=child["session_id"],

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -55,6 +55,7 @@ def _build_state_db(
         );
         CREATE TABLE session_model_usage (
             session_id TEXT NOT NULL, model TEXT NOT NULL,
+            billing_provider TEXT NOT NULL DEFAULT '',
             api_call_count INTEGER NOT NULL DEFAULT 0,
             input_tokens INTEGER NOT NULL DEFAULT 0,
             output_tokens INTEGER NOT NULL DEFAULT 0,
@@ -91,20 +92,32 @@ def _build_state_db(
             single = child.get("usage")
             usages = [single] if single else []
         for usage in usages:
+            # Named columns, not positions: the host's real table carries
+            # more of them than this fixture does, and a positional insert
+            # made adding one a rewrite of every call site.
+            values = {
+                "session_id": child["id"],
+                # The usage table records the model each call ran on, which
+                # is not always what the session row holds.
+                "model": usage.get("model", child["model"]),
+                "billing_provider": usage.get("billing_provider", ""),
+                "api_call_count": usage.get("api_calls", 0),
+                "input_tokens": usage.get("input_tokens", 0),
+                "output_tokens": usage.get("output_tokens", 0),
+                "cache_read_tokens": usage.get("cache_read_tokens", 0),
+                "actual_cost_usd": usage.get("actual_cost_usd", 0.0),
+                "estimated_cost_usd": usage.get("estimated_cost_usd", 0.0),
+                "first_seen": usage.get("first_seen"),
+                "last_seen": usage.get("last_seen"),
+            }
+            if include_cost_provenance:
+                values["cost_status"] = usage.get("cost_status")
+                values["cost_source"] = usage.get("cost_source")
             connection.execute(
-                (
-                    "INSERT INTO session_model_usage VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-                    if include_cost_provenance
-                    else "INSERT INTO session_model_usage VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO session_model_usage ({}) VALUES ({})".format(
+                    ", ".join(values), ", ".join("?" for _ in values)
                 ),
-                (
-                    child["id"], child["model"], usage.get("api_calls", 0),
-                    usage.get("input_tokens", 0), usage.get("output_tokens", 0),
-                    usage.get("cache_read_tokens", 0), usage.get("actual_cost_usd", 0.0),
-                    usage.get("estimated_cost_usd", 0.0),
-                    *(([usage.get("cost_status"), usage.get("cost_source")] if include_cost_provenance else [])),
-                    usage.get("first_seen"), usage.get("last_seen"),
-                ),
+                tuple(values.values()),
             )
     for delegation_id, state in (delegation_states or {}).items():
         connection.execute(
@@ -883,6 +896,303 @@ class HermesNativeSubagentReaderTest(unittest.TestCase):
         self.assertTrue(row["cost_approximate"])
         self.assertNotIn("cost_status", row)
         self.assertNotIn("cost_source", row)
+
+    def test_the_hosts_no_pricing_sentinel_is_approximated_like_an_absence(self):
+        # Given: a child served by a custom gateway provider. Hermes has no
+        # rate for it, so its pricing returns no amount and stamps its own
+        # `unknown` no-figure status (`agent/usage_pricing.py:549`, persisted
+        # by `agent/turn_usage.py:236,257`) -- the host saying it has NO
+        # figure, not a billing outcome.
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_gateway1",
+                "model": "anthropic/claude-fable-5-1",
+                "started_at": NOW - 60,
+                "usage": {
+                    "input_tokens": 10_000,
+                    "output_tokens": 4_000,
+                    "actual_cost_usd": 0.0,
+                    "cost_status": "unknown",
+                    "cost_source": "none",
+                    "last_seen": NOW - 5,
+                },
+            }],
+        )
+        _write_manifest(self.home, "deleg_gw", ["gateway lane"], started=NOW - 65, log_mtime=NOW - 5)
+        # When: the reader projects the child
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        # Then: the token-derived figure fires exactly as it does for a row
+        # with no provenance at all. Fable 5.1 lists $10/M input, $50/M
+        # output, cache reads at $0.25/M.
+        self.assertTrue(row["cost_approximate"])
+        self.assertAlmostEqual(
+            row["cost_usd"], (10_000 * 10.0 + 4_000 * 50.0) / 1_000_000
+        )
+        # And: the host's own words stay on the row as recorded -- OMH
+        # reports what the host wrote, it does not rewrite it.
+        self.assertEqual(row["cost_status"], "unknown")
+        self.assertEqual(row["cost_source"], "none")
+
+    def test_an_unpriceable_sentinel_keeps_the_zero_the_host_can_render(self):
+        # Given: the same no-pricing sentinel on a model OMH has no rate for
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_gateway2",
+                "model": "og/some-unlisted-model",
+                "started_at": NOW - 60,
+                "usage": {
+                    "input_tokens": 10_000,
+                    "output_tokens": 4_000,
+                    "actual_cost_usd": 0.0,
+                    "cost_status": "unknown",
+                    "cost_source": "none",
+                    "last_seen": NOW - 5,
+                },
+            }],
+        )
+        _write_manifest(self.home, "deleg_gw2", ["gateway lane"], started=NOW - 65, log_mtime=NOW - 5)
+        # When: the reader projects the child
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        # Then: nothing is invented and nothing is taken away -- the row
+        # renders exactly as it did before this rule existed,
+        # `$0.0000 (unknown)`. Only a SUCCESSFUL approximation changes it.
+        self.assertEqual(row["cost_usd"], 0.0)
+        self.assertNotIn("cost_approximate", row)
+        self.assertEqual(row["cost_status"], "unknown")
+        self.assertEqual(row["cost_source"], "none")
+
+    def test_one_informative_row_stops_the_sentinel_approximation(self):
+        # Given: a group that mixes the host's no-pricing sentinel with one
+        # row that DID record a billing outcome, and whose summed cost is
+        # still zero. MAX(cost_status) over this group answers "unknown",
+        # which is exactly the reduction a per-row count has to survive.
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_mixedsen",
+                "model": "gpt-5.6-sol",
+                "started_at": NOW - 60,
+                "usages": [
+                    {
+                        "input_tokens": 10_000,
+                        "output_tokens": 4_000,
+                        "actual_cost_usd": 0.0,
+                        "cost_status": "unknown",
+                        "cost_source": "none",
+                        "first_seen": NOW - 55,
+                        "last_seen": NOW - 30,
+                    },
+                    {
+                        "input_tokens": 5_000,
+                        "output_tokens": 1_000,
+                        "actual_cost_usd": 0.0,
+                        "cost_status": "included",
+                        "cost_source": "subscription",
+                        "first_seen": NOW - 25,
+                        "last_seen": NOW - 5,
+                    },
+                ],
+            }],
+        )
+        _write_manifest(self.home, "deleg_ms", ["mixed lane"], started=NOW - 65, log_mtime=NOW - 5)
+        # When: the reader projects the child
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        # Then: the confirmed zero stands. One row vouching for the figure
+        # is enough, whatever the other rows recorded.
+        self.assertEqual(row["cost_usd"], 0.0)
+        self.assertNotIn("cost_approximate", row)
+        # And: the WORD the surface renders is the one that vouched for the
+        # zero. A plain MAX answers alphabetically, which put "unknown"
+        # ahead of "included" and made a vouched zero read as unpriced.
+        self.assertEqual(row["cost_status"], "included")
+        self.assertEqual(row["cost_source"], "subscription")
+
+    def test_an_empty_session_model_is_filled_from_the_observed_usage_model(self):
+        # Given: a child whose `sessions.model` is empty -- the row was
+        # created before the model was known -- while its usage rows record
+        # the model every call actually ran on
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_nomodel1",
+                "model": "",
+                "effort": "high",
+                "started_at": NOW - 60,
+                "usage": {
+                    "model": "claude-fable-5-1",
+                    "input_tokens": 10_000,
+                    "output_tokens": 4_000,
+                    "last_seen": NOW - 5,
+                },
+            }],
+        )
+        _write_manifest(self.home, "deleg_nm", ["unnamed lane"], started=NOW - 65, log_mtime=NOW - 5)
+        # When: the reader projects the child
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        # Then: the label names the observed model instead of the bare
+        # `:high` the empty recording used to produce, and everything keyed
+        # off the model follows it -- category here, and pricing below.
+        self.assertEqual(row["model"], "claude-fable-5-1")
+        self.assertEqual(row["effort"], "high")
+        self.assertEqual(row["category"], "visual-engineering")
+        self.assertTrue(row["cost_approximate"])
+
+    def test_two_observed_usage_models_leave_an_empty_model_untouched(self):
+        # The negative control: a child whose usage rows name two models has
+        # no single answer, so the row stays exactly as recorded. Nothing is
+        # inferred from the parent -- Hermes does not copy its model down.
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_twomodel",
+                "model": "",
+                "started_at": NOW - 60,
+                "usages": [
+                    {"model": "claude-fable-5-1", "output_tokens": 10, "last_seen": NOW - 20},
+                    {"model": "gpt-5.6-sol", "output_tokens": 10, "last_seen": NOW - 5},
+                ],
+            }],
+        )
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        self.assertEqual(row["model"], "")
+        self.assertEqual(row["category"], "")
+
+    def test_a_recorded_session_model_wins_over_the_usage_model(self):
+        # The session row is the child's own identity when it has one; the
+        # usage fill only covers the absence.
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_ownmodel",
+                "model": "claude-fable-5-1",
+                "started_at": NOW - 60,
+                "usage": {"model": "gpt-5.6-sol", "output_tokens": 10, "last_seen": NOW - 5},
+            }],
+        )
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        self.assertEqual(row["model"], "claude-fable-5-1")
+
+    def test_an_unrouted_child_shows_the_provider_the_host_billed_it_under(self):
+        # Given: a wire model no `model-providers.json` row names, whose
+        # usage the host recorded against a billing provider
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_billprov",
+                "model": "anthropic/claude-fable-5-1",
+                "started_at": NOW - 60,
+                "usage": {
+                    "billing_provider": "og",
+                    "output_tokens": 10,
+                    "last_seen": NOW - 5,
+                },
+            }],
+        )
+        # When: the reader projects the child
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        # Then: the provider column shows the observed billing provider,
+        # marked with the origin that earned it rather than passed off as
+        # OMH's own configuration.
+        self.assertEqual(row["provider"], "og")
+        self.assertEqual(row["provider_source"], "hermes_billing_provider")
+
+    def test_two_billing_providers_leave_the_provider_column_empty(self):
+        # The negative control: a session billed under two providers has no
+        # single answer, and a guessed one would be worse than none.
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_twoprovs",
+                "model": "anthropic/claude-fable-5-1",
+                "started_at": NOW - 60,
+                "usages": [
+                    {"billing_provider": "og", "output_tokens": 10, "last_seen": NOW - 20},
+                    {"billing_provider": "custom", "output_tokens": 10, "last_seen": NOW - 5},
+                ],
+            }],
+        )
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        self.assertEqual(row["provider"], "")
+        self.assertNotIn("provider_source", row)
+
+    def test_one_billing_provider_beside_an_unattributed_row_is_still_one(self):
+        # The column defaults to the empty string, so a session with one
+        # attributed row and one unattributed row must not read as two
+        # providers -- there is exactly one, and it is the one to show.
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_oneprov1",
+                "model": "anthropic/claude-fable-5-1",
+                "started_at": NOW - 60,
+                "usages": [
+                    {"billing_provider": "og", "output_tokens": 10, "last_seen": NOW - 20},
+                    {"billing_provider": "", "output_tokens": 10, "last_seen": NOW - 5},
+                ],
+            }],
+        )
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        self.assertEqual(row["provider"], "og")
+        self.assertEqual(row["provider_source"], "hermes_billing_provider")
+
+    def test_the_no_figure_status_is_the_test_whatever_source_it_carries(self):
+        # Hermes stamps `unknown` whenever its pricing produced no amount,
+        # and a partially-rated route pairs that status with an informative
+        # source instead of `none`. The STATUS is what says "no figure", so
+        # the source must not rescue it into a vouched zero.
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_partial1",
+                "model": "gpt-5.6-sol",
+                "started_at": NOW - 60,
+                "usage": {
+                    "input_tokens": 10_000,
+                    "output_tokens": 4_000,
+                    "actual_cost_usd": 0.0,
+                    "cost_status": "unknown",
+                    "cost_source": "litellm",
+                    "last_seen": NOW - 5,
+                },
+            }],
+        )
+        _write_manifest(self.home, "deleg_pr", ["partial lane"], started=NOW - 65, log_mtime=NOW - 5)
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        self.assertTrue(row["cost_approximate"])
+        self.assertGreater(row["cost_usd"], 0.0)
+        self.assertEqual(row["cost_status"], "unknown")
+        self.assertEqual(row["cost_source"], "litellm")
+
+    def test_a_configured_route_still_wins_over_the_billing_provider(self):
+        # The other negative control: OMH's own configuration is the answer
+        # whenever it has one, so the fallback never overrides a route.
+        route_path = self.home / "routing" / "model-providers.json"
+        route_path.parent.mkdir(parents=True)
+        route_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "model_provider_routes/v1",
+                    "models": {
+                        "fable": {"provider": "gateway", "model": "anthropic/claude-fable-5-1"}
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        _build_state_db(
+            self.home,
+            [{
+                "id": "20260818_100100_routewin",
+                "model": "anthropic/claude-fable-5-1",
+                "started_at": NOW - 60,
+                "usage": {"billing_provider": "og", "output_tokens": 10, "last_seen": NOW - 5},
+            }],
+        )
+        row = read_hermes_native_subagents(self.home, now=NOW, omh_home=self.home)["rows"][0]
+        self.assertEqual(row["provider"], "gateway")
+        self.assertEqual(row["provider_source"], "model_provider_routes")
 
     def test_legacy_schema_preserves_usage_and_approximates_zero(self):
         _build_state_db(


### PR DESCRIPTION
## Feature Report

Part of #1466 — the HUD reader half. The `omh update` profile half is a separate PR (`claude/update-profile-registration`) per Delivery Grain: two capabilities, two PRs; the only link is that the reader fix would not have reached a frozen profile without the other.

### What Changed

- **Gateway children get a `~$` approximation.** `src/plugin_bundle/omh/hermes_delegation.py`: `_informative_cost_row_sql` counts, per session, usage rows whose provenance is a cost claim (a recorded status/source whose status is not Hermes' own `unknown` no-figure status); the approximation gate is now `not cost and not informative_cost_rows`. `_preferred_provenance_sql` surfaces the informative word for a mixed group. `billed_zero` / `included` / source-only rows are unchanged; an unpriceable child keeps `$0.0000 (unknown)`.
- **Empty `sessions.model` is filled from observation**, not inference: `_observed_wire_model` takes the sole distinct `session_model_usage.model`; two values or none leave the row as recorded.
- **Provider fallback for unrouted children**: `GROUP_CONCAT(DISTINCT NULLIF(billing_provider, ''))` → `_sole_distinct_value`; `provider_source: hermes_billing_provider` for JSON consumers (`read_omh_hud`, menubar/status). The TUI widget renders the model, not the provider.
- `src/omh/tui_widgets/omh-status.mjs`: comment block over `costSegmentText` states the rule and cites the Hermes lines; no rendering change (a successful approximation already renders `~$x.xxxx`).
- `MODEL_OPTI.md` cost-approximation bullet and `docs/INSTALLATION.md` cost paragraph describe the sentinel rule with the Hermes citations.
- Eleven new cases in `tests/test_plugin_hermes_delegation.py`, including the negatives: mixed group not approximated (and renders `included`), two usage models leave the model empty, two billing providers leave the provider empty, a configured route still wins.

### Why This Exists

Hermes' pricing produces no amount for a provider it has no rate for and stamps `cost_status="unknown"`, `cost_source="none"` (`agent/usage_pricing.py:549` `_unknown_cost`, called at :565/:583; persisted by `agent/turn_usage.py:236,257`). The reader treated any recorded word as a vouched zero — the right rule for `included`/`billed_zero`, the wrong one for the host's own "I have no figure". On the owner's live DB: 133 `unknown` rows (67 `og`, 65 `custom`), all at $0, four of them 700–860K-token Fable 5.1 runs rendered as `$0.0000 (unknown)`.

### User / Operator Impact

A HUD row for a gateway child now reads `~$9.0601` instead of `$0.0000 (unknown)` when OMH's price table knows the model; a child without a rate still reads `$0.0000 (unknown)`; a subscription/billed-zero child is untouched. JSON consumers see the billed provider for unrouted children.

### How It Works

- Rule: approximate when no row carries a cost claim. A claim = recorded status or source with status ≠ `unknown`. Every-row semantics via `SUM(CASE …)`; NULL/NULL and legacy schemas (no cost columns) count as no claim exactly as before.
- No host-vocabulary enumeration beyond the one word Hermes defines as "no figure"; the design comment cites the Hermes source, and the rule is combined with the group count so a single informative row anywhere in the session blocks approximation.

### Files And Contracts Touched

`src/plugin_bundle/omh/hermes_delegation.py`, `src/omh/tui_widgets/omh-status.mjs`, `tests/test_plugin_hermes_delegation.py`, `MODEL_OPTI.md`, `docs/INSTALLATION.md`. HUD payload: rows gain `provider_source: hermes_billing_provider` where applicable; no schema version change.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: the reader run read-only (`mode=ro`) against the owner's live `~/.hermes/state.db`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: rendered frame not captured; the reader rows are the observed surface (below)

### Observed Evidence

- Full suite: running on the committed tree; the `Ran … / OK` line is posted as a comment on this PR when it finishes.
- Targeted: `tests/test_plugin_hermes_delegation.py tests/test_tui_widget_pack.py tests/test_hud.py tests/test_hud_conversation_scope.py tests/test_menubar_status.py tests/test_broad_exception_policy.py tests/test_plugin_distribution.py` — 262 tests, OK.
- Gates: `docs navigation/workflows --check`, `release drift` — PASS; ruff, compileall, `git diff --check` — clean.
- Live read-only reader rows (owner DB, four 2026-09-07 og children): before — `cost_usd 0.0, cost_approximate null, cost_status unknown, cost_source none`; after — `cost_usd 9.06 / 11.99 / 11.15 / …, cost_approximate true`, `provider og`, `category architect`.
- Reviewer lane (read-only): provenance table traced against the new SQL for `billed_zero/gateway`, `included/subscription`, source-only, status-only, NULL/NULL, `unknown/none`, `unknown/''`, mixed, legacy schema — pinned cases preserved, mixed group not approximated; the blocker it raised on the combined change (opt-out reachability) lives on the companion branch; its findings 2–8 and 10 on this branch were confirmed closed on re-verification, and the four remaining nits it named as cosmetic are applied in this commit.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`: no harness/release/install contract changed.
- A rendered TUI frame: the widget's rendering code is unchanged; the reader payload is what was observed.

## Risk

- If Hermes later prices custom providers the sentinel stops firing on its own; a new host word must come with a Hermes source line.
- The empty-model fill has no live occurrence to observe; it is pinned by fixtures only.

## Compatibility / Rollout

- Reaches the owner machine through `omh update` + TUI restart; `profiles/*` need the companion PR to be refreshed at all.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Companion PR: `claude/update-profile-registration` (closes #1466).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfePFn3Q9axYU2fBGhpCMV
