### PR TITLE
fix(update): a Hermes profile registered at any OMH-managed skills path is registered, and opting out removes every one

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -864,18 +864,29 @@ zero OMH skills while the default chat has the full set.
 
 `omh setup` and `omh update` sync every profile automatically:
 
-- an already-registered profile is refreshed to the running version;
+- an already-registered profile is refreshed to the running version — its
+  plugin bundle, TUI widget, and skin, under the same manifest-checked
+  refusals the primary home gets;
 - a profile with no OMH bundle at all — including a bot created after
   install — gets the full bootstrap on the next `omh setup` or `omh update`;
 - a deliberately unregistered profile (see below) is left alone.
+
+"Registered" means the profile names any OMH-managed skills directory, not
+the exact one this install would write today. A profile registered at
+`~/.omh/skills` before the command install moved to its shared generation
+pointer is still registered: it gets refreshed and carried forward, not read
+as an opt-out and frozen on the generation it was installed at. Only a
+profile naming none of them has opted out.
 
 `omh uninstall` is symmetric with the sync. A full uninstall (`omh uninstall`,
 `--all`, or `--purge`) clears every profile's registration and removes its
 managed artifacts — the plugin bundle, the TUI widget, and the skin — through
 the same manifest checks the primary home gets: a profile directory OMH cannot
 prove it owns is kept and reported, never deleted blind. `--registration-only`
-unregisters every profile while keeping their plugin directories, which is
-exactly the deliberate opt-out state described below.
+removes every OMH-managed entry from each profile — the same directories the
+sync reads, so nothing is left behind for the next update to score as still
+registered — while keeping their plugin directories, which is exactly the
+deliberate opt-out state described below.
 
 After a sync, restart Hermes Desktop so bot chats reload their skills.
 
@@ -885,8 +896,10 @@ To keep OMH out of one bot, unregister that profile only:
 omh --hermes-home ~/.hermes/profiles/<name> uninstall --registration-only
 ```
 
-The plugin directory stays in place as the opt-out marker; setup and update
-never re-register a profile in that state.
+That removes every OMH-managed skills directory the profile's config named,
+whichever one it was registered at. The plugin directory stays in place as
+the opt-out marker; setup and update never re-register a profile in that
+state.
 
 OMH workflows are skill triggers, not Hermes slash commands, so they do not
 appear in the `/` autocomplete — in any chat, bot or default. Invoke them as

--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -85,8 +85,8 @@ from ..release import (
     package_url_for,
     release_artifact_note,
 )
-from ..skin_pack import SKIN_NAME, install_skin, is_omh_skin_name, uninstall_skin
-from ..tui_widget_pack import install_tui_widget, uninstall_tui_widget
+from ..skin_pack import SKIN_NAME, SkinInstallError, install_skin, is_omh_skin_name, uninstall_skin
+from ..tui_widget_pack import TuiWidgetInstallError, install_tui_widget, uninstall_tui_widget
 from ..routing.recommend import recommend_skills
 from ..routing.route_plan import build_workflow_route_plan, compact_workflow_route_plan
 from ..runtime.artifacts import read_state_result, update_state
@@ -483,15 +483,20 @@ def _sync_hermes_profiles(args: argparse.Namespace) -> list[dict[str, object]]:
     puts it back. A profile with no bundle at all is a new bot — it gets the
     full bootstrap, which is what makes bots created after install pick up
     OMH on the next `omh update`.
+
+    The opt-out test asks whether the profile names ANY managed skills
+    directory, not the one this install would write today: see
+    `_managed_workflow_dir_candidates`.
     """
     results: list[dict[str, object]] = []
     for name, profile_dir in _hermes_profile_dirs(_paths(args)):
         clone = argparse.Namespace(**vars(args))
         clone.hermes_home = str(profile_dir)
         profile_paths = _paths(clone)
-        registered = _external_dir_registered(
-            read_config(profile_paths.hermes_config_path),
-            _registered_workflow_dir(profile_paths),
+        config_text = read_config(profile_paths.hermes_config_path)
+        registered = any(
+            _external_dir_registered(config_text, candidate)
+            for candidate in _managed_workflow_dir_candidates(profile_paths)
         )
         if profile_paths.hermes_plugin_dir.is_dir() and not registered:
             results.append({"profile": name, "status": "unregistered_kept"})
@@ -505,7 +510,11 @@ def _sync_hermes_profiles(args: argparse.Namespace) -> list[dict[str, object]]:
             install_tui_widget(profile_paths.hermes_home, dry_run=bool(args.dry_run))
             install_skin(profile_paths.hermes_home, dry_run=bool(args.dry_run))
             _apply_result(clone)
-        except (PluginPackError, OmhError) as exc:
+        # A profile's widget or skin the manifest cannot vouch for refuses,
+        # exactly as the primary home's does. That refusal is one profile's
+        # row, never the end of the update: the primary home and every other
+        # profile still get their refresh.
+        except (PluginPackError, OmhError, TuiWidgetInstallError, SkinInstallError) as exc:
             entry["status"] = "failed"
             entry["error"] = str(exc)
         results.append(entry)
@@ -531,9 +540,9 @@ def _uninstall_hermes_profiles(args: argparse.Namespace, *, remove_all: bool) ->
         profile_paths = _paths(clone)
         entry: dict[str, object] = {"profile": name}
         try:
-            change = remove_external_dir(
+            change = _remove_managed_external_dirs(
                 read_config(profile_paths.hermes_config_path),
-                _registered_workflow_dir(profile_paths),
+                profile_paths,
             )
             if not args.dry_run and change.changed:
                 write_config(profile_paths.hermes_config_path, change.text)
@@ -590,6 +599,57 @@ def _registered_workflow_dir(paths: OmhPaths) -> Path:
     return paths.skills_dir
 
 
+def _managed_workflow_dir_candidates(paths: OmhPaths) -> list[Path]:
+    """Every managed skills directory a registration may legitimately name.
+
+    `_registered_workflow_dir` picks the ONE this install would write today:
+    the shared generation pointer on a managed command install, otherwise the
+    OMH home's own skills directory. Both are OMH-owned, and which of them a
+    given home recorded depends only on when it was registered — so a home
+    naming either one is registered, not opted out. Only a home naming
+    neither has actually opted out.
+
+    Reading "registered" as "names today's path" is what froze the owner's
+    `profiles/miku`: the profile pointed at `~/.omh/skills` while the primary
+    home had moved to the generation pointer, so every `omh update` scored it
+    as the deliberate opt-out (plugin directory present, registration
+    "absent"), skipped the whole profile, and left its plugin bundle and TUI
+    widget on the generation they were installed at.
+    """
+    candidates = [_registered_workflow_dir(paths)]
+    for candidate in (paths.skills_dir, managed_current_workflow_pack_dir()):
+        if candidate is not None and candidate not in candidates:
+            candidates.append(candidate)
+    return candidates
+
+
+def _remove_managed_external_dirs(config_text: str, paths: OmhPaths) -> ConfigChange:
+    """Strip every OMH-managed skills directory this home may carry.
+
+    Removal has to read the same set `_managed_workflow_dir_candidates` reads,
+    or the opt-out becomes unreachable on exactly the installs that need it:
+    removing only today's path left a home registered at the older one with
+    its entry intact and its plugin directory in place, so the next
+    `omh update` scored it registered again and refreshed it. Unregistering
+    means unregistered, whichever managed path recorded it.
+
+    The reported message is the first removal that actually changed the
+    config; with nothing to remove, the last no-op's message stands, exactly
+    as a single-path removal reported before.
+    """
+    changed = False
+    message = ""
+    for candidate in _managed_workflow_dir_candidates(paths):
+        change = remove_external_dir(config_text, candidate)
+        config_text = change.text
+        if change.changed and not changed:
+            changed = True
+            message = change.message
+        elif not changed:
+            message = change.message
+    return ConfigChange(changed, message, config_text)
+
+
 def _external_dir_registered(config: str, path: Path) -> bool:
     entries = external_dirs(config)
     wanted = _external_dir_key(path)
@@ -617,7 +677,14 @@ def _refresh_hermes_registration(args: argparse.Namespace) -> dict[str, object] 
     put it back.
     """
     paths = _paths(args)
-    if not _external_dir_registered(read_config(paths.hermes_config_path), _registered_workflow_dir(paths)):
+    config_text = read_config(paths.hermes_config_path)
+    # Same candidate set the profile sync reads: a primary home registered at
+    # the older managed path is registered, and must be carried forward
+    # rather than read as a deliberate unregistration.
+    if not any(
+        _external_dir_registered(config_text, candidate)
+        for candidate in _managed_workflow_dir_candidates(paths)
+    ):
         return None
     try:
         return _apply_result(args)
@@ -1670,7 +1737,7 @@ def cmd_uninstall(args: argparse.Namespace) -> int:
     paths = _paths(args)
     current = read_config(paths.hermes_config_path)
     try:
-        change = remove_external_dir(current, _registered_workflow_dir(paths))
+        change = _remove_managed_external_dirs(current, paths)
     except ValueError as exc:
         raise OmhError(str(exc)) from exc
     if not args.dry_run and change.changed:

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import errno
 import hashlib
 import importlib.resources as resources
@@ -1804,6 +1805,39 @@ class HermesProfileSyncTests(unittest.TestCase):
         profile.mkdir(parents=True, exist_ok=True)
         return profile
 
+    @contextmanager
+    def _managed_install(self, current: Path):
+        """What a managed command install looks like to the setup module.
+
+        Only the two probes are stubbed -- the generation pointer and the
+        managed-runtime answer a test process cannot give truthfully -- so
+        `_registered_workflow_dir` and the candidate list run for real. The
+        self-update plan is pinned off because a managed runtime is exactly
+        what would otherwise send `omh update` into the staged command
+        package transaction, which is not what these tests exercise.
+        """
+        with (
+            mock.patch.object(
+                _setup_module, "managed_current_workflow_pack_dir", return_value=current
+            ),
+            mock.patch.object(
+                _setup_module,
+                "_managed_command_runtime",
+                return_value={
+                    "managed": True,
+                    "reason": "",
+                    "python": sys.executable,
+                    "venv_dir": str(current.parent),
+                },
+            ),
+            mock.patch.object(
+                _setup_module,
+                "_command_package_self_update_plan",
+                return_value={"should_update": False, "reason": "test fixture"},
+            ),
+        ):
+            yield
+
     def test_setup_registers_every_bot_profile(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1879,6 +1913,143 @@ class HermesProfileSyncTests(unittest.TestCase):
             rows = {entry["profile"]: entry["status"] for entry in payload["hermes_profiles"]}
             self.assertEqual(rows, {"politehelper": "unregistered_kept"})
             self.assertEqual((profile / "config.yaml").read_text(encoding="utf-8"), config_before)
+
+    def test_a_profile_registered_at_the_other_managed_dir_is_refreshed(self) -> None:
+        # A managed command install registers the shared generation pointer;
+        # a home registered before that move names the OMH home's own skills
+        # directory. Both are OMH-owned, so a profile carrying the older of
+        # the two is registered — reading it as the deliberate opt-out is
+        # what froze one real profile's plugin bundle and TUI widget at the
+        # generation they were installed at, update after update.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile = self._profile(root, "politehelper")
+            status, _, stderr = run_cli(self._base(root) + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            widget = profile / "tui-widgets" / "omh-status.mjs"
+            self.assertTrue(widget.is_file())
+            # The profile stays registered at ~/.omh/skills while the
+            # command install moves on to a generation pointer.
+            self.assertIn(
+                (root / ".omh" / "skills").resolve().as_posix(),
+                (profile / "config.yaml").read_text(encoding="utf-8"),
+            )
+            widget.unlink()
+            generation = root / "generation" / "skills"
+            generation.mkdir(parents=True)
+
+            with self._managed_install(generation):
+                status, stdout, stderr = run_cli(
+                    self._base(root) + ["update"], output_json=False
+                )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("Bot profiles: politehelper (refreshed)", stdout)
+            # Refreshed means artifacts, not just a label.
+            self.assertTrue(widget.is_file())
+
+    def test_opting_out_removes_a_registration_at_the_older_managed_dir(self) -> None:
+        # Reading "registered" across both managed paths only works if
+        # removal reads the same set. Removing today's path alone left the
+        # older entry in place, so the opt-out never took: the profile kept
+        # its plugin directory AND a live registration, and the next update
+        # refreshed it again. This is the miku shape — the one install this
+        # whole change targets — so the opt-out has to be reachable on it.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile = self._profile(root, "politehelper")
+            status, _, stderr = run_cli(self._base(root) + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            old_path = (root / ".omh" / "skills").resolve().as_posix()
+            self.assertIn(old_path, (profile / "config.yaml").read_text(encoding="utf-8"))
+            current = root / "generation" / "skills"
+            current.mkdir(parents=True)
+
+            with self._managed_install(current):
+                status, _, stderr = run_cli(
+                    [
+                        "--omh-home",
+                        str(root / ".omh"),
+                        "--hermes-home",
+                        str(profile),
+                        "uninstall",
+                        "--registration-only",
+                    ]
+                )
+                self.assertEqual(status, 0, stderr)
+                config_after = (profile / "config.yaml").read_text(encoding="utf-8")
+                self.assertNotIn(old_path, config_after)
+                self.assertNotIn(current.as_posix(), config_after)
+                # The plugin directory stays: that plus no registration is
+                # the documented opt-out marker the sync must now respect.
+                self.assertTrue((profile / "plugins" / "omh").is_dir())
+
+                status, stdout, stderr = run_cli(
+                    self._base(root) + ["update"], output_json=False
+                )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("Bot profiles: politehelper (left unregistered)", stdout)
+
+    def test_opting_out_removes_a_registration_at_the_current_managed_dir(self) -> None:
+        # The mirror case: a home registered only at the generation pointer,
+        # with the older path absent, opts out identically.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile = self._profile(root, "politehelper")
+            current = root / "generation" / "skills"
+            current.mkdir(parents=True)
+
+            with self._managed_install(current):
+                status, _, stderr = run_cli(self._base(root) + ["setup"])
+                self.assertEqual(status, 0, stderr)
+                config = (profile / "config.yaml").read_text(encoding="utf-8")
+                self.assertIn(current.as_posix(), config)
+                self.assertNotIn((root / ".omh" / "skills").resolve().as_posix(), config)
+
+                status, _, stderr = run_cli(
+                    [
+                        "--omh-home",
+                        str(root / ".omh"),
+                        "--hermes-home",
+                        str(profile),
+                        "uninstall",
+                        "--registration-only",
+                    ]
+                )
+                self.assertEqual(status, 0, stderr)
+                self.assertNotIn(
+                    current.as_posix(), (profile / "config.yaml").read_text(encoding="utf-8")
+                )
+
+                status, stdout, stderr = run_cli(
+                    self._base(root) + ["update"], output_json=False
+                )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("Bot profiles: politehelper (left unregistered)", stdout)
+
+    def test_the_primary_home_opts_out_from_the_older_managed_dir_too(self) -> None:
+        # `cmd_uninstall` removes the primary home's own registration on the
+        # same path set, so an old-path primary home is not left registered
+        # and silently re-refreshed by the next update.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            status, _, stderr = run_cli(self._base(root) + ["setup"])
+            self.assertEqual(status, 0, stderr)
+            hermes_config = root / ".hermes" / "config.yaml"
+            old_path = (root / ".omh" / "skills").resolve().as_posix()
+            self.assertIn(old_path, hermes_config.read_text(encoding="utf-8"))
+            current = root / "generation" / "skills"
+            current.mkdir(parents=True)
+
+            with self._managed_install(current):
+                status, _, stderr = run_cli(
+                    self._base(root) + ["uninstall", "--registration-only"]
+                )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertNotIn(old_path, hermes_config.read_text(encoding="utf-8"))
 
     def test_a_dry_run_setup_writes_nothing_into_profiles(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Feature Report

Closes #1466 (the `omh update` half; the HUD reader half is the companion PR `claude/hud-gateway-cost-approx`).

### What Changed

- `src/commands/setup.py`: `_managed_workflow_dir_candidates(paths)` — every OMH-managed skills directory a registration may legitimately name (today's path, the home's own skills dir, the shared generation pointer). `_sync_hermes_profiles` treats a profile naming ANY of them as registered; only a profile naming none is the deliberate opt-out and stays `unregistered_kept`.
- `_remove_managed_external_dirs(config_text, paths)` strips every candidate; used by `cmd_uninstall` (primary home) and the per-profile uninstall loop, so `omh --hermes-home <profile> uninstall --registration-only` is reachable on a managed install whose profile was registered before the generation pointer existed. `_refresh_hermes_registration` reads the same candidate set.
- The per-profile `except` adds `TuiWidgetInstallError` and `SkinInstallError`: one profile's unmanaged widget/skin refuses that profile's row, not the whole update.
- `docs/INSTALLATION.md` profile section states the rule and the opt-out; four new tests in `tests/test_plugin_distribution.py` (`HermesProfileSyncTests`, with the real managed-runtime probes patched): a profile at the other managed dir is refreshed; opting out removes a registration at the older managed dir; at the current one; the primary home opts out from the older dir too.

### Why This Exists

The owner's `~/.hermes/profiles/miku/config.yaml` registers `~/.omh/skills` while `~/.hermes/config.yaml` registers the generation pointer `~/.local/share/omh/current/skills`. The opt-out heuristic asked for today's path only, scored miku as "unregistered + plugin dir present", and skipped it on every `omh update` since 2026-09-04: its plugin bundle and TUI widget stayed at that generation (pre-`3f5fa3b1`, the widget that still truncated `anthropic/…` labels) and every restart reloaded the stale files.

### User / Operator Impact

After merge, the next `omh update` prints `Bot profiles: miku (refreshed)` and the profile's plugin and widget follow the primary home; a TUI restart on that profile then renders the current generation. A profile that was opted out on purpose (no OMH skills registration at all) is still left alone, and the documented opt-out command now removes every managed registration.

### How It Works

Read and removal share one candidate set, so "registered" and "unregistered" are inverses again. Force/refuse semantics per profile are unchanged (each profile is its own Hermes home with its own manifests).

### Files And Contracts Touched

`src/commands/setup.py`, `tests/test_plugin_distribution.py`, `docs/INSTALLATION.md`. No manifest schema change.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: the frozen-profile and opt-out sequences on fixture homes (the four tests)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: `omh update` on the owner machine is the rollout step after merge, not a pre-merge check

### Observed Evidence

- Full suite: running on the committed tree; the `Ran … / OK` line is posted as a comment on this PR when it finishes.
- Targeted: `tests/test_plugin_distribution.py tests/test_staged_self_update.py tests/test_broad_exception_policy.py tests/test_interpreter_spawn_policy.py tests/test_plugin_hermes_delegation.py` — 171 tests, OK.
- Gates: `docs navigation/workflows --check`, `release drift` — PASS; ruff, compileall, `git diff --check` — clean.
- Reviewer lane (read-only): reproduced the frozen-profile sequence on `origin/main` (`left unregistered`) and the fixed behaviour; the blocker it raised (opt-out unreachable when only the read side widened) is what `_remove_managed_external_dirs` closes; verdict on this branch after re-verification: "mergeable as-is".

### Not Tested / Not Applicable

- `omh update` on the owner machine (rollout step); `harness validate` / `release checklist` / `release hermes-smoke`: no harness, release, or install-manifest contract changed.

## Risk

- A profile that an operator "opted out" by deleting only today's registration while an older one remained will now be refreshed — that state was never a documented opt-out, and the documented command now clears every registration.

## Compatibility / Rollout

- `omh update` + TUI restart per profile. The `profiles/miku` widget goes from the 2026-09-04 generation to current on the first update after merge.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Companion PR: `claude/hud-gateway-cost-approx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfePFn3Q9axYU2fBGhpCMV
