### PR TITLE
docs: gate the shipped chain table in docs/INSTALLATION.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,12 @@ jobs:
       - name: Generated ULW site region check
         if: matrix.shard == 0
         run: python -m omh.cli docs ulw-site --check
+      # The public shipped-chain table in docs/INSTALLATION.md agreed with the
+      # catalog only because whoever retired a model generation remembered the
+      # doc too. This step is what fails when they do not; it names the rows.
+      - name: Generated chain table region check
+        if: matrix.shard == 0
+        run: python -m omh.cli docs chain-table --check
       # Structure, not equality: a page can stay byte-identical to its producer
       # and still have left the public map. This gate is the one that notices.
       # The windows leg reaches the same verdict through

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,7 @@ uv run python -m omh.cli docs navigation --check
 uv run python -m omh.cli docs capability-families --check
 uv run python -m omh.cli docs ulw-inventory --check
 uv run python -m omh.cli docs ulw-site --check
+uv run python -m omh.cli docs chain-table --check
 uv run --group lint ruff check src tests
 git diff --check
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ uv run python -m compileall -q src tests                          # syntax gate
 uv run python -m omh.cli docs workflows --check                   # byte gate
 uv run python -m omh.cli docs roles --check                       # byte gate
 uv run python -m omh.cli docs claims --check --json               # selected claims
+uv run python -m omh.cli docs chain-table --check                 # byte gate
 uv run python -m omh.cli docs navigation --check                  # docs structure gate
 uv run --group lint ruff check src tests                          # static-analysis gate
 git diff --check
@@ -63,11 +64,19 @@ Source of truth → generated file → regen command → drift gate:
 | `capability_family_projection()` in `src/capabilities/families.py` | `src/plugin_bundle/omh/tools/capability_families.json` | `uv run python -m omh.cli docs capability-families` | `uv run python -m omh.cli docs capability-families --check`; dict-parity in `tests/test_plugin_capabilities.py` |
 | `ulw_inventory_payload()` in `src/skills/catalog.py` via `src/catalogs/ulw_surfaces.py` | marked ULW region of `README.md` | `uv run python -m omh.cli docs ulw-inventory` | `uv run python -m omh.cli docs ulw-inventory --check`; `tests/test_ulw_inventory.py` |
 | Same producer | marked ULW region of `site/index.html` | `uv run python -m omh.cli docs ulw-site` | `uv run python -m omh.cli docs ulw-site --check`; i18n parity in `tests/test_ulw_inventory.py` |
+| `SHIPPED_MODEL_RECOMMENDATIONS` in `src/coding/model_recommendations.py` via `src/catalogs/model_chain_table.py` | marked chain-table region of `docs/INSTALLATION.md` | `uv run python -m omh.cli docs chain-table` | `uv run python -m omh.cli docs chain-table --check`; round-trip equality in `tests/test_model_chain_table.py` |
 
 Rules:
 
-- Never hand-edit `skills/*/SKILL.md`, `docs/WORKFLOWS.md`, `docs/ROLES.md`, or
-  the demo-cards JSON. Edit the catalog/render source, regenerate, commit both.
+- Never hand-edit `skills/*/SKILL.md`, `docs/WORKFLOWS.md`, `docs/ROLES.md`, the
+  demo-cards JSON, or a marked region (ULW in `README.md` / `site/index.html`,
+  the shipped chain table in `docs/INSTALLATION.md`). Edit the catalog/render
+  source, regenerate, commit both.
+- A model generation that leaves or joins a shipped chain needs
+  `docs chain-table` rerun; a NEW mixture category also needs a
+  `CHAIN_SURFACE_PURPOSES` entry in `src/catalogs/model_chain_table.py`, and a
+  new model alias a `MODEL_DISPLAY_LABELS` entry. Both raise with the key to
+  add — the public table cannot stay silent about a shipped chain.
 - After any catalog or render change, rerun every `--check` gate before commit.
 - The gates are byte-exact comparisons. A one-character drift fails CI.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -264,23 +264,25 @@ applied.
 
 The shipped catalog is editorial policy, not benchmark output:
 
+<!-- omh:model-chain-table:begin (generated: uv run python -m omh.cli docs chain-table; source: src/coding/model_recommendations.py) -->
 | Surface | What it is for | Shipped editable order |
 | --- | --- | --- |
-| Hermes `main` suggestion | The session's own model | Kimi K3, Claude Fable 5.1, Claude Opus 5, GPT-6 Astra, GPT-5.6 Terra |
+| Hermes `main` suggestion | The session's own model | Kimi K3, Claude Fable 5.1, Claude Opus 5, GPT-6 Astra (`xhigh`), GPT-5.6 Terra (`high`) |
 | `ultrabrain` | Deepest reasoning | GPT-6 Astra (`xhigh`) |
-| `deep` | Strong default tier | GPT-5.6 Terra, DeepSeek Flash (V4.1) (`high`) |
-| `architect` | Architecture and system design | Claude Fable 5.1, GPT-6 Astra, Kimi K3 (`xhigh`) |
-| `unspecified-high` | Default working model | Kimi K3, Claude Opus 5 |
-| `unspecified-low` | Cheaper fallback | GLM 5.3, DeepSeek Flash (V4.1), Claude Opus 5 (low) |
-| `visual-engineering` | Frontend and visual | Claude Fable 5.1, Kimi K3 |
-| `quick` | Short tasks | GLM 5.3 Flash, Kimi K3, GPT-5.6 Luna, Claude Fable 5.1 (low) |
-| `writing` | Prose and docs | Kimi K3, Qwen3-Coder, Gemini 3.1 Pro |
-| `artistry` | Unconventional work | Gemini 3.1 Pro, Claude Fable 5.1, Kimi K3 |
-| `capable` | Strong general work | Claude Fable 5.1, Claude Opus 5, Kimi K3, GLM 5.3 (`medium`) |
-| `simple-work` | Small everyday tasks | GPT-5.6 Luna, DeepSeek Flash (V4.1), Claude Haiku 4.5 (`low`) |
+| `deep` | Strong default tier | GPT-5.6 Terra (`high`), DeepSeek Flash (V4.1) (`high`) |
+| `architect` | Architecture and system design | Claude Fable 5.1 (`xhigh`), GPT-6 Astra (`xhigh`), Kimi K3 (`xhigh`) |
+| `unspecified-high` | Default working model | Kimi K3 (`medium`), Claude Opus 5 (`medium`) |
+| `unspecified-low` | Cheaper fallback | GLM 5.3 (`low`), DeepSeek Flash (V4.1) (`low`), Claude Opus 5 (`low`) |
+| `quick` | Short tasks | GLM 5.3 Flash (`low`), Kimi K3 (`low`), GPT-5.6 Luna (`low`), Claude Fable 5.1 (`low`) |
+| `writing` | Prose and docs | Kimi K3 (`medium`), Qwen3-Coder (`medium`), Gemini 3.1 Pro (`medium`) |
+| `visual-engineering` | Frontend and visual | Claude Fable 5.1 (`high`), Kimi K3 (`high`) |
+| `artistry` | Unconventional work | Gemini 3.1 Pro (`high`), Claude Fable 5.1 (`high`), Kimi K3 (`high`) |
+| `capable` | Strong general work | Claude Fable 5.1 (`medium`), Claude Opus 5 (`medium`), Kimi K3 (`medium`), GLM 5.3 (`medium`) |
+| `simple-work` | Small everyday tasks | GPT-5.6 Luna (`low`), DeepSeek Flash (V4.1) (`low`), Claude Haiku 4.5 (`low`) |
 | `deep-work` | Long tasks at frontier depth | GPT-6 Astra (`high`) |
-| `x_platform_data` affinity | X-platform data affinity | Grok, Kimi K3, Gemini |
-| Shared final order (`last_resort.any`) | Last resort when a chain is exhausted | Claude Opus 5, GPT-5.6 Sol |
+| `x_platform_data` affinity | X-platform data affinity | Grok Code Fast, Kimi K3, Gemini 3.1 Pro |
+| Shared final order (`last_resort.any`) | Last resort when a chain is exhausted | Claude Opus 5, GPT-5.6 Sol (`medium`) |
+<!-- omh:model-chain-table:end -->
 
 Chain customization is a config edit, not a source edit — `omh model-chains
 show` prints the current per-category state, `omh model-chains interview`

--- a/docs/MODEL-ONBOARDING.md
+++ b/docs/MODEL-ONBOARDING.md
@@ -233,7 +233,8 @@ Files that move together (grep the old id to find every site):
 | Maestro-lane built-in table + executor option rows | `src/coding/model_routing.py` (`BUILTIN_CATEGORY_MODELS`, `EXECUTOR_MODEL_OPTIONS`) |
 | `model-setup` skill text naming the chains verbatim | `src/skills/catalog_definitions.py` → regenerate `skills/omh-model-setup/SKILL.md` and `docs/WORKFLOWS.md` |
 | Skill body budget note | `src/maintenance/release.py` (`FULL_PROFILE_SKILL_BODY_CHAR_LIMIT`, add the `old -> new` line) |
-| Public chain tables | `README.md`, `README.ko.md`, `README.ja.md`, `README.zh.md`, `docs/INSTALLATION.md`, `site/index.html`, `site/docs/model-routing/index.html` (`tests/test_model_recommendations.py` reads all seven) |
+| Hand-maintained public chain tables | `README.md`, `README.ko.md`, `README.ja.md`, `README.zh.md`, `site/index.html`, `site/docs/model-routing/index.html` (`tests/test_model_recommendations.py` reads those six and checks alias order inside each category row) |
+| Generated public chain table | `docs/INSTALLATION.md` is not hand-edited: its marked region renders from `SHIPPED_MODEL_RECOMMENDATIONS` through `src/catalogs/model_chain_table.py`. Run `uv run python -m omh.cli docs chain-table` and add the new alias to `MODEL_DISPLAY_LABELS` there — the renderer raises with the key to add when it is missing |
 | Pinned-chain and fallback-count tests | `tests/test_model_recommendations.py`, `tests/test_model_recommendation_routing.py`, `tests/test_model_routing_journey.py`, `tests/test_delegate_route_tool.py`, `tests/test_model_routing.py`, `tests/test_category_maestro.py`, `tests/test_task_scale_routing.py`, `tests/test_model_chains_command.py`, `tests/test_provider_entitlements.py` (chain-shaping cases), `tests/test_plugin_hermes_delegation.py` (route-provenance and reader fixtures name a chain member) — pins live in fixtures as well as assertions, so grep `tests/` for the old id and start the full suite in the background before the first doc edit, not after |
 | Retired-alias list (an alias that left every chain but stays routable) | `_RECOGNITION_ONLY_ALIAS_FAMILIES` in `tests/test_provider_entitlements.py` |
 | Contract audit doc paths | `_MODEL_DOCS` in `src/coding/model_contract_coverage.py` |
@@ -295,6 +296,7 @@ uv run python -m omh.cli docs roles --check
 uv run python -m omh.cli docs capability-families --check
 uv run python -m omh.cli docs ulw-inventory --check
 uv run python -m omh.cli docs ulw-site --check
+uv run python -m omh.cli docs chain-table --check
 uv run python -m omh.cli release drift
 uv run --group lint ruff check src tests
 git diff --check

--- a/src/catalogs/model_chain_table.py
+++ b/src/catalogs/model_chain_table.py
@@ -1,0 +1,332 @@
+"""Generated public projection of the shipped model recommendation chains.
+
+`docs/INSTALLATION.md` publishes the shipped chains as a reader-facing table.
+Before this module the table was hand-maintained: it agreed with
+`SHIPPED_MODEL_RECOMMENDATIONS` only for as long as whoever retired a model
+generation remembered to edit the doc too, and nothing failed when they did
+not. Every other public projection of catalog data in this repository is byte-
+or equality-gated, so this one was the exception.
+
+The producer renders the whole marked region (markers included) from the
+catalog, and `omh docs chain-table --check` compares bytes, which takes the
+table out of human hands the same way the ULW regions are.
+
+Two things the table shows do not exist as catalog data, so they live here and
+only here:
+
+- The display label for a model alias (`claude-fable-5-1` -> `Claude Fable
+  5.1`). The alias is what routing uses; the label is what a reader needs.
+- The "What it is for" phrase per surface. This is editorial one-line prose,
+  and the same strings are already duplicated into `site/i18n.js` under the
+  `chain.*` keys; source is the better home for them.
+
+Both are required, not defaulted: a chain surface with no phrase, or a model
+with no label, raises with the key to add and the command to rerun. A new
+mixture category therefore cannot reach the shipped chains while staying
+invisible in the public table — which is the point of the gate.
+
+Effort is rendered from the catalog, never assumed, and always on the entry
+that declares it. The hand-written table used a trailing token for a row whose
+entries all shared an effort, which reads shorter but cannot be read back: in
+`Claude Opus 5, GPT-5.6 Sol (medium)` the token could belong to the row or to
+Sol alone, and for `last_resort.any` it belongs to Sol alone. One rule --
+`Label (effort)` per entry, nothing at all for an entry that declares none --
+is longer on the uniform rows and unambiguous on every row, which is what lets
+`tests/test_model_chain_table.py` read the table back into aliases and efforts
+and compare it against the catalog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Mapping, Sequence
+
+from ..coding.model_recommendations import (
+    HERMES_MODEL_SETUP_ROLE_SLOTS,
+    MODEL_RECOMMENDATION_DOMAINS,
+    MODEL_RECOMMENDATION_LAST_RESORT_SLOTS,
+    SHIPPED_MODEL_RECOMMENDATIONS,
+)
+from ..coding.model_routing import MODEL_CATEGORIES
+
+MODEL_CHAIN_TABLE_REGION_BEGIN: Final[str] = (
+    "<!-- omh:model-chain-table:begin "
+    "(generated: uv run python -m omh.cli docs chain-table; "
+    "source: src/coding/model_recommendations.py) -->"
+)
+MODEL_CHAIN_TABLE_REGION_END: Final[str] = "<!-- omh:model-chain-table:end -->"
+
+MODEL_CHAIN_TABLE_PATH: Final[str] = "docs/INSTALLATION.md"
+_SOURCE_MODULE: Final[str] = "src/catalogs/model_chain_table.py"
+_REGEN_COMMAND: Final[str] = "uv run python -m omh.cli docs chain-table"
+
+# Reader-facing label per model alias. `deepseek-flash` keeps its version in
+# the label because the alias is the vendor's served pointer id and the
+# generation behind it is the thing a reader is checking.
+MODEL_DISPLAY_LABELS: Final[dict[str, str]] = {
+    "claude-fable-5-1": "Claude Fable 5.1",
+    "claude-haiku-4-5": "Claude Haiku 4.5",
+    "claude-opus-5": "Claude Opus 5",
+    "deepseek-flash": "DeepSeek Flash (V4.1)",
+    "gemini-3.1-pro": "Gemini 3.1 Pro",
+    "glm-5.3": "GLM 5.3",
+    "glm-5.3-flash": "GLM 5.3 Flash",
+    "gpt-5.6-luna": "GPT-5.6 Luna",
+    "gpt-5.6-sol": "GPT-5.6 Sol",
+    "gpt-5.6-terra": "GPT-5.6 Terra",
+    "gpt-6-astra": "GPT-6 Astra",
+    "grok-code-fast": "Grok Code Fast",
+    "kimi-k3": "Kimi K3",
+    "qwen3-coder": "Qwen3-Coder",
+}
+
+# One editorial phrase per chain surface, keyed by the row id built below.
+# Categories are keyed by their bare category name so a new category needs one
+# obvious line here. Every phrase is the one its surface already published --
+# in the hand-written table this region replaces, and in `site/i18n.js` under
+# the matching `chain.*` key, which also carries the ko/ja/zh translations.
+# Adding a category means moving its existing phrase here, not writing a new
+# one; keep the register of the neighbours.
+CHAIN_SURFACE_PURPOSES: Final[dict[str, str]] = {
+    "role.main": "The session's own model",
+    "ultrabrain": "Deepest reasoning",
+    "deep": "Strong default tier",
+    "architect": "Architecture and system design",
+    "unspecified-high": "Default working model",
+    "unspecified-low": "Cheaper fallback",
+    "quick": "Short tasks",
+    "writing": "Prose and docs",
+    "visual-engineering": "Frontend and visual",
+    "artistry": "Unconventional work",
+    "capable": "Strong general work",
+    "simple-work": "Small everyday tasks",
+    "deep-work": "Long tasks at frontier depth",
+    "domain.x_platform_data": "X-platform data affinity",
+    "last_resort.any": "Last resort when a chain is exhausted",
+}
+
+_EMPTY_CHAIN_CELL: Final[str] = "(none shipped)"
+_TABLE_HEADER: Final[tuple[str, str]] = (
+    "| Surface | What it is for | Shipped editable order |",
+    "| --- | --- | --- |",
+)
+
+
+@dataclass(frozen=True)
+class ChainTableRow:
+    """One rendered row: its id, the two label cells, and the order cell."""
+
+    row_id: str
+    surface: str
+    purpose: str
+    order: str
+
+
+def _purpose(row_id: str) -> str:
+    try:
+        return CHAIN_SURFACE_PURPOSES[row_id]
+    except KeyError:
+        raise ValueError(
+            f"chain surface {row_id!r} has no 'What it is for' phrase: add "
+            f"CHAIN_SURFACE_PURPOSES[{row_id!r}] in {_SOURCE_MODULE}, then run {_REGEN_COMMAND}"
+        ) from None
+
+
+def _label(model_alias: str) -> str:
+    try:
+        return MODEL_DISPLAY_LABELS[model_alias]
+    except KeyError:
+        raise ValueError(
+            f"model alias {model_alias!r} has no display label: add "
+            f"MODEL_DISPLAY_LABELS[{model_alias!r}] in {_SOURCE_MODULE}, then run {_REGEN_COMMAND}"
+        ) from None
+
+
+def _entries(section: object, key: str) -> tuple[dict[str, str], ...]:
+    """Return (alias, effort) pairs for one catalog slot, or () when absent."""
+    if not isinstance(section, Mapping):
+        return ()
+    chain = section.get(key)
+    if not isinstance(chain, Sequence) or isinstance(chain, (str, bytes)):
+        return ()
+    entries: list[dict[str, str]] = []
+    for candidate in chain:
+        if not isinstance(candidate, Mapping):
+            continue
+        entries.append(
+            {
+                "model_alias": str(candidate.get("model_alias", "")),
+                "reasoning_effort": str(candidate.get("reasoning_effort", "")),
+            }
+        )
+    return tuple(entries)
+
+
+def _render_order(entries: Sequence[Mapping[str, str]]) -> str:
+    """Render one chain as reader-facing labels plus per-entry declared effort.
+
+    Every declared effort is annotated on its own entry, and an entry that
+    declares none carries no token: the catalog's empty string means the lane
+    inherits, and printing a guess there would turn a missing value into a
+    claim. See the module docstring for why there is no shorter row-wide form.
+    """
+    if not entries:
+        return _EMPTY_CHAIN_CELL
+    parts: list[str] = []
+    for entry in entries:
+        label = _label(entry["model_alias"])
+        effort = entry["reasoning_effort"]
+        parts.append(f"{label} (`{effort}`)" if effort else label)
+    return ", ".join(parts)
+
+
+def chain_table_rows(
+    catalog: Mapping[str, object] = SHIPPED_MODEL_RECOMMENDATIONS,
+) -> tuple[ChainTableRow, ...]:
+    """Project every shipped chain surface, in catalog vocabulary order.
+
+    The enumeration walks the four closed vocabularies rather than the
+    catalog's own keys, so a surface that gains a chain cannot stay out of the
+    public table and a surface that loses one still renders as `(none
+    shipped)` instead of disappearing without a trace.
+    """
+    rows: list[ChainTableRow] = []
+    for slot in HERMES_MODEL_SETUP_ROLE_SLOTS:
+        row_id = f"role.{slot}"
+        rows.append(
+            ChainTableRow(
+                row_id,
+                f"Hermes `{slot}` suggestion",
+                _purpose(row_id),
+                _render_order(_entries(catalog.get("role_suggestions"), slot)),
+            )
+        )
+    for category in MODEL_CATEGORIES:
+        rows.append(
+            ChainTableRow(
+                category,
+                f"`{category}`",
+                _purpose(category),
+                _render_order(_entries(catalog.get("categories"), category)),
+            )
+        )
+    for domain in MODEL_RECOMMENDATION_DOMAINS:
+        row_id = f"domain.{domain}"
+        rows.append(
+            ChainTableRow(
+                row_id,
+                f"`{domain}` affinity",
+                _purpose(row_id),
+                _render_order(_entries(catalog.get("domain_affinities"), domain)),
+            )
+        )
+    for slot in MODEL_RECOMMENDATION_LAST_RESORT_SLOTS:
+        row_id = f"last_resort.{slot}"
+        rows.append(
+            ChainTableRow(
+                row_id,
+                f"Shared final order (`last_resort.{slot}`)",
+                _purpose(row_id),
+                _render_order(_entries(catalog.get("last_resort"), slot)),
+            )
+        )
+    return tuple(rows)
+
+
+def model_chain_table_region() -> str:
+    """The generated chain table, markers included, no trailing newline."""
+    lines = [MODEL_CHAIN_TABLE_REGION_BEGIN, *_TABLE_HEADER]
+    for row in chain_table_rows():
+        lines.append(f"| {row.surface} | {row.purpose} | {row.order} |")
+    lines.append(MODEL_CHAIN_TABLE_REGION_END)
+    return "\n".join(lines)
+
+
+def _region_bounds(text: str) -> tuple[int, int]:
+    begin, end = MODEL_CHAIN_TABLE_REGION_BEGIN, MODEL_CHAIN_TABLE_REGION_END
+    if text.count(begin) != 1 or text.count(end) != 1:
+        raise ValueError(
+            f"{MODEL_CHAIN_TABLE_PATH} must contain the markers {begin!r} and {end!r} "
+            "exactly once each; restore them from git or re-add the region by hand once"
+        )
+    start = text.index(begin)
+    stop = text.index(end) + len(end)
+    if stop < start:
+        raise ValueError(
+            f"{MODEL_CHAIN_TABLE_PATH} has its chain-table end marker before the begin marker"
+        )
+    return start, stop
+
+
+def installation_with_generated_region(text: str) -> str:
+    """Return `text` with its chain-table region replaced by the generated one."""
+    start, stop = _region_bounds(text)
+    return text[:start] + model_chain_table_region() + text[stop:]
+
+
+def _parsed_rows(region: str) -> dict[str, tuple[str, str]]:
+    """Map the surface cell to (purpose, order) for every table row present."""
+    parsed: dict[str, tuple[str, str]] = {}
+    for line in region.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|") or not stripped.endswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) != 3:
+            continue
+        if cells[0] in {"Surface", "---"}:
+            continue
+        parsed[cells[0]] = (cells[1], cells[2])
+    return parsed
+
+
+def model_chain_table_drift(text: str) -> tuple[str, ...]:
+    """Name every disagreement between the documented table and the chains.
+
+    A byte comparison alone reports that the region is stale, which is the
+    symptom; these findings are the cause, one line per row, so the reader
+    knows which chain moved without diffing the file by hand.
+    """
+    start, stop = _region_bounds(text)
+    current = text[start:stop]
+    if current == model_chain_table_region():
+        return ()
+    documented = _parsed_rows(current)
+    expected = {row.surface: (row.purpose, row.order) for row in chain_table_rows()}
+    findings: list[str] = []
+    for surface, (purpose, order) in expected.items():
+        if surface not in documented:
+            findings.append(
+                f"row {surface} is a shipped chain surface but is missing from the table "
+                f"(expected: {purpose} | {order})"
+            )
+            continue
+        documented_purpose, documented_order = documented[surface]
+        if documented_order != order:
+            findings.append(
+                f"row {surface} documents the order {documented_order!r} "
+                f"but the shipped chain renders {order!r}"
+            )
+        if documented_purpose != purpose:
+            findings.append(
+                f"row {surface} documents the purpose {documented_purpose!r} "
+                f"but the catalog declares {purpose!r}"
+            )
+    for surface in documented:
+        if surface not in expected:
+            findings.append(
+                f"row {surface} is documented but is not a shipped chain surface"
+            )
+    documented_order_of_rows = [key for key in documented if key in expected]
+    expected_order_of_rows = [key for key in expected if key in documented]
+    if documented_order_of_rows != expected_order_of_rows:
+        findings.append(
+            "table rows are in a different order than the catalog: documented "
+            f"{documented_order_of_rows}, catalog {expected_order_of_rows}"
+        )
+    if not findings:
+        findings.append(
+            "the region text differs from the generated table outside the row cells "
+            "(header, separator, spacing, or marker line)"
+        )
+    return tuple(findings)

--- a/src/commands/docs.py
+++ b/src/commands/docs.py
@@ -138,6 +138,43 @@ def _sync_ulw_region(*, path: Path, check: bool, label: str, site: bool = False)
     return 0
 
 
+def cmd_docs_chain_table(args: argparse.Namespace) -> int:
+    """Write or check the generated shipped-chain table region.
+
+    The failure path names the rows that disagree, not just the file: the byte
+    comparison knows the region is stale, and `model_chain_table_drift` knows
+    which chain moved, so the message carries both.
+    """
+    from ..catalogs.model_chain_table import (
+        installation_with_generated_region,
+        model_chain_table_drift,
+    )
+
+    path = Path(args.path).expanduser().resolve()
+    label = "shipped chain table region"
+    try:
+        current = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise OmhError(f"{label} check failed: {exc}") from exc
+    try:
+        updated = installation_with_generated_region(current)
+        findings = model_chain_table_drift(current)
+    except ValueError as exc:
+        raise OmhError(f"{label} check failed: {exc}") from exc
+    if args.check:
+        if current != updated:
+            raise OmhError(
+                f"{label} is stale: {path}: {'; '.join(findings)}. "
+                "Regenerate with: uv run python -m omh.cli docs chain-table"
+            )
+        _print_json({"ok": True, "checked": str(path)})
+        return 0
+    if updated != current:
+        atomic_write_text(path, updated)
+    _print_json({"written": str(path), "rewritten": updated != current})
+    return 0
+
+
 def cmd_docs_skill_trigger_report(args: argparse.Namespace) -> int:
     from ..skills.trigger_review import skill_trigger_review_payload
 
@@ -372,6 +409,14 @@ def _add_docs_commands(sub) -> None:
     docs_ulw_site.add_argument("--path", default="site/index.html")
     docs_ulw_site.add_argument("--check", action="store_true")
     docs_ulw_site.set_defaults(func=cmd_docs_ulw_site)
+
+    docs_chain_table = docs_sub.add_parser(
+        "chain-table",
+        help="Write or check the generated shipped model-chain table region of docs/INSTALLATION.md.",
+    )
+    docs_chain_table.add_argument("--path", default="docs/INSTALLATION.md")
+    docs_chain_table.add_argument("--check", action="store_true")
+    docs_chain_table.set_defaults(func=cmd_docs_chain_table)
 
     docs_skill_context_cost = docs_sub.add_parser(
         "skill-context-cost",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14101,6 +14101,43 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
         self.assertEqual(status, 2)
         self.assertIn("cannot be combined", stderr)
 
+    def test_docs_chain_table_command_generates_checks_and_names_stale_rows(self) -> None:
+        status, stdout, stderr = run_cli(["docs", "chain-table", "--check"])
+        self.assertEqual(stderr, "")
+        self.assertEqual(status, 0)
+        self.assertTrue(json.loads(stdout)["ok"])
+
+        with TemporaryDirectory() as tmp:
+            stale_copy = Path(tmp) / "INSTALLATION.md"
+            stale_copy.write_text(
+                Path("docs/INSTALLATION.md")
+                .read_text(encoding="utf-8")
+                .replace("| `ultrabrain` | Deepest reasoning |", "| `ultrabrain` | Deepest thinking |"),
+                encoding="utf-8",
+            )
+            status, _, stderr = run_cli(["docs", "chain-table", "--check", "--path", str(stale_copy)])
+            self.assertEqual(status, 2)
+            self.assertIn("stale", stderr)
+            # The row and both strings, not just the file: a reader must not
+            # have to diff the document to learn which chain moved.
+            self.assertIn("`ultrabrain`", stderr)
+            self.assertIn("Deepest thinking", stderr)
+            self.assertIn("Deepest reasoning", stderr)
+            self.assertIn("docs chain-table", stderr)
+
+            status, stdout, stderr = run_cli(["docs", "chain-table", "--path", str(stale_copy)])
+            self.assertEqual(stderr, "")
+            self.assertEqual(status, 0)
+            self.assertTrue(json.loads(stdout)["rewritten"])
+            status, _, stderr = run_cli(["docs", "chain-table", "--check", "--path", str(stale_copy)])
+            self.assertEqual(status, 0)
+
+            no_markers = Path(tmp) / "NO_MARKERS.md"
+            no_markers.write_text("no generated region here\n", encoding="utf-8")
+            status, _, stderr = run_cli(["docs", "chain-table", "--check", "--path", str(no_markers)])
+            self.assertEqual(status, 2)
+            self.assertIn("markers", stderr)
+
     def test_harness_cli_lists_inspects_and_validates_contracts(self) -> None:
         status, stdout, stderr = run_cli(["harness", "list"])
         self.assertEqual(stderr, "")

--- a/tests/test_model_chain_table.py
+++ b/tests/test_model_chain_table.py
@@ -1,0 +1,243 @@
+"""Contract for the generated shipped-chain table in docs/INSTALLATION.md.
+
+The table is the public projection of `SHIPPED_MODEL_RECOMMENDATIONS`. It was
+hand-maintained until this module's producer existed, so these tests pin both
+halves of the gate:
+
+1. the checked-in region is current, and the projection is faithful in the
+   direction the byte check cannot see -- every documented display label maps
+   back to the alias and effort the catalog actually ships;
+2. the failure surface. A stale table must name the row and both strings, a
+   missing purpose or display label must name the key to add, and a surface
+   that gains or loses a chain must be reported as that row rather than as a
+   byte difference somewhere in a file.
+
+Point 2 is deliberate: a projection gate whose only output is "stale" sends
+the reader diffing the whole document to find which chain moved.
+"""
+
+from __future__ import annotations
+
+import unittest
+from copy import deepcopy
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.catalogs.model_chain_table import (
+    CHAIN_SURFACE_PURPOSES,
+    MODEL_CHAIN_TABLE_PATH,
+    MODEL_CHAIN_TABLE_REGION_BEGIN,
+    MODEL_CHAIN_TABLE_REGION_END,
+    MODEL_DISPLAY_LABELS,
+    chain_table_rows,
+    installation_with_generated_region,
+    model_chain_table_drift,
+    model_chain_table_region,
+)
+from omh.coding.model_recommendations import (
+    HERMES_MODEL_SETUP_ROLE_SLOTS,
+    MODEL_RECOMMENDATION_DOMAINS,
+    MODEL_RECOMMENDATION_LAST_RESORT_SLOTS,
+    SHIPPED_MODEL_RECOMMENDATIONS,
+)
+from omh.coding.model_routing import MODEL_CATEGORIES
+from omh.maintenance.drift import repo_root_default
+
+REPO_ROOT = repo_root_default()
+
+
+def _installation_text() -> str:
+    return (REPO_ROOT / MODEL_CHAIN_TABLE_PATH).read_text(encoding="utf-8")
+
+
+def _catalog_chain(section: str, key: str) -> list[tuple[str, str]]:
+    chain = SHIPPED_MODEL_RECOMMENDATIONS[section][key]  # type: ignore[index]
+    return [(entry["model_alias"], entry["reasoning_effort"]) for entry in chain]
+
+
+def _documented_chain(order_cell: str) -> list[tuple[str, str]]:
+    """Read one rendered order cell back into (alias, effort) pairs.
+
+    The reader is the inverse of the renderer: one effort token per entry,
+    bound to that entry, and no token where the catalog declares none. Labels
+    resolve through the same map the renderer used, so a label that does not
+    round-trip fails here instead of reading as plausible prose.
+    """
+    label_to_alias = {label: alias for alias, label in MODEL_DISPLAY_LABELS.items()}
+    entries: list[tuple[str, str]] = []
+    # No shipped display label contains a comma, so ", " separates entries.
+    for chunk in order_cell.split(", "):
+        chunk = chunk.strip()
+        effort = ""
+        if chunk.endswith("`)") and " (`" in chunk:
+            chunk, _, tail = chunk.rpartition(" (`")
+            effort = tail[:-2]
+        entries.append((label_to_alias[chunk], effort))
+    return entries
+
+
+class GeneratedChainTableTests(unittest.TestCase):
+    def test_checked_in_region_is_current(self) -> None:
+        text = _installation_text()
+        self.assertIn(MODEL_CHAIN_TABLE_REGION_BEGIN, text)
+        self.assertIn(MODEL_CHAIN_TABLE_REGION_END, text)
+        self.assertEqual(installation_with_generated_region(text), text)
+        self.assertEqual(model_chain_table_drift(text), ())
+
+    def test_every_shipped_chain_surface_has_a_row(self) -> None:
+        rows = chain_table_rows()
+        expected_ids = (
+            [f"role.{slot}" for slot in HERMES_MODEL_SETUP_ROLE_SLOTS]
+            + list(MODEL_CATEGORIES)
+            + [f"domain.{domain}" for domain in MODEL_RECOMMENDATION_DOMAINS]
+            + [f"last_resort.{slot}" for slot in MODEL_RECOMMENDATION_LAST_RESORT_SLOTS]
+        )
+        self.assertEqual([row.row_id for row in rows], expected_ids)
+        documented = _installation_text()
+        for row in rows:
+            self.assertIn(f"| {row.surface} | {row.purpose} | {row.order} |", documented)
+
+    def test_documented_orders_round_trip_to_the_catalog(self) -> None:
+        """The byte gate proves the doc equals the renderer; this proves the
+        renderer equals the catalog, alias and effort included."""
+        by_id = {row.row_id: row for row in chain_table_rows()}
+        for slot in HERMES_MODEL_SETUP_ROLE_SLOTS:
+            self.assertEqual(
+                _documented_chain(by_id[f"role.{slot}"].order),
+                _catalog_chain("role_suggestions", slot),
+            )
+        for category in MODEL_CATEGORIES:
+            self.assertEqual(
+                _documented_chain(by_id[category].order),
+                _catalog_chain("categories", category),
+            )
+        for domain in MODEL_RECOMMENDATION_DOMAINS:
+            self.assertEqual(
+                _documented_chain(by_id[f"domain.{domain}"].order),
+                _catalog_chain("domain_affinities", domain),
+            )
+        for slot in MODEL_RECOMMENDATION_LAST_RESORT_SLOTS:
+            self.assertEqual(
+                _documented_chain(by_id[f"last_resort.{slot}"].order),
+                _catalog_chain("last_resort", slot),
+            )
+
+    def test_undeclared_effort_prints_no_token(self) -> None:
+        """`role.main` mixes declared and undeclared effort, which is exactly
+        the row a trailing-token rendering would have made unreadable."""
+        main = {row.row_id: row for row in chain_table_rows()}["role.main"]
+        self.assertEqual(
+            main.order,
+            "Kimi K3, Claude Fable 5.1, Claude Opus 5, "
+            "GPT-6 Astra (`xhigh`), GPT-5.6 Terra (`high`)",
+        )
+
+    def test_every_declared_effort_is_annotated_on_its_own_entry(self) -> None:
+        architect = {row.row_id: row for row in chain_table_rows()}["architect"]
+        self.assertEqual(
+            architect.order,
+            "Claude Fable 5.1 (`xhigh`), GPT-6 Astra (`xhigh`), Kimi K3 (`xhigh`)",
+        )
+
+    def test_empty_chain_renders_without_inventing_a_model(self) -> None:
+        catalog = deepcopy(dict(SHIPPED_MODEL_RECOMMENDATIONS))
+        catalog["categories"] = dict(catalog["categories"])  # type: ignore[arg-type]
+        catalog["categories"]["artistry"] = []  # type: ignore[index]
+        row = {row.row_id: row for row in chain_table_rows(catalog)}["artistry"]
+        self.assertEqual(row.order, "(none shipped)")
+
+
+class ChainTableFailureSurfaceTests(unittest.TestCase):
+    def test_stale_row_is_named_with_both_orders(self) -> None:
+        text = _installation_text().replace(
+            "| `ultrabrain` | Deepest reasoning | GPT-6 Astra (`xhigh`) |",
+            "| `ultrabrain` | Deepest reasoning | GPT-5.6 Sol (`xhigh`) |",
+        )
+        findings = model_chain_table_drift(text)
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("`ultrabrain`", findings[0])
+        self.assertIn("GPT-5.6 Sol (`xhigh`)", findings[0])
+        self.assertIn("GPT-6 Astra (`xhigh`)", findings[0])
+
+    def test_stale_purpose_is_reported_as_that_row(self) -> None:
+        text = _installation_text().replace(
+            "| `quick` | Short tasks |", "| `quick` | Tiny tasks |"
+        )
+        findings = model_chain_table_drift(text)
+        self.assertEqual(len(findings), 1, findings)
+        self.assertIn("`quick`", findings[0])
+        self.assertIn("Tiny tasks", findings[0])
+        self.assertIn("Short tasks", findings[0])
+
+    def test_missing_row_is_reported_as_a_missing_surface(self) -> None:
+        text = _installation_text()
+        dropped = [
+            line
+            for line in text.splitlines(keepends=True)
+            if not line.startswith("| `writing` |")
+        ]
+        findings = model_chain_table_drift("".join(dropped))
+        self.assertTrue(
+            any("`writing`" in finding and "missing from the table" in finding for finding in findings),
+            findings,
+        )
+
+    def test_unknown_row_is_reported_as_not_a_shipped_surface(self) -> None:
+        text = _installation_text().replace(
+            MODEL_CHAIN_TABLE_REGION_END,
+            "| `invented` | Nothing | Kimi K3 |\n" + MODEL_CHAIN_TABLE_REGION_END,
+        )
+        findings = model_chain_table_drift(text)
+        self.assertTrue(
+            any("`invented`" in finding and "not a shipped chain surface" in finding for finding in findings),
+            findings,
+        )
+
+    def test_region_without_markers_is_refused(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            model_chain_table_drift("no generated region here\n")
+        self.assertIn("markers", str(caught.exception))
+
+    def test_surface_without_a_purpose_names_the_key_to_add(self) -> None:
+        purposes = dict(CHAIN_SURFACE_PURPOSES)
+        purposes.pop("quick")
+        with patch.dict(CHAIN_SURFACE_PURPOSES, purposes, clear=True):
+            with self.assertRaises(ValueError) as caught:
+                chain_table_rows()
+        message = str(caught.exception)
+        self.assertIn("'quick'", message)
+        self.assertIn("CHAIN_SURFACE_PURPOSES", message)
+        self.assertIn("src/catalogs/model_chain_table.py", message)
+
+    def test_model_without_a_display_label_names_the_alias(self) -> None:
+        labels = dict(MODEL_DISPLAY_LABELS)
+        labels.pop("kimi-k3")
+        with patch.dict(MODEL_DISPLAY_LABELS, labels, clear=True):
+            with self.assertRaises(ValueError) as caught:
+                chain_table_rows()
+        message = str(caught.exception)
+        self.assertIn("'kimi-k3'", message)
+        self.assertIn("MODEL_DISPLAY_LABELS", message)
+        self.assertIn("src/catalogs/model_chain_table.py", message)
+
+    def test_generated_region_keeps_the_document_around_it(self) -> None:
+        text = _installation_text()
+        start = text.index(MODEL_CHAIN_TABLE_REGION_BEGIN)
+        stop = text.index(MODEL_CHAIN_TABLE_REGION_END) + len(MODEL_CHAIN_TABLE_REGION_END)
+        hand_edited = (
+            text[:start]
+            + MODEL_CHAIN_TABLE_REGION_BEGIN
+            + "\n| hand | edited | row |\n"
+            + MODEL_CHAIN_TABLE_REGION_END
+            + text[stop:]
+        )
+        rewritten = installation_with_generated_region(hand_edited)
+        self.assertEqual(rewritten, text)
+        self.assertIn("The shipped catalog is editorial policy", rewritten)
+        self.assertIn(model_chain_table_region(), rewritten)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- The shipped-chain table in `docs/INSTALLATION.md` is now a generated marked
  region rendered from `SHIPPED_MODEL_RECOMMENDATIONS`, gated byte-exactly by
  `uv run python -m omh.cli docs chain-table --check` in CI.
- A stale table names the rows that disagree and both strings, not just the
  file.
- Regenerating changed eleven of the twelve rows' wording (only `ultrabrain`
  is byte-identical). **No model and no chain order changed** — seven rows
  gained information that was missing, the rest moved to the unambiguous
  per-entry effort form. See the two findings below.

### Two findings from verifying the premise before building

This PR was assigned as "the table is ungated", with the explicit correction
that its content was already correct. Checking that first turned up two things
worth more than the gate itself.

**1. The table was lossy, not stale.** Its content was correct in *order* and
wrong in *fidelity* — a distinction nobody had drawn, including the assignment.
Every row's model sequence on `origin/main` matches the live catalog exactly.
But `unspecified-high`, `writing`, `visual-engineering` and `artistry`, plus the
Hermes `main` role slot and `last_resort.any`, each declare a reasoning effort
the published table simply omitted; and the `x_platform_data` row printed
"Grok" and "Gemini" for `grok-code-fast` and `gemini-3.1-pro`. A reader picking
one of those categories off the table could not see what effort it would run
at. Seven rows gain that missing information here.

**2. `docs/MODEL-ONBOARDING.md` asserted coverage that did not exist.** Its
surface map said `tests/test_model_recommendations.py` "reads all seven" public
chain tables, naming `docs/INSTALLATION.md` among them. The test reads six —
`README.md` plus the three localized READMEs plus two site pages. INSTALLATION
was never in that dict. A document claiming a gate that is not there is worse
than no document, because it stops the next person from looking; that is
plausibly why this table stayed ungated while the other six did not. Fixed here
in one line: the row now separates the six hand-maintained tables (with what
their test actually checks) from the one generated table.

### Why This Exists

The table was the one public projection of catalog data in this repo with no
gate. It agreed with the live chains only for as long as whoever retired a
model generation remembered to hand-edit the doc as well (PR #1465 did), and
nothing failed when they did not.

### User / Operator Impact

A reader of the installation doc now sees the effort each chain entry declares
and the full model id behind each display name. Nobody edits that table by
hand again; `uv run python -m omh.cli docs chain-table` regenerates it.

### How It Works

`src/catalogs/model_chain_table.py` walks the four closed vocabularies —
`HERMES_MODEL_SETUP_ROLE_SLOTS`, `MODEL_CATEGORIES`,
`MODEL_RECOMMENDATION_DOMAINS`, `MODEL_RECOMMENDATION_LAST_RESORT_SLOTS` — and
projects each into one row, so every shipped chain surface appears and a
surface that loses its chain renders `(none shipped)` rather than vanishing.

Two things the table shows are not catalog data, so they live in the producer
and are required rather than defaulted:

- `MODEL_DISPLAY_LABELS`: reader-facing label per model alias.
- `CHAIN_SURFACE_PURPOSES`: the one-line "What it is for" phrase per surface.

The obvious objection to generating prose is that prose is editorial. These
phrases are not being invented: every one of them already existed twice, in the
doc row and in `site/i18n.js` under its `chain.*` key (which also carries the
ko/ja/zh translations). Generation moves an existing duplicated string into the
producer; it does not author a new one. A missing entry in either map raises
with the key to add and the command to rerun.

#### Why the verbose effort form is the correct one

Effort renders per entry — `Label (effort)`, nothing where the catalog declares
none. The hand-written table used a shorter trailing token for a row whose
entries happened to share an effort, and I implemented that first to keep the
diff small. The round-trip test rejected it, and it was right to:
`Claude Opus 5, GPT-5.6 Sol (medium)` cannot be read back, because the token
could bind to the whole row or to Sol alone — and in `last_resort.any` it
genuinely binds to Sol alone, since `claude-opus-5` declares no effort there. A
byte check cannot see that ambiguity: both forms are self-consistent bytes. It
is visible only because `tests/test_model_chain_table.py` parses the *published*
table back into (alias, effort) pairs and compares those against the catalog
rather than comparing bytes. So the repetition on the uniform rows is not
verbosity for its own sake; one unambiguous rule is what makes the projection
checkable in the direction the byte gate is blind to.

### Files And Contracts Touched

- `src/catalogs/model_chain_table.py` (new): `chain_table_rows()`,
  `model_chain_table_region()`, `installation_with_generated_region()`,
  `model_chain_table_drift()`, plus the two required maps and the region
  markers.
- `src/commands/docs.py`: `omh docs chain-table [--path] [--check]`.
- `docs/INSTALLATION.md`: markers added; region regenerated.
- `tests/test_model_chain_table.py` (new, 14 tests), `tests/test_cli.py`
  (CLI generate/check/stale-message/no-markers).
- `.github/workflows/ci.yml`: `Generated chain table region check` (shard 0).
- `CLAUDE.md` (Generated Artifacts Map row, byte-gate list, hand-edit rule),
  `AGENTS.md` and `docs/MODEL-ONBOARDING.md` (gate lists; corrected the
  "all seven" surface row).

### Affected Surfaces

- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `uv run python -m omh.cli docs chain-table --check` → `{"checked": ".../docs/INSTALLATION.md", "ok": true}`.
- Also observed green: `docs claims --check --json`, `docs navigation --check`,
  `docs ulw-inventory --check`, `docs ulw-site --check`.
- Deliberately observed red first: before regenerating, `--check` exited 2 and
  named all nine disagreeing rows with both strings plus the row-order
  difference; after `docs chain-table`, exit 0.
- Full suite, run as `PYTHONPATH=tests uv run python -m unittest discover -s tests`
  (without `-v`): `Ran 10959 tests in 889.613s` / `OK (skipped=3)`.
- `ruff check src tests` -> `All checks passed!`; `compileall -q src tests` clean;
  `git diff --check` clean; `drift_report()["ok"]` True.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, the install
  smokes and `omh --help`: this change adds one docs generator and one CLI
  check subcommand. It touches no harness contract, no release artifact, no
  installer path and no runtime surface.
- Manual Hermes/TUI check: nothing here renders in the TUI; the generated
  region is a markdown doc.
- The six hand-maintained public chain tables (READMEs, site pages) are out of
  scope and keep their existing looser gate in
  `tests/test_model_recommendations.py` — see Follow-Up.

## Risk

Low and contained to docs tooling. The worst realistic failure is the new check
blocking a PR that changes chains without regenerating, which is the intended
behavior and prints the regen command.

**Merge order (agreed with the coordinator): this lands after #1469.** The
check renders one row per entry in `MODEL_CATEGORIES`, so the three categories
#1469 adds (`capable`, `simple-work`, `deep-work`) need a
`CHAIN_SURFACE_PURPOSES` entry each. Rather than push that requirement into
#1469's diff — it is one owner-decision edit from done and its goal is
unrelated — this branch rebases onto merged #1469 and absorbs the three rows
itself, along with a `MODEL_DISPLAY_LABELS` entry for `claude-haiku-4-5`, the
new alias `simple-work` introduces. The three purpose strings are lifted from
#1469's own doc rows and its new `site/i18n.js` `chain.*` keys, so they stay in
register and are still not invented here.

The strictness is deliberate and stays: a category that reaches the shipped
chains while staying invisible in the public table is the exact failure being
gated. The failure names each missing key. No row count is hardcoded anywhere.

## Compatibility / Rollout

No runtime behavior changes. No new dependency, no network call. The published
doc gains the effort each chain entry declares and the full name behind each
abbreviated one.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- The same producer could generate `README.md`, the three localized READMEs,
  `site/index.html` and `site/docs/model-routing/index.html`, which still carry
  hand-written copies of these chains behind a looser alias-order test. Not
  attempted here: the localized tables and the site i18n strings are
  hand-maintained by an existing decision (the ULW region carries the same
  note), so widening this would be its own goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8
