### PR TITLE
fix(update): the pre-pointer skills home is a managed registration on a managed install too

### DIFF
--- a/src/commands/setup.py
+++ b/src/commands/setup.py
@@ -615,9 +615,20 @@ def _managed_workflow_dir_candidates(paths: OmhPaths) -> list[Path]:
     as the deliberate opt-out (plugin directory present, registration
     "absent"), skipped the whole profile, and left its plugin bundle and TUI
     widget on the generation they were installed at.
+
+    `<omh_home>/skills` is listed by name, not through `paths.skills_dir`: on
+    a managed command install `resolve_paths` already redirects `skills_dir`
+    to the running generation's pack, so the pre-pointer registration home —
+    the very path the frozen profile carries — would otherwise never be a
+    candidate on exactly the machines that need it (the first fix read
+    `paths.skills_dir` and passed its tests from an unmanaged interpreter).
     """
     candidates = [_registered_workflow_dir(paths)]
-    for candidate in (paths.skills_dir, managed_current_workflow_pack_dir()):
+    for candidate in (
+        paths.omh_home / "skills",
+        paths.skills_dir,
+        managed_current_workflow_pack_dir(),
+    ):
         if candidate is not None and candidate not in candidates:
             candidates.append(candidate)
     return candidates

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -1809,16 +1809,27 @@ class HermesProfileSyncTests(unittest.TestCase):
     def _managed_install(self, current: Path):
         """What a managed command install looks like to the setup module.
 
-        Only the two probes are stubbed -- the generation pointer and the
-        managed-runtime answer a test process cannot give truthfully -- so
+        Only the probes a test process cannot answer truthfully are stubbed
+        -- the generation pointer, the managed-runtime verdict, and the
+        generation the running interpreter lives in -- so
         `_registered_workflow_dir` and the candidate list run for real. The
-        self-update plan is pinned off because a managed runtime is exactly
-        what would otherwise send `omh update` into the staged command
-        package transaction, which is not what these tests exercise.
+        third stub matters: on a real managed install `resolve_paths`
+        redirects `paths.skills_dir` to the running generation's pack, so a
+        helper that leaves it at `<omh_home>/skills` models an unmanaged
+        interpreter and lets a candidate list that forgets the pre-pointer
+        home pass (the first fix did exactly that). The self-update plan is
+        pinned off because a managed runtime is exactly what would otherwise
+        send `omh update` into the staged command package transaction, which
+        is not what these tests exercise.
         """
         with (
             mock.patch.object(
                 _setup_module, "managed_current_workflow_pack_dir", return_value=current
+            ),
+            mock.patch.object(
+                sys.modules[resolve_paths.__module__],
+                "managed_workflow_pack_dir",
+                return_value=current,
             ),
             mock.patch.object(
                 _setup_module,


### PR DESCRIPTION
## Feature Report

Follow-up to #1472 (#1466). The merged candidate list misses the one machine shape the fix was for.

### What Changed

- `src/commands/setup.py` `_managed_workflow_dir_candidates`: `paths.omh_home / "skills"` — the pre-pointer registration home — is a candidate by name, ahead of `paths.skills_dir` and the generation pointer. Read and removal share the list, so the per-profile opt-out strips it too.
- `tests/test_plugin_distribution.py` `_managed_install`: also stubs `managed_workflow_pack_dir` on the `resolve_paths` module, so `paths.skills_dir` is redirected to the generation pack exactly as on a managed command install. With that stub the three older-dir cases (`…registered_at_the_other_managed_dir_is_refreshed`, `…opting_out_removes_a_registration_at_the_older_managed_dir`, `…primary_home_opts_out_from_the_older_managed_dir_too`) fail on the #1472 list and pass on this one.

### Why This Exists

On a managed command install `resolve_paths` sets `managed_skills_dir` to the running generation's pack (`src/system/paths.py:822`), so `paths.skills_dir` is not `<omh_home>/skills`. #1472's list read `paths.skills_dir` and therefore never contained `~/.omh/skills` on the owner machine — the path `profiles/miku/config.yaml` registers. Re-derived read-only on the owner machine after the `omh` auto-update to `8052a1b3` (the generation that carries #1472): candidates were `~/.local/share/omh/current/skills` and `…/generations/<gen>/skills` only, both `registered=False`; miku's plugin and widget stayed at their 2026-09-04 files (manifests match on disk, so nothing would refuse a refresh). The #1472 fixture left the interpreter unmanaged, so `paths.skills_dir` stayed at `<omh_home>/skills` and the list looked complete.

### User / Operator Impact

The next `omh update` (or the bare-`omh` auto-update, which spawns `omh update --no-interactive`) prints `Bot profiles: miku (refreshed)` and refreshes the profile's plugin bundle and TUI widget. A profile that registers no OMH-managed path at all is still the deliberate opt-out.

### How It Works

One list, three OMH-owned locations: today's path, the pre-pointer home, the pointer. `_remove_managed_external_dirs` iterates the same list.

### Files And Contracts Touched

`src/commands/setup.py`, `tests/test_plugin_distribution.py`.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check` (no catalog change)
- [ ] `uv run python -m omh.cli docs capability-families --check` (no catalog change)
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: read-only re-derivation of the candidate list on the owner machine with this source (`~/.omh/skills registered=True` for miku)
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: `omh update` on the owner machine is the rollout step after merge

### Observed Evidence

- Full suite: running on the committed tree; the `Ran … / OK` line is posted as a comment on this PR when it finishes.
- Targeted: `tests/test_plugin_distribution.py tests/test_staged_self_update.py tests/test_broad_exception_policy.py tests/test_interpreter_spawn_policy.py` — `Ran 113 tests … OK`; compileall, ruff, `git diff --check`, `docs navigation/workflows --check`, `release drift` all clean/PASS.
- Discrimination: fixture with the redirect, candidate list as merged in #1472 → `FAILED (failures=3)` on the three older-dir cases; with this change → `Ran 11 tests … OK`.
- Owner machine, read-only, with the current generation's (#1472) code: miku candidates = pointer + generation pack, both unregistered; with this source: `~/.omh/skills` registered=True.

### Not Tested / Not Applicable

- `omh update` on the owner machine (rollout); release/harness checks: no such contract changed.

## Risk

- None beyond #1472's: one more OMH-owned path counts as registered; a home naming none is still opted out.

## Compatibility / Rollout

- Bare `omh` auto-updates to the generation carrying this fix, then the same `omh update` path syncs the profiles.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfePFn3Q9axYU2fBGhpCMV
