### PR TITLE
fix(hud): a lane routed to the parent's own model keeps its category and says =parent

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -298,10 +298,13 @@ document is ignored whole (defaults apply) and reported by
 Next to those two documents, `omh_delegate_route` maintains
 `~/.omh/routing/route-provenance.json` (`delegation_route_provenance/v1`): a
 capped history of the routes it prepared (head, explicit, fallback, chain
-exhaustion, clear) that the HUD uses to label a fallback lane as a fallback
-and an exhausted chain as `category(model inherit)` — one `category(model
-tag)` shape for every lane, where the category names the lane and only the
-parenthesized model and state token move. It is written automatically,
+exhaustion, clear) that the HUD uses to label a fallback lane as a fallback,
+an exhausted chain as `category(model inherit)`, and a lane routed to the
+model the parent session itself runs as `category(model =parent)` — one
+`category(model tag)` shape for every lane, where the category names the
+lane and only the parenthesized model and state token move. A child on the
+parent's model with no route record at all is the plain `inherit(model)`:
+inherit is not a category. It is written automatically,
 carries its own `claim_boundary` (prepared routes only, never dispatch
 evidence), and is safe to delete — an absent or invalid file only means HUD
 rows fall back to plain category projection.

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -324,19 +324,26 @@ export default function register(sdk) {
     // Prepared-route provenance from the reader, rendered as one shape:
     // `category(model tag)`. The category names the LANE and never changes;
     // only the parenthesized model (and its state token) moves — a fallback
-    // lane reads `category(model fallback)`, and an exhausted chain running
-    // the parent's model reads `category(model inherit)` instead of being
-    // relabeled away from its category.
+    // lane reads `category(model fallback)`, an exhausted chain running the
+    // parent's model reads `category(model inherit)`, and a lane the tool
+    // routed to the model the parent itself runs reads
+    // `category(model =parent)` — its category survives, and the token says
+    // the dispatch cost what the parent costs. A child with no route record
+    // at all on the parent's model is the one plain `inherit(model)`: inherit
+    // is not a category, so it never wears the `category:` prefix.
     const routeOrigin = safeText(row.route_origin)
     const routeCategory = safeText(row.route_category)
     const routeTag = routeOrigin === 'fallback' ? 'fallback'
       : routeOrigin === 'exhausted_to_inherit' ? 'inherit'
-        : ''
+        : row.same_as_parent === true ? '=parent'
+          : ''
     const routeDetail = [model, routeTag].filter(Boolean).join(' ')
     const displayCategory = routeOrigin === 'exhausted_to_inherit' && routeCategory ? routeCategory : category
-    const route = displayCategory
-      ? `category:${displayCategory}${routeDetail ? `(${routeDetail})` : ''}`
-      : model
+    const route = displayCategory === 'inherit'
+      ? `inherit${model ? `(${model})` : ''}`
+      : displayCategory
+        ? `category:${displayCategory}${routeDetail ? `(${routeDetail})` : ''}`
+        : model
     const routeKind = routeOrigin === 'fallback' || routeOrigin === 'exhausted_to_inherit' ? 'route-fallback' : 'route'
     return dispatchLane ? metricSegment('maestro', dispatchIdentity) : metricSegment(routeKind, route)
   }

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -333,10 +333,12 @@ export default function register(sdk) {
     // is not a category, so it never wears the `category:` prefix.
     const routeOrigin = safeText(row.route_origin)
     const routeCategory = safeText(row.route_category)
-    const routeTag = routeOrigin === 'fallback' ? 'fallback'
+    // A fallback that landed on the parent's own model keeps both tokens:
+    // the fallback is what happened, `=parent` is what it cost.
+    const parentTag = row.same_as_parent === true ? '=parent' : ''
+    const routeTag = routeOrigin === 'fallback' ? ['fallback', parentTag].filter(Boolean).join(' ')
       : routeOrigin === 'exhausted_to_inherit' ? 'inherit'
-        : row.same_as_parent === true ? '=parent'
-          : ''
+        : parentTag
     const routeDetail = [model, routeTag].filter(Boolean).join(' ')
     const displayCategory = routeOrigin === 'exhausted_to_inherit' && routeCategory ? routeCategory : category
     const route = displayCategory === 'inherit'

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -1203,7 +1203,10 @@ def mixture_category_for(
     """Project an observed child model+effort onto a mixture category label.
 
     ``inherit`` wins over any chain match: a child on the parent session's own
-    model was not routed, whatever chain its model also appears in. Otherwise
+    model looks unrouted, whatever chain its model also appears in — the
+    projection cannot tell "routed to the model the parent also runs" from
+    "not routed"; a fresh matching provenance record can, and the reader
+    upgrades the row from it (`same_as_parent`). Otherwise
     the first category (canonical chain order) whose head matches wins, then
     the category where the model sits earliest in its chain (a shallow
     fall-through entry is a likelier route than a deep one; canonical order
@@ -1852,11 +1855,10 @@ def read_hermes_native_subagents(
         # (`category(model inherit)`), and a lane routed to the parent's own
         # model keeps its category with a `=parent` token, instead of
         # converging into plain inherit. The upgrade carries its own source
-        # marker. The model that
-        # matches here is the same observed wire model the alias and category
-        # above were derived from, so the three stay one identity; a child
-        # whose model the host never recorded and never used matches nothing,
-        # which is the safe degradation.
+        # marker. The model that matches here is the same observed wire
+        # model the alias and category above were derived from, so the three
+        # stay one identity; a child whose model the host never recorded and
+        # never used matches nothing, which is the safe degradation.
         provenance = _provenance_for_dispatch(
             route_provenance,
             started_at=child["started_at"],
@@ -1878,7 +1880,11 @@ def read_hermes_native_subagents(
                         # Routed to the model the parent also runs: the
                         # category is the lane's, and the row says the
                         # model is the parent's own so nobody reads the
-                        # label as a cheaper dispatch than it was.
+                        # label as a cheaper dispatch than it was. Gated on
+                        # the record carrying a category by decision: an
+                        # explicit bare-model route (`set` with a model and
+                        # no category) onto the parent's model has no lane
+                        # to name, so it stays the plain `inherit(model)`.
                         row["same_as_parent"] = True
                     row["category"] = provenance["category"]
                     row["category_source"] = "route_provenance"

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -702,8 +702,10 @@ def configured_route_for_wire(
 # chain exhaustion clearing back to parent inheritance. omh_delegate_route
 # records each successful route write here so the HUD can label a fallback
 # lane as a fallback instead of rendering it indistinguishable from a head
-# route (and an exhausted chain as `category(model inherit)` — the category
-# names the lane and never changes — instead of plain inherit). The record is preparation evidence only: a label upgrade for an
+# route, an exhausted chain as `category(model inherit)`, and a lane routed
+# to the model the parent session itself runs as `category(model =parent)`
+# — the category names the lane and never changes — instead of plain
+# inherit. The record is preparation evidence only: a label upgrade for an
 # observed child whose wire identity matches, never execution evidence and
 # never a routing input.
 DELEGATION_ROUTE_PROVENANCE_SCHEMA_VERSION = "delegation_route_provenance/v1"
@@ -887,11 +889,13 @@ def _provenance_for_dispatch(
                 return None
             claimed = (exhaustion_claims or {}).get(index, "")
             return record if session_id and session_id == claimed else None
-        if is_inherit:
-            # `inherit` wins over any chain match (the projection's
-            # documented invariant): a child on the parent session's own
-            # model was not routed, whatever the prepared route said.
-            return None
+        # A child on the parent session's own model may still have been
+        # ROUTED there: the owner's `deep` chain heads on the model the
+        # session itself runs, so every deep lane looked unrouted and the
+        # category the tool prepared was thrown away. The chain projection
+        # alone still says inherit (it cannot tell the two apart); a fresh
+        # record whose identity matches is what tells them apart, and the
+        # caller marks the row `same_as_parent` so the label says both.
         matched = (wire_model and wire_model == record["wire_model"]) or (
             alias and alias == record["alias"]
         )
@@ -1845,8 +1849,10 @@ def read_hermes_native_subagents(
         # row identity: when the child's identity matches the newest route
         # prepared before its dispatch, a fallback lane says so and an
         # exhausted chain keeps its category with an `inherit` model token
-        # (`category(model inherit)`) instead of converging into plain
-        # inherit. The upgrade carries its own source marker. The model that
+        # (`category(model inherit)`), and a lane routed to the parent's own
+        # model keeps its category with a `=parent` token, instead of
+        # converging into plain inherit. The upgrade carries its own source
+        # marker. The model that
         # matches here is the same observed wire model the alias and category
         # above were derived from, so the three stay one identity; a child
         # whose model the host never recorded and never used matches nothing,
@@ -1868,6 +1874,12 @@ def read_hermes_native_subagents(
                     row["category_source"] = "route_provenance"
             else:
                 if provenance["category"]:
+                    if row["category"] == "inherit":
+                        # Routed to the model the parent also runs: the
+                        # category is the lane's, and the row says the
+                        # model is the parent's own so nobody reads the
+                        # label as a cheaper dispatch than it was.
+                        row["same_as_parent"] = True
                     row["category"] = provenance["category"]
                     row["category_source"] = "route_provenance"
                 if provenance["origin"] == "fallback":

--- a/tests/test_plugin_hermes_delegation.py
+++ b/tests/test_plugin_hermes_delegation.py
@@ -1681,17 +1681,53 @@ class RouteProvenanceProjectionTest(unittest.TestCase):
         self.assertNotIn("category_source", row)
         self.assertEqual(row["category"], "quick")
 
-    def test_inherit_wins_over_a_matching_routed_record(self):
-        # The parent's own model can also be a chain member; a child that
-        # inherited it was NOT routed, whatever the prepared route said.
+    def test_a_route_to_the_parents_own_model_keeps_its_category_and_says_so(self):
+        # The parent's own model can also be a chain head (the owner's
+        # `deep` heads on the model the session runs). A fresh record whose
+        # identity matches proves the tool routed the lane there; the row
+        # keeps the lane's category and says the model is the parent's own,
+        # so the label is neither "unrouted" nor "a cheaper dispatch".
         _write_provenance(
             self.home,
-            [_record(alias="gpt-5.6-sol", wire_model="gpt-5.6-sol", provider="")],
+            [_record(origin="head", alias="gpt-5.6-sol", wire_model="gpt-5.6-sol", provider="")],
         )
         row = self._row("gpt-5.6-sol")
-        self.assertEqual(row["category"], "inherit")
+        self.assertEqual(row["category"], "visual-engineering")
+        self.assertEqual(row["category_source"], "route_provenance")
+        self.assertIs(row["same_as_parent"], True)
         self.assertNotIn("route_origin", row)
-        self.assertNotIn("category_source", row)
+
+    def test_a_fallback_to_the_parents_own_model_keeps_both_tokens(self):
+        _write_provenance(
+            self.home,
+            [_record(origin="fallback", alias="gpt-5.6-sol", wire_model="gpt-5.6-sol", provider="")],
+        )
+        row = self._row("gpt-5.6-sol")
+        self.assertEqual(row["category"], "visual-engineering")
+        self.assertEqual(row["route_origin"], "fallback")
+        self.assertIs(row["same_as_parent"], True)
+
+    def test_an_unrouted_child_on_the_parents_model_stays_plain_inherit(self):
+        # No record, a stale record, or a cleared route: the chain
+        # projection's inherit stands and nothing claims a category.
+        for records in (
+            [],
+            [_record(alias="gpt-5.6-sol", wire_model="gpt-5.6-sol", provider="", written_at=NOW - 2000)],
+            [_record(alias="gpt-5.6-sol", wire_model="gpt-5.6-sol", provider=""), {"origin": "cleared", "written_at": NOW - 100}],
+        ):
+            with self.subTest(records=records):
+                _write_provenance(self.home, records)
+                (self.home / "state.db").unlink(missing_ok=True)
+                row = self._row("gpt-5.6-sol")
+                self.assertEqual(row["category"], "inherit")
+                self.assertNotIn("same_as_parent", row)
+                self.assertNotIn("category_source", row)
+
+    def test_a_routed_child_on_another_model_never_carries_the_parent_token(self):
+        _write_provenance(self.home, [_record(origin="head")])
+        row = self._row("moonshotai/kimi-k3")
+        self.assertEqual(row["category"], "visual-engineering")
+        self.assertNotIn("same_as_parent", row)
 
     def test_a_newer_unrelated_record_blocks_an_older_matching_one(self):
         # Only the newest record written before the dispatch describes it;

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -738,6 +738,13 @@ class TuiWidgetPackTests(unittest.TestCase):
         # its state token (fallback / inherit) move.
         self.assertIn("routeOrigin === 'fallback' ? 'fallback'", widget)
         self.assertIn("routeOrigin === 'exhausted_to_inherit' ? 'inherit'", widget)
+        # A lane routed to the parent's own model keeps its category and
+        # wears `=parent`; a child with no route record on that model is
+        # the plain `inherit(model)` — inherit is not a category, so it
+        # never wears the `category:` prefix.
+        self.assertIn("row.same_as_parent === true ? '=parent'", widget)
+        self.assertIn("displayCategory === 'inherit'", widget)
+        self.assertIn("? `inherit${model ? `(${model})` : ''}`", widget)
         self.assertNotIn("→inherit", widget)
         self.assertIn("row.route_category", widget)
         self.assertIn("tools", widget)

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -736,13 +736,15 @@ class TuiWidgetPackTests(unittest.TestCase):
         # One label shape for every lane: category(model tag). The category
         # names the lane and never changes; only the parenthesized model and
         # its state token (fallback / inherit) move.
-        self.assertIn("routeOrigin === 'fallback' ? 'fallback'", widget)
+        self.assertIn("routeOrigin === 'fallback' ? ['fallback', parentTag]", widget)
         self.assertIn("routeOrigin === 'exhausted_to_inherit' ? 'inherit'", widget)
         # A lane routed to the parent's own model keeps its category and
         # wears `=parent`; a child with no route record on that model is
         # the plain `inherit(model)` — inherit is not a category, so it
         # never wears the `category:` prefix.
-        self.assertIn("row.same_as_parent === true ? '=parent'", widget)
+        self.assertIn("const parentTag = row.same_as_parent === true ? '=parent' : ''", widget)
+        # A fallback that landed on the parent's model keeps both tokens.
+        self.assertIn("['fallback', parentTag].filter(Boolean).join(' ')", widget)
         self.assertIn("displayCategory === 'inherit'", widget)
         self.assertIn("? `inherit${model ? `(${model})` : ''}`", widget)
         self.assertNotIn("→inherit", widget)


### PR DESCRIPTION
## Feature Report

### What Changed

- `src/plugin_bundle/omh/hermes_delegation.py`: `_provenance_for_dispatch` no longer discards a fresh matching route record because the child runs the parent session's model; the row keeps the lane's category from the record and carries `same_as_parent: true`. `cleared`, stale, and exhausted handling unchanged.
- `src/omh/tui_widgets/omh-status.mjs` `routeIdentity`: new token `=parent` → `category:deep(gpt-6-astra:high =parent)`; a child on the parent's model with **no** record renders `inherit(model:effort)` (inherit is not a category, so no `category:` prefix). Exhausted chains keep `category:<lane>(model inherit)`.
- `docs/INSTALLATION.md` provenance paragraph; tests: the old `test_inherit_wins_over_a_matching_routed_record` (which pinned the opposite) is replaced by four cases — head record → category + token; fallback record → both tokens; no / stale / cleared record → plain inherit without the token; a routed child on another model → no token. Widget shape pinned.

### Why This Exists

Owner report (screenshot): three lanes rendered `category:inherit(gpt-6-astra:high)`. Read-only facts: the owner's `~/.omh/routing/model-chains.json` heads `deep` on `gpt-6-astra`; the parent session `20260911_104611` runs `gpt-6-astra`; `route-provenance.json` carries `category: deep, alias: gpt-6-astra, origin: explicit` for each wave. The lanes were routed — to the model the parent also runs — and the label said "unrouted". The owner asked for the category to be shown.

### User / Operator Impact

| case | before | after |
|---|---|---|
| routed, model == parent's | `category:inherit(gpt-6-astra:high)` | `category:deep(gpt-6-astra:high =parent)` |
| exhausted chain → parent model | `category:deep(model inherit)` | unchanged |
| no route record, model == parent's | `category:inherit(model:effort)` | `inherit(model:effort)` |

The cost lever is unchanged and visible: `=parent` says the lane cost what the parent costs; `omh model-chains set deep "gpt-5.6-terra:high, deepseek-flash:high"` (the shipped default) is how to make deep cheaper than the session.

### How It Works

The chain projection (`mixture_category_for`) still answers `inherit` for a child on the parent's model — a chain match alone is not evidence of a route. Only a fresh record written before the dispatch whose wire model / alias matches upgrades the label, the same best-effort pairing every other provenance label already uses (newest record before the dispatch describes it).

### Files And Contracts Touched

`src/plugin_bundle/omh/hermes_delegation.py`, `src/omh/tui_widgets/omh-status.mjs`, `docs/INSTALLATION.md`, `tests/test_plugin_hermes_delegation.py`, `tests/test_tui_widget_pack.py`. HUD row gains an optional `same_as_parent: true` field; no schema version change.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [x] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check` (no catalog change)
- [ ] `uv run python -m omh.cli docs capability-families --check` (no catalog change)
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: read-only reader run (`read_hermes_native_subagents`) against the owner's live `~/.hermes/state.db`
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: rendered frame not captured; the reader rows and the pinned widget shape are the observed surface

### Observed Evidence

- Full suite on this tree: `Ran 10978 tests in 858.890s` / `OK (skipped=3)`.
- Targeted: `tests/test_plugin_hermes_delegation.py tests/test_tui_widget_pack.py tests/test_hud.py` — 160 tests, OK; compileall, ruff, `git diff --check`, `docs navigation/workflows --check`, `release drift` clean/PASS.
- Live DB (read-only, `now` inside the children's window): `886a52` / `c7db30` / `f3c160` → `model gpt-6-astra, effort high, category deep, category_source route_provenance, same_as_parent True` (before this change: `category inherit`).
- Reviewer lane (read-only): in progress at open time; its verdict is posted as a comment on this PR.

### Not Tested / Not Applicable

- Rendered TUI frame; release/harness checks (no such contract changed).

## Risk

- Best-effort pairing: a wave that dispatches several lanes without calling `omh_delegate_route` between them carries the newest record's category onto later lanes — the pre-existing semantics for every provenance label, made visible here for inherit children too. The tool contract (set → dispatch per lane) is the guard; the Directive trailer says so.

## Compatibility / Rollout

- `omh update` + TUI restart. Rows without a record look different (`inherit(model)` instead of `category:inherit(model)`); no consumer keys on the old string (grepped).

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfePFn3Q9axYU2fBGhpCMV
