### PR TITLE
fix(memory): decide store containment lexically instead of by two resolves

### DIFF
--- a/src/workflows/memory_batches.py
+++ b/src/workflows/memory_batches.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from ..plugin_bundle.omh.memory_governance import MEMORY_GOVERNANCE_POLICY_VERSION, MEMORY_SCOPE_SCHEMA_VERSION, PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION, SOURCE_CLASSES, build_retention, canonical_memory_scope, canonical_payload_digest, classify_memory_admission, evaluate_renderable_strings, stable_artifact_identity
-from ..system.local_store import atomic_write_json, file_lock, read_json_object_result
+from ..system.local_store import atomic_write_json, file_lock, is_directory_link, read_json_object_result
 from ..system.paths import OmhPaths
 from ._memory_store_validation import safe_token
 from .memory_store import (
@@ -727,20 +727,25 @@ def _scope_snapshot_by_target(paths: OmhPaths, target: str) -> dict[str, Any] | 
 
 
 def _checked_scope_path(paths: OmhPaths, target: str) -> Path:
+    # Lexical for the reason `memory_store._checked_memory_relative_path`
+    # spells out: `Path.resolve` canonicalizes only what exists, so comparing
+    # two resolves makes containment depend on who is creating the store right
+    # now. This is the same check on the same root, reached by the batch apply
+    # path that two processes contend on, so it carries the same race.
     root = paths.memory_dir
     relative = Path(target)
     if relative.is_absolute() or ".." in relative.parts:
         raise ValueError("scope path is unsafe")
+    if is_directory_link(root):
+        raise ValueError("scope path is unsafe")
     path = root / relative
+    if not path.is_relative_to(root):
+        raise ValueError("scope path is unsafe")
     cursor = root
     for part in relative.parts:
         cursor /= part
-        if cursor.is_symlink():
+        if is_directory_link(cursor):
             raise ValueError("scope path is unsafe")
-    resolved_root = root.resolve(strict=False)
-    resolved_path = path.resolve(strict=False)
-    if resolved_root != resolved_path and resolved_root not in resolved_path.parents:
-        raise ValueError("scope path is unsafe")
     return path
 
 

--- a/src/workflows/memory_store.py
+++ b/src/workflows/memory_store.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from ..system.local_store import atomic_write_json, atomic_write_text, ensure_dir, file_lock, read_json_object_result, utc_now
+from ..system.local_store import atomic_write_json, atomic_write_text, ensure_dir, file_lock, is_directory_link, read_json_object_result, utc_now
 from ..system.paths import OmhPaths
 from ._memory_store_validation import (
     MEMORY_OPERATION_SCHEMA_VERSION,
@@ -357,19 +357,48 @@ def checked_memory_directory(paths: OmhPaths, relative: str) -> Path:
 
 
 def _checked_memory_relative_path(paths: OmhPaths, relative: str) -> Path:
+    """Contain a validated relative path in the store without resolving it.
+
+    Containment used to be decided by comparing ``root.resolve()`` with
+    ``(root / relative).resolve()``. ``Path.resolve`` canonicalizes only the
+    components that exist at the moment it runs and appends the rest
+    literally, so the same path resolves differently depending on how much of
+    it is on disk. Two callers racing to create the store therefore got two
+    spellings of one directory and the comparison rejected the store as an
+    escape -- ``ensure_memory_directory`` raising "memory path escapes store"
+    against its own root while a sibling process created it. POSIX hid that:
+    there the only thing ``resolve`` rewrites is a symlink, and symlinks are
+    already rejected below, so the comparison never changed an answer. Windows
+    also folds 8.3 short names, drive spelling and on-disk casing per existing
+    component, which is what made the race observable there.
+
+    Deciding it lexically removes the race and loses nothing. Every caller has
+    already rejected an absolute path, ``..`` and any component outside
+    ``_SAFE_TOKEN``, so ``root / relative`` extends ``root`` unless the join
+    itself discards it. It does for a drive-qualified or UNC token -- ``D:name``
+    joins to ``D:name`` and ``//host/share`` to that share, both leaving the
+    store, and ``_SAFE_TOKEN`` permits ``:`` because the token spells no
+    separator. ``is_relative_to`` is the containment test rather than a parts
+    comparison because it is case-correct about the drive: ``c:name`` on the
+    store's own drive stays inside but joins to a differently-cased spelling,
+    and rejecting that would trade one wrong refusal for another. Comparing
+    resolves used to catch the real escapes by accident.
+
+    The link walk is also stricter now: ``Path.is_symlink`` answers False for a
+    Windows directory junction, so a junction component was previously caught,
+    if at all, only by the resolve comparison it is replacing.
+    """
     root = paths.memory_dir
-    if root.is_symlink():
+    if is_directory_link(root):
         raise ValueError("memory path escapes store")
     path = root / relative
+    if not path.is_relative_to(root):
+        raise ValueError("memory path escapes store")
     cursor = root
     for part in Path(relative).parts:
         cursor /= part
-        if cursor.is_symlink():
+        if is_directory_link(cursor):
             raise ValueError("memory path escapes store")
-    resolved_root = root.resolve(strict=False)
-    resolved_path = path.resolve(strict=False)
-    if resolved_root != resolved_path and resolved_root not in resolved_path.parents:
-        raise ValueError("memory path escapes store")
     return path
 
 

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -13,6 +13,7 @@ from _platform_support import requires_enforced_file_lock, requires_symlinks
 
 load_local_package()
 from omh.paths import resolve_paths
+from omh.system import local_store
 from omh.workflows import memory_batches as memory_batches_workflow
 from omh.workflows.memory import (
     _memory_snapshots,
@@ -1572,3 +1573,47 @@ class MemoryBatchTests(TestCase):
                 self.assertCountEqual([queue.get(timeout=2), queue.get(timeout=2)], [("applied", first["batch_id"]), ("applied", second["batch_id"])])
                 ids = {item["item_id"] for item in build_handoff_context_pack(paths)["included_context"]}
                 self.assertTrue({first["items"][0]["item_id"], second["items"][0]["item_id"]} <= ids)
+
+
+class ScopePathContainmentTests(TestCase):
+    """The batch scope check is `memory_store`'s twin and carried its race."""
+
+    def test_containment_does_not_depend_on_how_much_of_the_path_exists(self) -> None:
+        real_resolve = Path.resolve
+
+        def existence_dependent_resolve(self_path: Path, strict: bool = False) -> Path:
+            resolved = real_resolve(self_path, strict=strict)
+            if self_path.exists():
+                return Path(str(resolved).replace("literal", "CANONICAL"))
+            return resolved
+
+        with TemporaryDirectory() as home:
+            base = Path(home) / "literal"
+            paths = resolve_paths(base / ".omh", base / ".hermes")
+            paths.memory_dir.mkdir(parents=True)
+            with patch.object(Path, "resolve", existence_dependent_resolve):
+                path = memory_batches_workflow._checked_scope_path(paths, "scopes/project.json")
+            self.assertEqual(path, paths.memory_dir / "scopes" / "project.json")
+
+    def test_a_symlinked_component_is_still_unsafe(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            paths.memory_dir.mkdir(parents=True)
+            outside = Path(home) / "outside"
+            outside.mkdir()
+            (paths.memory_dir / "scopes").symlink_to(outside, target_is_directory=True)
+
+            with self.assertRaisesRegex(ValueError, "scope path is unsafe"):
+                memory_batches_workflow._checked_scope_path(paths, "scopes/project.json")
+
+    def test_a_junction_component_is_unsafe_even_though_is_symlink_says_no(self) -> None:
+        with TemporaryDirectory() as home:
+            paths = resolve_paths(Path(home) / ".omh", Path(home) / ".hermes")
+            paths.memory_dir.mkdir(parents=True)
+            junction = paths.memory_dir / "scopes"
+            junction.mkdir()
+
+            with patch.object(local_store, "is_junction", lambda probe: probe == junction):
+                self.assertFalse(junction.is_symlink())
+                with self.assertRaisesRegex(ValueError, "scope path is unsafe"):
+                    memory_batches_workflow._checked_scope_path(paths, "scopes/project.json")

--- a/tests/test_memory_operations.py
+++ b/tests/test_memory_operations.py
@@ -4,18 +4,22 @@ import json
 import multiprocessing
 import unittest
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from tempfile import TemporaryDirectory
 from typing import Any
+from unittest.mock import patch
 
 from _local_package import load_local_package
 from _platform_support import requires_enforced_file_lock, requires_symlinks
 
 load_local_package()
 from omh.local_store import atomic_write_json, ensure_dir, read_json_object_result
+from omh.system import local_store
 from omh.paths import OmhPaths
 from omh.workflows.memory_store import (
     apply_memory_operation_step,
+    checked_memory_directory,
+    ensure_memory_directory,
     prune_expired_memory_evidence,
     recover_memory_operations,
     run_memory_operation,
@@ -485,8 +489,17 @@ class MemoryOperationTests(unittest.TestCase):
             ]
             for worker in workers:
                 worker.start()
-            self.assertTrue(first_ready.wait(20))
-            self.assertTrue(second_ready.wait(20))
+            # `assertTrue(ready.wait(20))` reported `False is not true` and
+            # nothing else, which reads as "the writer was slow" and was in
+            # fact "the writer died": the child raised before it could signal,
+            # and its exit code -- the one fact that separates the two -- was
+            # only checked further down, after this assertion had already
+            # stopped the test. Say which writer and what became of it.
+            for label, ready, worker in (("first", first_ready, workers[0]), ("second", second_ready, workers[1])):
+                self.assertTrue(
+                    ready.wait(20),
+                    f"{label} writer never signalled: exitcode={worker.exitcode} alive={worker.is_alive()}",
+                )
             for worker in workers:
                 worker.join(20)
                 self.assertEqual(worker.exitcode, 0)
@@ -616,6 +629,97 @@ class MemoryOperationTests(unittest.TestCase):
             self.assertTrue((paths.memory_dir / "records/result.json").exists())
             first_still_failed, _ = read_json_object_result(paths.memory_operations_dir / "op-first-fail.json")
             self.assertEqual(first_still_failed["state"], "failed")
+
+
+class MemoryPathContainmentTests(unittest.TestCase):
+    """The store's containment rule, which had no coverage until it flaked."""
+
+    def test_containment_does_not_depend_on_how_much_of_the_path_exists(self) -> None:
+        """A concurrent creator must not turn the store into an escape.
+
+        `Path.resolve` canonicalizes the components that exist and appends the
+        rest literally, so a directory resolves to one spelling before it is
+        created and another after. The old check compared two resolves taken a
+        line apart, which made containment a race: on Windows, where resolve
+        also folds short names and on-disk casing, a sibling process creating
+        the store between them was enough to fail the check against its own
+        root. The stub models exactly that -- an existing directory answers
+        with its canonical spelling, a missing one answers literally.
+        """
+        real_resolve = Path.resolve
+        canonical = "CANONICAL"
+
+        def existence_dependent_resolve(self_path: Path, strict: bool = False) -> Path:
+            resolved = real_resolve(self_path, strict=strict)
+            if self_path.exists():
+                return Path(str(resolved).replace("literal", canonical))
+            return resolved
+
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp) / "literal"
+            paths = OmhPaths(base / "omh", base / "hermes")
+            ensure_dir(paths.memory_dir, private=True)
+            with patch.object(Path, "resolve", existence_dependent_resolve):
+                # The root exists and the child does not, which is precisely
+                # the window the two racing writers hit.
+                self.assertFalse((paths.memory_dir / "operations").exists())
+                directory = ensure_memory_directory(paths, "operations")
+            self.assertEqual(directory, paths.memory_dir / "operations")
+            self.assertTrue(directory.is_dir())
+
+    def test_a_symlinked_component_is_still_an_escape(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            ensure_dir(paths.memory_dir, private=True)
+            outside = Path(tmp) / "outside"
+            outside.mkdir()
+            (paths.memory_dir / "operations").symlink_to(outside, target_is_directory=True)
+
+            with self.assertRaisesRegex(ValueError, "memory path escapes store"):
+                checked_memory_directory(paths, "operations")
+
+    def test_a_junction_component_is_an_escape_that_is_symlink_calls_safe(self) -> None:
+        """`Path.is_symlink` answers False for a junction; containment must not.
+
+        Only the resolve comparison stood between a Windows junction and the
+        store before, and it was the racy half. The link walk now asks
+        `is_directory_link`, which asks `is_junction` too.
+        """
+        with TemporaryDirectory() as tmp:
+            paths = _paths(tmp)
+            ensure_dir(paths.memory_dir, private=True)
+            junction = paths.memory_dir / "operations"
+            junction.mkdir()
+
+            # Patched on `local_store`, not on `Path`: `Path.is_junction` only
+            # exists from 3.12, and `is_directory_link` reaches its junction
+            # probe through this module global, so the composition under test
+            # stays real on every supported version.
+            with patch.object(local_store, "is_junction", lambda probe: probe == junction):
+                self.assertFalse(junction.is_symlink())
+                with self.assertRaisesRegex(ValueError, "memory path escapes store"):
+                    checked_memory_directory(paths, "operations")
+
+    def test_a_drive_qualified_token_is_what_the_containment_test_is_for(self) -> None:
+        """Why containment is still asserted and not left to the link walk.
+
+        `_SAFE_TOKEN` permits `:` because the token spells no separator, so a
+        drive-qualified or UNC component survives validation and then discards
+        the root it is joined to. `is_relative_to` rather than a parts
+        comparison because pathlib is case-correct about the drive: a token on
+        the store's own drive stays inside but joins to a differently-cased
+        spelling, and a parts comparison would reject it. Measured identical on
+        3.11, 3.12 and 3.13; asserted against Windows semantics directly, since
+        POSIX gives none of these tokens special meaning.
+        """
+        root = PureWindowsPath(r"C:\store\omh\memory")
+
+        for escaping in ("D:evil", "//host/share"):
+            with self.subTest(token=escaping):
+                self.assertFalse((root / escaping).is_relative_to(root))
+        for contained in ("operations", "scopes/project.json", "c:evil", "C:evil"):
+            with self.subTest(token=contained):
+                self.assertTrue((root / contained).is_relative_to(root))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature Report

### What Changed

- `memory_store._checked_memory_relative_path` decides containment lexically instead of by comparing two `Path.resolve()` results.
- `memory_batches._checked_scope_path` — the same check on the same root — gets the same treatment.
- Both link walks now use `is_directory_link`, so a Windows junction is an escape rather than something `Path.is_symlink()` waves through.
- `test_two_processes_serialize_same_target_without_lost_updates` reports which writer failed and what became of it.
- Seven new tests. The containment rule had none.

### Why This Exists

**The product loses correctness on Windows, not the test.**

`test-windows (1)` on PR #1479 failed with `AssertionError: False is not true`. That names nothing, so I went to the job log, where the child process had printed its own traceback:

```
Process SpawnProcess-51:
  File "tests\test_memory_operations.py", line 50, in _process_writer
    run_memory_operation(
  File "src\workflows\memory_store.py", line 69, in run_memory_operation
    ensure_memory_directory(paths, "operations")
  ...
  File "src\workflows\memory_store.py", line 372, in _checked_memory_relative_path
    raise ValueError("memory path escapes store")
```

Line 372 was the resolve comparison, not the symlink walk above it. The store rejected **its own root** as an escape, before taking any lock. The writer never signalled, and the parent's `assertTrue(ready.wait(20))` reported a 20-second wait as though the child had been slow — it had been dead for most of it.

```python
resolved_root = root.resolve(strict=False)
resolved_path = path.resolve(strict=False)
if resolved_root != resolved_path and resolved_root not in resolved_path.parents:
    raise ValueError("memory path escapes store")
```

`Path.resolve` canonicalizes only the components that exist when it runs and appends the rest literally. So the same directory resolves to one spelling before it is created and another after, and these two calls are a line apart with another process creating that directory in between.

This is not my inference — **the repo already recorded the mechanism**, in `coding/verification_receipts.py:_containment_path`:

> `Path.resolve(strict=False)` can return an extended DOS path for a **missing child** while returning a normal path for its **existing parent**.

That module normalized the spelling locally. The memory store kept the comparison. **The knowledge existed in this repo and did not travel to the other caller of the same primitive** — that, more than the race itself, is what this PR is about.

POSIX hid it: there the only thing `resolve` rewrites is a symlink, and the walk above already rejects symlinks, so the comparison never changed an answer and could not race. Windows additionally folds extended-path spelling, 8.3 short names and on-disk casing per existing component. It was only observable at all because #1470 lifted this test onto Windows — which is precisely what that PR was for.

### User / Operator Impact

- A memory operation could fail on Windows whenever another process was creating the store, with an error that reads like a security rejection. The check runs **before the lock is taken**, so no locking change could ever have reached it. That stops now.
- **The old check never rejected a junction at all** — a containment gap, not a flake fix. `Path.is_symlink` answers False for a Windows junction, and the resolve comparison did not catch one either: the new junction case fails with `AssertionError: ValueError not raised` against the old code. Both link walks now ask `is_directory_link`, so a junction inside the memory store is an escape.

### How It Works

Every caller has already rejected an absolute path, `..`, and any component outside `_SAFE_TOKEN`, so `root / relative` extends `root` unless the join discards the root. It does for a drive-qualified or UNC token — `D:name` joins to `D:name`, `//host/share` to that share — and `_SAFE_TOKEN` permits `:` because the token spells no separator, while `Path("D:name").is_absolute()` is False on Windows.

```python
if is_directory_link(root):
    raise ValueError("memory path escapes store")
path = root / relative
if not path.is_relative_to(root):
    raise ValueError("memory path escapes store")
cursor = root
for part in Path(relative).parts:
    cursor /= part
    if is_directory_link(cursor):
        raise ValueError("memory path escapes store")
return path
```

`is_relative_to` rather than a parts comparison, and that distinction was measured rather than assumed. I wrote the parts comparison first; the first CI round failed on Linux, and running the cases under 3.11 and 3.12 locally showed why it was wrong on its own terms:

| token | `root / token` | inside? |
| --- | --- | --- |
| `D:evil` | `D:evil` | no — escapes to another drive |
| `//host/share` | `\\host\share\` | no — escapes to UNC |
| `c:evil` | `c:\store\omh\memory\evil` | **yes**, but the drive letter changes case |
| `C:evil` | `C:\store\omh\memory\evil` | yes |

A parts comparison rejects the third row on a case difference alone — trading one wrong refusal for another. `is_relative_to` is case-correct about the drive and gives identical answers on 3.11, 3.12 and 3.13. No filesystem call decides containment any more, so nothing another process does can change the verdict.

### Files And Contracts Touched

- `src/workflows/memory_store.py` — `_checked_memory_relative_path`; `is_directory_link` imported.
- `src/workflows/memory_batches.py` — `_checked_scope_path`; same import.

  **Why this is one PR and not scope creep:** `_checked_scope_path` is the same check on the same root, byte-for-byte the same resolve comparison, reached by the batch apply path that two processes contend on — and #1470 put *its* test on Windows in the same change that exposed this one. Fixing only `memory_store` would have left a known-identical defect behind a test that had just started running on the platform it fails on. That is shipping the next flake on purpose.
- `tests/test_memory_operations.py` — diagnostic message, `MemoryPathContainmentTests` (4 cases).
- `tests/test_memory_batches.py` — `ScopePathContainmentTests` (3 cases).

No signature, return type or error string changes.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Intermittency established from CI, not assumed: run 34562948137 on `cc22a5dd`, attempt 1 `test-windows (1)` failed, attempt 2 passed; `origin/main` at `918bcdd5` — which already contains #1470 — is green with the same test running.
- The failing line identified from the job log as line 372, the resolve comparison, with the child's own traceback naming `ensure_memory_directory` → `_checked_memory_relative_path`. The two symlink guards above it passed.
- Full suite on the committed tree: `Ran 10982 tests in 836.665s` / `OK (skipped=3)` — seven more than main's 10975, matching the seven cases added.
- Memory suites together (`test_memory_operations`, `test_memory_batches`, `test_memory`): `Ran 154 tests` / `OK`.
- **Guards bite at both sites.** Restoring the resolve comparison makes the racing case reproduce the exact CI error — `ValueError: memory path escapes store` and `ValueError: scope path is unsafe` — and makes the junction case report `AssertionError: ValueError not raised`, confirming the old check never rejected a junction at all.
- **Diagnostic bites.** Making the second child raise the way the Windows one did now reports `second writer never signalled: exitcode=1 alive=False` instead of `False is not true`.
- Rebased onto `origin/main` past `c39ac4a6`. The earlier `test_c4_real_process_negative_admission_matrix` red on this branch was not caused by it: that test has no reference to memory containment, passed 8/8 on a control tree, 3/3 in isolation on 3.11, and passed when I ran the exact CI shard plan locally (lane `linux-3.11`, shard 1, 5436 tests in order) — my seven added tests had rebalanced the timing-based plan and moved it from shard 0 into shard 1. #1483 has since fixed the cause: a test setting a process-global interrupt flag and never restoring it.
- ruff, compileall, all five byte gates, `docs claims --check --json` `"ok": true`, `release drift --json` `"drift_count": 0`, `git diff --check` clean.

### Not Tested / Not Applicable

- **Native Windows.** The existence-dependent resolve is modelled from CPython's documented contract and this repo's own recorded observation in `verification_receipts.py`, not observed here. The model is explicit in the test: an existing directory answers with a canonical spelling, a missing one answers literally. CI adjudicates.
- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`, installed-command smoke: no catalog, skill, routing case, CLI output or installed surface is touched. No exact-count assertion moves.

### Two self-corrections, both caught by measurement

Neither came from review. Both are recorded because the second is a case of my own fix being wrong in a way only running it could show.

1. **`Path.is_junction` is 3.12+.** I measured on 3.13, so `patch.object(Path, "is_junction", ...)` passed locally and raised `AttributeError` on the 3.11 shards. The junction cases now patch `local_store.is_junction`, which is where `is_directory_link` reaches its probe, so the composition under test stays real on every supported version.
2. **My first containment check was wrong on its own terms.** I used a parts-prefix comparison. Running the cases under 3.11 falsified it, and measuring across versions showed why:

| token | `root / token` | inside the store? |
| --- | --- | --- |
| `D:evil` | `D:evil` | no — escapes to another drive |
| `//host/share` | `\\host\share\` | no — escapes to UNC |
| `c:evil` | `c:\store\omh\memory\evil` | **yes**, but the drive letter changes case |
| `C:evil` | `C:\store\omh\memory\evil` | yes |

   A parts comparison rejects the third row on a case difference alone — trading one wrong refusal for another, which is the same class of bug I was fixing. `is_relative_to` is case-correct about the drive and answers identically on 3.11, 3.12 and 3.13.

## Risk

- Containment is security-relevant, so the replacement is deliberately **wider** than the original on junctions and narrower on nothing I can identify. The old rule accepted a path iff the two resolves agreed; the new one accepts iff the join extends the root lexically and no component is a link. For inputs the callers permit — relative, no `..`, `_SAFE_TOKEN` components — the second is the stronger statement, and it no longer depends on the filesystem at the instant it runs.
- The one behaviour I removed on purpose: a path whose *ancestry above the store* contains a symlink used to resolve identically on both sides and pass; it still passes. That is correct — where the store itself lives is not an escape.

## Compatibility / Rollout

No schema, artifact or CLI change. Nothing to roll out.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- **A sweep is warranted and is not in this PR.** `grep -rn "resolve(strict=False)" src/` returns 30 sites, several of them containment comparisons of the same shape: `_memory_lifecycle_scan.relative_path` (`"path_escape"`), `rejected_decision_evidence`, `web_visual_qa_captures`, `hermes_retained_context_provider`, `provider_profile_posture`, `memory_provider_posture`, `run_efficiency`, `_memory_migration_reactivation_data`. I fixed the two I could show are in the failing path family — one observed, one its exact twin with a test I had just moved onto Windows. I have not established that the others race, so I have not touched them.
- **Windows on Python 3.11 cannot detect junctions at all.** `local_store.is_junction` probes `getattr(path, "is_junction", None)`, and that attribute arrived in 3.12, so `is_directory_link` silently degrades to `is_symlink()` there. CI runs Windows only on 3.12 (`lane: windows-3.12`), so the gates do not see it, but an operator on Windows with 3.11 gets no junction containment in either of these checks. Worth a decision — a real probe, or a documented floor — and not something to settle inside a flake fix.
- `coding/verification_receipts.py:_containment_path` normalizes the spelling rather than removing the dependency. It is not wrong, but it is the workaround for this defect, and it should probably become the lexical rule too once the sweep above happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8


