### PR TITLE
test(fanout): restore the process-global interrupt flag after every test that sets it (C4 admission matrix on CI)

### DIFF
--- a/tests/five_issue_cases/capacity.py
+++ b/tests/five_issue_cases/capacity.py
@@ -87,7 +87,7 @@ def negative_admission_cases() -> int:
         stdout.replace(b'"thread_id":', b'"extra":true,"thread_id":'),
         stdout.replace(b'"thread_id":', b'"type":"thread.started","thread_id":'),
         stdout + b'forged extra output\n', b'\xff\n')]
-    for out, err in [(stdout, stderr), *variants]:
+    for index, (out, err) in enumerate([(stdout, stderr), *variants]):
         observer = capacity.CodexAdmissionObserver()
         capture = FanoutOutput(protocol='codex', observer=observer.observe)
         result = signal_safe_unit_runner([sys.executable, '-c',
@@ -97,7 +97,16 @@ def negative_admission_cases() -> int:
                                              '/owned', 'invocation-1', 'attempt-1')
         receipt = observer.receipt(capture, binding=binding, source=source, returncode=result.returncode,
                                    process_started=True, fresh_exec=True, artifact_observed=False)
-        assert (receipt is not None) == ((out, err) == (stdout, stderr)), 'admission framing misclassified'
+        # A bare "misclassified" left three hosted-runner failures (#1482)
+        # undiagnosable: the message now names the variant and every input
+        # the receipt consults, so a runner-side capture difference can be
+        # told apart from a framing regression from the CI log alone.
+        assert (receipt is not None) == ((out, err) == (stdout, stderr)), (
+            f'admission framing misclassified: variant={index} out={out!r} err={err!r} '
+            f'returncode={result.returncode} events={observer.events} valid={observer.valid} '
+            f'streams={capture.streams()!r} issues={capture.issues!r} '
+            f'stdout_window={capture.error_window("stdout")!r} stderr_window={capture.error_window("stderr")!r}'
+        )
         if receipt is not None:
             cases: list[tuple[capacity.CodexAdmissionSource | None, int | None, bool, bool, bool]] = [
                 (None, 1, True, True, False), (source, 0, True, True, False),

--- a/tests/test_fanout_cancellation_states.py
+++ b/tests/test_fanout_cancellation_states.py
@@ -207,9 +207,16 @@ class CancelledJournalTests(unittest.TestCase):
 
 class InterruptedRunningUnitTests(unittest.TestCase):
     def setUp(self) -> None:
+        # The interrupt flag is process-global and the dispatch under test
+        # sets it. Clearing only BEFORE the test leaked the set flag to
+        # whichever test ran next in the same process: on the CI shard plan
+        # that was `test_fanout_capacity`'s C4 matrix, whose direct
+        # `signal_safe_unit_runner` spawn then hit register-then-check and
+        # was SIGTERMed before writing a byte (#1482). Restore it after too.
         from omh.coding.fanout_dispatch import _INTERRUPT_FLAG
 
         _INTERRUPT_FLAG.clear()
+        self.addCleanup(_INTERRUPT_FLAG.clear)
 
     def test_a_signal_killed_unit_records_cancelled_rather_than_a_model_failure(self) -> None:
         with TemporaryDirectory() as tmp:

--- a/tests/test_fanout_signal_safety.py
+++ b/tests/test_fanout_signal_safety.py
@@ -74,10 +74,13 @@ class SignalSafeRunnerTests(unittest.TestCase):
     def setUp(self) -> None:
         # The interrupt flag is process-global (one dispatch per process is
         # the supported shape); direct runner tests must not inherit a
-        # sibling test's interrupt.
+        # sibling test's interrupt — and must not bequeath their own:
+        # `terminate_live_unit_groups` below sets it, and a later test's
+        # direct spawn would be terminated on register-then-check (#1482).
         from omh.coding.fanout_dispatch import _INTERRUPT_FLAG
 
         _INTERRUPT_FLAG.clear()
+        self.addCleanup(_INTERRUPT_FLAG.clear)
 
     @posix_only
     def test_unit_runs_as_its_own_group_leader(self) -> None:
@@ -256,6 +259,13 @@ class SignalSafeRunnerTests(unittest.TestCase):
 
 
 class InterruptedDispatchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Same process-global flag; the interrupted dispatches below set it.
+        from omh.coding.fanout_dispatch import _INTERRUPT_FLAG
+
+        _INTERRUPT_FLAG.clear()
+        self.addCleanup(_INTERRUPT_FLAG.clear)
+
     def _fixture(self, tmp: str):
         root = Path(tmp)
         paths = _paths(tmp)


### PR DESCRIPTION
## Feature Report

Closes #1482.

### What Changed

- `tests/test_fanout_cancellation_states.py`, `tests/test_fanout_signal_safety.py`: every test class that sets the process-global `_INTERRUPT_FLAG` (`InterruptedRunningUnitTests`, `SignalSafeRunnerTests`, `InterruptedDispatchTests`) now restores it with `addCleanup(_INTERRUPT_FLAG.clear)` instead of clearing it only in `setUp`.
- `tests/five_issue_cases/capacity.py` (first commit): the C4 `admission framing misclassified` assertion reports the variant index and every input `CodexAdmissionObserver.receipt` consults — this is what named the cause from the CI log.

### Why This Exists

Every CI shard-1 run since 2026-09-11 ~04:38Z failed `test_c4_real_process_negative_admission_matrix` (three branches, including one unrelated to this session), while the test passed locally. The diagnostic message in this PR's own first CI run read: `variant=0 … returncode=-15 events=0 streams=[…'original_bytes': 0…]` — the base case's child was SIGTERMed before writing a byte. That is `signal_safe_unit_runner`'s register-then-check firing because `_INTERRUPT_FLAG` was already set: the interrupted-dispatch tests set it and cleared it only before themselves, never after, and the shard planner (`tools/test_sharding/plan.py`, LPT over the cached timings history) had placed `InterruptedRunningUnitTests.test_a_signal_killed_unit_…` immediately before `test_fanout_capacity` in shard 1 (plan artifact of run 34567560865). Runner image and Python patch levels were identical between the last green main run and the failing ones; no fanout code changed.

Local reproduction: `PYTHONPATH=tests uv run python -m unittest tests.test_fanout_cancellation_states tests.test_fanout_capacity.CapacityPublicIntegrationTests.test_c4_real_process_negative_admission_matrix` → the same assertion. With this change the same command passes.

### User / Operator Impact

None at runtime; CI is unblocked for every open PR.

### Files And Contracts Touched

`tests/test_fanout_cancellation_states.py`, `tests/test_fanout_signal_safety.py`, `tests/five_issue_cases/capacity.py`. No `src/` change.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [x] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [ ] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` (result posted as a comment when the run finishes)
- [x] `git diff --check`
- [x] Relevant dry-run or smoke command: the two reproduction orders above (`cancellation_states → C4`, `signal_safety → C4`) and the three fanout test files (50 tests) — all OK

### Observed Evidence

- Before the fix, in this order: `FAIL: test_c4_real_process_negative_admission_matrix … admission framing misclassified: variant=0 … returncode=-15 events=0`; after: `Ran 11 tests … OK`.
- CI on this PR is the shard-level proof.

### Not Tested / Not Applicable

- Release / harness checks: tests only.

## Risk

- None to product code. Order-dependent leaks of other process-global state remain possible; the shard planner reorders tests whenever the timings cache moves, which is how this one surfaced.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- #1480 picks this up by merging `main` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfePFn3Q9axYU2fBGhpCMV