### PR TITLE
fix(coding): a failed dispatch stops reporting success

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,26 @@ Rules:
 - Grepping the repo and matching stale strings under `build/lib/` — it is a
   gitignored copy of old sources. Scope searches to `src/`, `tests/`, `docs/`,
   `skills/`.
+- Letting an exit code report success over work that failed. On 2026-09-11
+  every unit of a dispatch failed on a provider session limit and
+  `omh coding fanout dispatch` exited `0`, so a wrapper reading only the status
+  was told the batch succeeded. The mapper had a case for a refusal, with a
+  docstring saying a shell that only checks the status must not read "nothing
+  was dispatched" as success — the sentence was right and had been applied to
+  only one of the ways work fails to happen.
+  `tests/test_exit_code_truthfulness_policy.py` now re-derives every
+  `*_exit_code` mapper under `src/commands/` and fails when one maps a summary
+  carrying a failure signal to `0`. It says nothing about which code to return,
+  so a new command keeps its own vocabulary and its own recoverable lane; it
+  only may not call failure success.
+- Matching a provider's refusal by wording alone. The limit-shape patterns in
+  `src/coding/fanout_dispatch.py` are how a failure becomes recoverable rather
+  than terminal, and the same day the exit code lied, `You've hit your session
+  limit` matched none of the twelve patterns and classified as `crash` — a
+  condition that clears at a stated time, recorded as a permanent fault. When a
+  provider adds a phrasing, add the pattern and a verbatim regression case; when
+  you add a pattern, check it against ordinary narration in the same commit, the
+  way the existing anchors are deliberately multi-word.
 - Trusting a red run before clearing `build/`. A `ModuleNotFoundError` whose
   traceback names a `build/__editable__…` path is the gitignored editable
   install, not the tree you are editing: your venv's copy predates a module the

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -678,6 +678,16 @@ _LIMIT_SHAPED_PATTERNS: tuple[tuple[str, str], ...] = (
     ("credit", "insufficient credit"),
     ("credit", "out of credits"),
     ("limit_reached", "limit reached"),
+    # Observed 2026-09-11: two dispatches ended with "You've hit your session
+    # limit · resets 6:10pm (Asia/Seoul)" and classified as `crash`, because
+    # every pattern above wants "rate", "usage", "quota", a 429, a credit, or
+    # the exact words "limit reached". A session limit is the same thing those
+    # describe -- the provider declining to serve this owner until a stated
+    # reset -- so it belongs in the recoverable lane, not the terminal one.
+    # Anchored on the possessive phrasing and on "session limit" together:
+    # a bare "session" matches half of this repo's own narration.
+    ("session_limit", "session limit"),
+    ("session_limit", "hit your limit"),
 )
 
 # Spawnability is a data property: profiles listed here have a local headless

--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -2308,15 +2308,29 @@ def _write_stderr_line(line: str) -> None:
 
 
 def _fanout_dispatch_exit_code(summary: dict) -> int:
-    """130 for a cut-short batch, 1 for a refusal, 0 otherwise.
+    """130 for a cut-short batch, 1 for a refusal or any failed unit, 0 otherwise.
 
     A spawn-guard refusal exits non-zero on purpose: the summary is still
     printed as JSON so a wrapper can read `refusal_reason`, but a shell that
     only checks the status must not read "nothing was dispatched" as success.
+
+    The same sentence applies to a unit that ran and failed, and until
+    2026-09-11 it did not: a batch whose every unit failed exited 0, so a
+    caller reading only the status was told the work succeeded. That is how a
+    real limit-exhausted run came back "ok" to its wrapper while the inner
+    dispatch had exit 1 and no report. `failure_kind` is the closed enum
+    `classify_failure_kind` sets on a failed unit and leaves empty on a
+    successful one, so presence is the signal and no status vocabulary is
+    duplicated here.
     """
     if summary.get("interrupted"):
         return 130
     if summary.get("refused"):
+        return 1
+    units = summary.get("units")
+    if isinstance(units, list) and any(
+        isinstance(unit, dict) and unit.get("failure_kind") for unit in units
+    ):
         return 1
     return 0
 

--- a/tests/test_exit_code_truthfulness_policy.py
+++ b/tests/test_exit_code_truthfulness_policy.py
@@ -1,0 +1,119 @@
+"""Gate: a command's exit code never reports success over failed work.
+
+On 2026-09-11 two real dispatches ended with "You've hit your session limit",
+every unit failed, and `omh coding fanout dispatch` exited **0**. A wrapper
+reading only the status was told the batch succeeded, the plan's checklist
+stayed marked running, and the operator learned otherwise only by opening the
+report. `_fanout_dispatch_exit_code` had a case for a refusal -- with a
+docstring saying in as many words that "a shell that only checks the status
+must not read 'nothing was dispatched' as success" -- and no case for a unit
+that ran and failed. The sentence was right and it had only been applied to
+half the ways work does not happen.
+
+This module re-derives every exit-code mapper from source rather than naming
+them, so the class cannot come back through a function nobody added here. It
+is deliberately narrow: it does not say what a mapper must return for any
+particular input, only that a summary carrying a failure signal must not map
+to 0. A new command is free to define its own vocabulary, its own recoverable
+lane and its own codes; it is not free to call failure success.
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+from typing import Any, Callable
+
+from _local_package import load_local_package
+
+load_local_package()
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMMANDS_ROOT = REPO_ROOT / "src" / "commands"
+
+# A mapper is a module-level function whose name ends `_exit_code` and which
+# takes exactly one positional argument: the result it is grading. The suffix
+# is the convention in use; a mapper spelled differently should be renamed
+# into it rather than exempted, so the next reader finds it here.
+MAPPER_SUFFIX = "_exit_code"
+
+# Summaries that mean "the work did not happen", each with the shape a real
+# caller would see. Every mapper must refuse to call any of these a success.
+FAILURE_SUMMARIES: tuple[tuple[str, dict[str, Any]], ...] = (
+    ("one unit failed", {"units": [{"unit_id": "a", "failure_kind": "crash"}]}),
+    (
+        "every unit failed",
+        {
+            "units": [
+                {"unit_id": "a", "failure_kind": "limit_shaped"},
+                {"unit_id": "b", "failure_kind": "crash"},
+            ]
+        },
+    ),
+    ("the batch was refused", {"refused": True, "refusal_reason": "spawn guard"}),
+    ("the batch was cut short", {"interrupted": True}),
+)
+
+# The one shape that must still map to 0, so a mapper cannot pass this gate by
+# refusing everything.
+SUCCESS_SUMMARY: dict[str, Any] = {"units": [{"unit_id": "a"}, {"unit_id": "b"}]}
+
+
+def _discovered_mappers() -> list[tuple[str, str]]:
+    """`(module stem, function name)` for every exit-code mapper under src/commands."""
+    found: list[tuple[str, str]] = []
+    for path in sorted(COMMANDS_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not node.name.endswith(MAPPER_SUFFIX):
+                continue
+            positional = len(node.args.args) + len(node.args.posonlyargs)
+            if positional != 1:
+                continue
+            found.append((path.stem, node.name))
+    return found
+
+
+def _load(module_stem: str, function_name: str) -> Callable[[Any], int]:
+    module = __import__(f"omh.commands.{module_stem}", fromlist=[function_name])
+    return getattr(module, function_name)
+
+
+class ExitCodeTruthfulnessPolicyTests(unittest.TestCase):
+    def test_at_least_one_mapper_is_discovered(self) -> None:
+        # A discovery gate that silently finds nothing is not a gate. If the
+        # naming convention moves, this fails first and says so.
+        self.assertTrue(
+            _discovered_mappers(),
+            f"no *{MAPPER_SUFFIX} function found under {COMMANDS_ROOT}; the convention moved",
+        )
+
+    def test_no_mapper_reports_success_over_failed_work(self) -> None:
+        for module_stem, function_name in _discovered_mappers():
+            mapper = _load(module_stem, function_name)
+            for label, summary in FAILURE_SUMMARIES:
+                with self.subTest(mapper=f"{module_stem}.{function_name}", case=label):
+                    self.assertNotEqual(
+                        mapper(summary),
+                        0,
+                        f"{module_stem}.{function_name} returned 0 when {label}; "
+                        "a caller reading only the exit status would be told the work succeeded",
+                    )
+
+    def test_a_clean_summary_still_maps_to_zero(self) -> None:
+        for module_stem, function_name in _discovered_mappers():
+            mapper = _load(module_stem, function_name)
+            with self.subTest(mapper=f"{module_stem}.{function_name}"):
+                self.assertEqual(
+                    mapper(SUCCESS_SUMMARY),
+                    0,
+                    f"{module_stem}.{function_name} refused a summary with no failure signal; "
+                    "this gate must not be satisfiable by failing everything",
+                )
+
+
+if __name__ == "__main__":  # pragma: no cover - unittest entry point
+    unittest.main()

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -2736,6 +2736,36 @@ class FanoutDispatchTelemetryTests(unittest.TestCase):
             result_events = [e for e in shown["journal_events"] if e["event"] == "executor_result_observed"]
             self.assertIn("limit-shaped failure (usage_limit)", result_events[-1]["summary"])
 
+    def test_a_session_limit_is_limit_shaped_and_not_a_crash(self) -> None:
+        # Observed 2026-09-11: two real dispatches ended with this exact line and
+        # were recorded as `crash`, so the recoverable lane never opened for a
+        # condition that clears by itself at a stated time. Quoted verbatim,
+        # middle dot and timezone included, because the earlier patterns missed
+        # it on wording alone.
+        with TemporaryDirectory() as tmp:
+            units = [
+                {"unit_id": "core", "title": "Core", "owner": "codex", "file_scope": ["src/core/"]},
+            ]
+            paths, repo, sha, contract = self._setup(tmp, units=units)
+
+            def runner(argv, **kwargs):
+                if argv[0] == "git":
+                    return subprocess.run(argv, **kwargs)
+                if argv[0] == "codex":
+                    return _FakeCompleted(
+                        1, "You've hit your session limit \u00b7 resets 6:10pm (Asia/Seoul)"
+                    )
+                return _FakeCompleted(0, "done")
+
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                runner=runner, readiness=_ready,
+            )
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+            self.assertTrue(core["limit_shaped"])
+            self.assertEqual(core["limit_pattern"], "session_limit")
+            self.assertEqual(core["failure_kind"], "limit_shaped")
+
     def test_unrelated_429_and_disk_quota_text_are_not_limit_shaped(self) -> None:
         with TemporaryDirectory() as tmp:
             units = [


### PR DESCRIPTION
## Feature Report

### What Changed

- `src/coding/fanout_dispatch.py` — the limit-shape patterns gain `session limit` and `hit your limit`, so a provider declining until a stated reset classifies as `limit_shaped` rather than `crash`.
- `src/commands/coding.py` — `_fanout_dispatch_exit_code` returns 1 when any unit carries a `failure_kind`. It previously returned 0 for a batch whose every unit failed.
- `tests/test_exit_code_truthfulness_policy.py` — new gate. It re-derives every `*_exit_code` mapper under `src/commands/` from source and fails when one maps a summary carrying a failure signal to 0.
- `tests/test_fanout_dispatch.py` — regression case quoting the observed message verbatim.
- `CLAUDE.md` — both classes recorded under Common Pitfalls.

### Why This Exists

Two defects, observed together in a real run on 2026-09-11 and separable only after the second one was found.

A provider declined with `You've hit your session limit · resets 6:10pm (Asia/Seoul)`. None of the twelve limit-shape patterns matched: they want "rate", "usage", "quota", a 429, a credit, or the exact words "limit reached". So a condition that clears by itself at a stated time classified as `crash` — the terminal lane — and the recovery choice that `limit_shaped` exists to offer was never made.

**Fixing the pattern alone would not have helped.** `_fanout_dispatch_exit_code` returned 0 for every failed unit:

```
every unit failed     -> exit 0
limit-shaped failure  -> exit 0
refused               -> exit 1
interrupted           -> exit 130
```

A wrapper reading only the status was told the work succeeded. That is how the run's own plan stayed marked running while the inner dispatch had exit 1 and produced no report. The mapper already carried the right sentence in its docstring — that a shell which only checks the status must not read "nothing was dispatched" as success — and it had been applied to a refusal and not to a unit that ran and failed. The sentence was right; it covered one of the two ways work fails to happen.

### The chain this breaks, measured after the fix was written

The pattern miss is not one defect with one consequence. `_record_limit_signal`
is called only when `limit_label` is non-empty (`src/coding/fanout_dispatch.py:4274`),
and the label only exists when a pattern matched. So the miss silently removed
the signal too:

```
message matches no pattern
  -> limit_label is ""
  -> failure_kind is crash, not limit_shaped        (terminal, no recovery choice)
  -> _record_limit_signal never runs                (no advisory written)
  -> executor readiness still reports available     (last_limit_signal: {})
  -> the next dispatch walks into the same wall
  -> and the exit code says 0, so the caller is told it worked
```

Confirmed on this machine rather than reasoned: the readiness report written
during the affected run carries `"last_limit_signal": {}` alongside
`"available": true` and `"exit_code": 0`, for an account that could not serve a
request until a stated reset.

Both ends of that chain are what this PR changes, and the middle follows on its
own: a matched pattern produces a label, a label records the signal, and a
recorded signal is what readiness reads.

### User / Operator Impact

- A session limit now reaches the recoverable lane, so the later-attempt choice is offered instead of the batch being recorded as a permanent fault.
- `omh coding fanout dispatch` exits non-zero when units failed, so a wrapper, a shell, or a plan checklist that reads the status is no longer told success over failed work.

### How It Works

`failure_kind` is the closed enum `classify_failure_kind` sets on a failed unit and leaves empty on a successful one, so its presence is the signal and no status vocabulary is duplicated in the mapper.

The gate is deliberately narrow. It discovers mappers by convention rather than by a maintained list, so a new one is covered without anyone remembering this file. It says nothing about *which* code to return: a new command keeps its own vocabulary, its own recoverable lane and its own codes. It may not call failure success. A clean summary must still map to 0, so the gate cannot be satisfied by refusing everything.

### Files And Contracts Touched

- `src/coding/fanout_dispatch.py` — `_LIMIT_SHAPED_PATTERNS`
- `src/commands/coding.py` — `_fanout_dispatch_exit_code`
- `tests/test_exit_code_truthfulness_policy.py` (new), `tests/test_fanout_dispatch.py`, `CLAUDE.md`

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests` — `Ran 10999 tests`, `OK (skipped=3)`
- [x] `uv run --group lint ruff check src tests` — All checks passed
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs claims --check --json`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [x] `uv run python -m omh.cli docs navigation --check`
- [x] `uv run python -m omh.cli docs ulw-inventory --check` and `ulw-site --check`
- [x] `git diff --check`
- [ ] `harness validate`, `release checklist`, `release hermes-smoke`, installed-CLI smoke — not run; no catalog, skill, generated artifact, installer or release surface is touched.
- [ ] Manual Hermes/TUI check — not applicable, no TUI surface.

### Observed Evidence

- Both guards bite. Removing the two patterns turns the regression case red; reverting the exit-code fix turns the policy gate red on both failed-unit cases, naming the mapper and the case: `coding._fanout_dispatch_exit_code returned 0 when every unit failed; a caller reading only the exit status would be told the work succeeded`.
- The new patterns do not widen onto ordinary narration: `session started` and `resume the session` match nothing.
- The existing `usage limit` case still matches on both of its labels, so no prior classification moved.

### Not Tested / Not Applicable

- No live provider limit was induced. The message is quoted verbatim from the observed run rather than reproduced against a provider, and the regression case asserts on that exact string.
- The gate discovers exactly one mapper today. Its value is prospective: a second mapper is covered without an edit here.

## Risk

Low, and one behaviour change worth a reviewer's eye: a dispatch with a partially failed batch now exits 1 where it exited 0. That is the intended correction, but any automation that treated `omh coding fanout dispatch` exit 0 as "the command ran" rather than "the work succeeded" will see the difference. The summary JSON is unchanged, so a caller that reads `units` rather than the status is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhN96KFcrfPRQySG4Txqnm
