### PR TITLE
feat(todo): drive open plans forward and report stalls even while calls run

### DIFF
--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -892,13 +892,24 @@ export default function register(sdk) {
     // no stall hint, same as before this signal existed.
     const answerable = !!(payload.activity && payload.activity.post_tool_call_observed)
     const live = answerable ? !!(payload.activity && payload.activity.live) : true
-    // The reader computes this age fresh on every read_omh_hud call (see
-    // `updated_age_seconds` in runtime_reader.py's `_todo_summary`) so it
-    // stays honest even when applySnapshot's byte-identical-payload check
-    // skips a repaint; a Date.now() computed here in render would freeze at
-    // whatever second it last actually rendered on an idle snapshot.
-    const stallElapsed = (() => {
-      if (live) return ''
+    // Colour and motion above answer "is anything running right now", which
+    // is an instantaneous reading and rightly flips the moment a call opens
+    // or closes. The elapsed hint below answers a different question -- has
+    // this checklist visibly stopped moving -- and that verdict is the
+    // READER's (`todo.stall` in runtime_reader.py's `_todo_stall`), so the
+    // TUI panel, the text HUD line and the per-turn reminder all state the
+    // same finding under the same rule instead of this renderer owning one
+    // copy of it. It fires only past the tool-call in-flight TTL, so a gap a
+    // single running call could still explain says nothing at all. The word
+    // is "unchanged", not "stalled": a plan waiting on the person is
+    // unchanged, and the payload's claim_boundary says so too.
+    // The age itself the reader computes fresh on every read_omh_hud call
+    // (see `updated_age_seconds`), so it stays honest even when
+    // applySnapshot's byte-identical-payload check skips a repaint; a
+    // Date.now() computed here in render would freeze at whatever second it
+    // last actually rendered on an idle snapshot.
+    const unchangedElapsed = (() => {
+      if (!todo.stall || todo.stall.status !== 'unchanged') return ''
       const seconds = todo.updated_age_seconds
       return Number.isFinite(seconds) ? elapsedText(Math.max(0, seconds)) : ''
     })()
@@ -945,9 +956,10 @@ export default function register(sdk) {
         h(Text, { color: t.color.muted }, `... (${count} ${side} task${count === 1 ? '' : 's'})`),
       )
     // The active item's text carries the colour wave ONLY while live; motion
-    // implies "actually running", so a stalled item renders as static warn
-    // text plus an elapsed hint instead -- the marker and indent stay the
-    // same shape either way, only the state they claim changes.
+    // implies "actually running", so a not-live item renders as static warn
+    // text instead, plus the reader's elapsed hint once the checklist has
+    // been unchanged long enough to be a finding -- the marker and indent
+    // stay the same shape either way, only the state they claim changes.
     const itemNode = (item, indent) =>
       item.state === 'active'
         ? live
@@ -961,7 +973,7 @@ export default function register(sdk) {
               Text,
               { wrap: 'truncate-end' },
               h(Text, itemProps(item), `${indent}${markers.active} ${truncateCells(item.text, budget)}`),
-              stallElapsed ? h(Text, { color: t.color.muted }, ` (stalled ${stallElapsed})`) : null,
+              unchangedElapsed ? h(Text, { color: t.color.muted }, ` (unchanged ${unchangedElapsed})`) : null,
             )
         : h(Text, itemProps(item), `${indent}${itemLabel(item)}`)
     const rows = []

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -20,7 +20,11 @@ from .subagent_graph_contract import (
     GRAPH_CONTRACT_UNIT_LIMIT,
     recorded_contract_blocker,
 )
-from .tool_bursts import tool_call_projection
+from .tool_bursts import (
+    TOOL_CALL_OPEN_TTL_SECONDS,
+    tool_call_activity,
+    tool_call_projection,
+)
 from .metadata import (
     OPTIONAL_HOOKS,
     PROVIDED_HOOKS,
@@ -50,6 +54,21 @@ HUD_PRESETS = {"minimal", "focused", "full"}
 # How long a fully-done plan keeps rendering after its last update.
 ALL_DONE_TODO_LINGER_SECONDS = 15 * 60
 TODO_DISPLAY_ITEM_LIMIT = 3
+# How long an established plan's checklist may sit unchanged before the reader
+# reports that it has stopped moving. NOT a guessed threshold: it is the tool
+# ledger's own bound for how long an unclosed call may still be presumed in
+# flight (`TOOL_CALL_OPEN_TTL_SECONDS`), so past it the wait cannot be
+# explained by one long tool call this install observed. Deriving it from that
+# constant keeps the two rules from drifting apart.
+TODO_UNCHANGED_SECONDS = TOOL_CALL_OPEN_TTL_SECONDS
+# The two statuses that ARE the finding; every other value is a way of being
+# silent. Named once so a caller cannot cover one and miss the other.
+TODO_UNCHANGED_STATUSES: frozenset[str] = frozenset({"unchanged", "unchanged_while_busy"})
+TODO_STALL_CLAIM_BOUNDARY = (
+    "Elapsed time since this checklist last changed, paired with whether this OMH "
+    "install currently has a tool call open. Not evidence that work failed, that "
+    "the session stopped, or that the plan should be resumed."
+)
 # Merged activity rows carried to HUD surfaces. Matches the native reader's
 # own per-source bound (`hermes_delegation._ROW_LIMIT`); the TUI widget
 # applies its viewport clamp on top and names anything hidden with `+N more`.
@@ -802,7 +821,9 @@ def read_omh_hud(
         "runtime": _hud_runtime_summary(status_payload, latest_run),
         "achievements": _achievements_summary(hermes),
         "tokens": _token_summary(token_metadata or {}),
-        "todo": _todo_summary(home, hermes, session_ref, tui_session_ref),
+        "todo": _todo_summary(
+            home, hermes, session_ref, tui_session_ref, activity=tool_calls["activity"]
+        ),
         # Concurrent tool-call batches observed by the pre_tool_call hook;
         # the [OMH] status line brands a fresh batch as a parallel shot.
         "parallel_shot": tool_calls["parallel_shot"],
@@ -1769,12 +1790,108 @@ def default_omh_home() -> Path:
     return _default_omh_home()
 
 
+def elapsed_text(seconds: float) -> str:
+    """``12s`` / ``4m 3s`` / ``2h 01m``.
+
+    Byte-identical to the widget's own ``elapsedText``, so the same elapsed
+    figure reads the same whether it arrives through the TUI panel, the text
+    HUD line, or the per-turn reminder.
+    """
+    total = max(0, int(seconds))
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        return f"{total // 60}m {total % 60}s"
+    return f"{total // 3600}h {total // 60 % 60:02d}m"
+
+
+def _todo_stall(activity: dict[str, Any] | None, age: float | None) -> dict[str, Any]:
+    """Whether an established plan's checklist has visibly stopped moving.
+
+    One finding and four ways of being silent, each of which names WHY it is
+    silent rather than collapsing into a bare false:
+
+    * ``unobserved`` -- there is no established plan to say anything about.
+    * ``unanswerable`` -- this install has never observed ``post_tool_call``
+      fire, so the in-flight ledger can only expire entries, never
+      legitimately close them. Liveness cannot be read either way here and
+      inverting that silence into a stall would brand a working agent stopped.
+    * ``live`` -- a tool call this install opened is still open AND the
+      checklist changed recently enough that the open call explains the gap.
+      Liveness excuses a short pause, never an indefinite one.
+    * ``unchanged_while_busy`` -- past the threshold with a call open. This is
+      a finding, not silence: calls are being made and the plan is not moving.
+    * ``idle`` -- nothing is open, but the checklist changed recently enough
+      that one tool call could still account for the gap.
+    * ``unchanged`` -- nothing is open AND the checklist has not changed for
+      at least ``TODO_UNCHANGED_SECONDS``. This is the finding.
+
+    Every ambiguity resolves toward silence. The ledger is machine-wide (see
+    ``tool_bursts``), so a sibling session holding one call open suppresses
+    this session's finding: a false negative, which is the safe direction for
+    a signal that must not cry wolf.
+    """
+    past_threshold = age is not None and age >= TODO_UNCHANGED_SECONDS
+    if activity is None:
+        status = "unobserved"
+    elif not activity.get("post_tool_call_observed"):
+        status = "unanswerable"
+    elif past_threshold:
+        # A live call explains a SHORT gap and nothing longer. Suppressing the
+        # finding whenever anything is open would read "a process is alive" as
+        # "the work is advancing", which is the exact substitution that let a
+        # real run spend 36 minutes retrying git workarounds while its plan sat
+        # on one item: tool calls opened and closed the whole time, so a
+        # liveness-gated signal would have stayed silent through the thing it
+        # exists to catch. Past the threshold the checklist not moving IS the
+        # finding, and whether something is open only changes which sentence
+        # is true about it.
+        status = "unchanged_while_busy" if activity.get("live") else "unchanged"
+    elif activity.get("live"):
+        status = "live"
+    else:
+        status = "idle"
+    return {
+        "status": status,
+        "threshold_seconds": TODO_UNCHANGED_SECONDS,
+        "claim_boundary": TODO_STALL_CLAIM_BOUNDARY,
+    }
+
+
+def todo_unchanged_text(todo: dict[str, Any]) -> str:
+    """How long this checklist has been unchanged, when that is the finding.
+
+    Empty for every other stall status, so a caller renders the hint by
+    appending this and nothing else; the projection's own status stays the
+    single place the rule lives.
+    """
+    stall = todo.get("stall")
+    # Both findings carry the age. `unchanged_while_busy` is the same fact with
+    # calls running, and dropping it here would have silently reinstated the
+    # liveness suppression the status split exists to remove.
+    if not isinstance(stall, dict) or stall.get("status") not in TODO_UNCHANGED_STATUSES:
+        return ""
+    seconds = todo.get("updated_age_seconds")
+    if not isinstance(seconds, (int, float)) or isinstance(seconds, bool):
+        return ""
+    return elapsed_text(seconds)
+
+
 def _todo_summary(
     home: Path,
     hermes: Path | None = None,
     session_ref: str = "",
     tui_session_ref: str = "",
+    activity: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    """Project the reading session's plan todo.
+
+    ``activity`` is the tool-call liveness projection the stall finding pairs
+    the checklist's age with. ``read_omh_hud`` already reads it for its own
+    block and passes it in so one poll sees one ledger state; a caller that
+    has none (``read_omh_todo``) makes the reader take its own read, and only
+    for a plan that is actually established.
+    """
     empty = {
         "status": "absent",
         "title": "",
@@ -1785,6 +1902,7 @@ def _todo_summary(
         "display_items": [],
         "display_phase": "",
         "more_count": 0,
+        "stall": _todo_stall(None, None),
     }
     session_id, session = _reading_session(hermes, session_ref or tui_session_ref)
     record, own_record = _own_todo_record(home, session_id)
@@ -1905,6 +2023,17 @@ def _todo_summary(
     # on every read_omh_hud call, so shipping it as a field keeps the number
     # honest; VOLATILE_KEYS carries it forward on the metrics repaint cadence.
     summary["updated_age_seconds"] = age
+    # The finding the age was already enough to support and nobody stated:
+    # computed once here, so the TUI panel, the text HUD line, the per-turn
+    # reminder and `omh runtime todo show` all read one verdict instead of
+    # each re-deriving it (only the TUI ever did). The block carries no
+    # elapsed number of its own -- `updated_age_seconds` above is the one
+    # figure, and it is the one VOLATILE_KEYS already throttles, so the
+    # status flip stays structural and repaints promptly while the seconds
+    # keep ticking on the metrics cadence.
+    summary["stall"] = _todo_stall(
+        activity if activity is not None else tool_call_activity(str(home)), age
+    )
     return summary
 
 
@@ -2006,6 +2135,15 @@ def _hud_todo_lines(todo: dict[str, Any], *, preset: str = "focused") -> list[st
     full = preset == "full"
     shown = todo.get("items", []) if full else todo.get("display_items", [])
     marker = {"done": "[✓]", "active": "[•]", "pending": "[ ]"}
+    # The stall finding rides the item it is about. Silent unless the reader
+    # actually observed it -- an unanswerable host, a live tool call, or a
+    # checklist that moved recently all render exactly as they did before.
+    unchanged = todo_unchanged_text(todo)
+
+    def item_line(item: dict[str, Any], indent: str) -> str:
+        line = f"{indent}{marker[item['state']]} {item['text']}"
+        return f"{line} (unchanged {unchanged})" if unchanged and item["state"] == "active" else line
+
     lines = [header]
     if full:
         # Full preset walks every phase in declaration order with headers;
@@ -2020,14 +2158,14 @@ def _hud_todo_lines(todo: dict[str, Any], *, preset: str = "focused") -> list[st
             elif not phase and depth == 0:
                 last_phase = ""
             indent_depth = depth + (1 if last_phase else 0)
-            lines.append(f"{'  ' * indent_depth}{marker[item['state']]} {item['text']}")
+            lines.append(item_line(item, "  " * indent_depth))
     else:
         display_phase = str(todo.get("display_phase", ""))
         if display_phase:
             lines.append(display_phase)
         base_depth = 1 if display_phase else 0
         lines.extend(
-            f"{'  ' * (base_depth + int(item.get('depth', 0) or 0))}{marker[item['state']]} {item['text']}"
+            item_line(item, "  " * (base_depth + int(item.get("depth", 0) or 0)))
             for item in shown
         )
     more = 0 if full else int(todo.get("more_count", 0) or 0)

--- a/src/plugin_bundle/omh/todo_reconciliation.py
+++ b/src/plugin_bundle/omh/todo_reconciliation.py
@@ -8,12 +8,53 @@ state, not a phrasing — so while one exists, every turn's context
 carries one compact line that binds completion claims to the checklist.
 The reminder is awareness (instruction), never state and never
 evidence; it stops the moment the plan is all done or cleared.
+
+While the reader's stall finding stands, the same line also carries how
+long the checklist has been unchanged. That covers the other half of the
+failure: a plan does not only part ways with the session by being
+contradicted, it parts ways by being left behind while the session talks
+about something else.
 """
 from __future__ import annotations
 
-from .runtime_reader import read_omh_todo
+from .runtime_reader import read_omh_todo, todo_unchanged_text
 
 _MAX_ACTIVE_TEXT_CHARS = 80
+
+# The TUI has shown a stopped checklist to the PERSON since the in-flight
+# liveness signal landed; the session driving that checklist never saw the
+# finding anywhere. A plan that sits with one item active for hours while the
+# session answers about other things and ends its turns is the observed
+# failure, and it is not a completion claim, so the rule below cannot catch
+# it. This sentence states what the reader observed and asks for one sentence
+# of accounting. It rides a turn that is already happening and starts
+# nothing, which is exactly why it is a context line and not a driver.
+TODO_UNCHANGED_RULE = (
+    "The checklist standing still is an observation, not evidence that the work "
+    "failed: say where the plan stands, and if nothing is blocking it, move it."
+)
+
+# The half that was missing. The reconciliation rule below guards a COMPLETION
+# CLAIM -- it fires when the model says it is done while items are open. It has
+# nothing to say about the far more common way a plan dies: the model answers
+# whatever arrived, reports, and ends the turn with the list untouched. A real
+# run spent 36 minutes that way, and an earlier one ended with 3 of 5 phases
+# pending while every notification got a courteous status reply.
+#
+# `omh_todo` exists to carry a goal ACROSS turns. A checklist that only ever
+# catches a contradiction is a detector, not a plan. So this line states the
+# obvious thing nobody was saying: open items mean the work is not finished.
+#
+# The termination criterion is explicit and it is what keeps this bounded --
+# this is a long loop with a stop condition, not an unbounded one. It ends when
+# every item is done, or when an item is recorded blocked with its reason. It
+# does not end because a turn happened to produce a paragraph.
+TODO_CONTINUATION_RULE = (
+    "Open items mean this plan is not finished. Unless something is blocking "
+    "it, advance the next item in this turn rather than ending on a status "
+    "report. This stops when every item is done or an item is recorded blocked "
+    "with its reason -- not when a turn has produced an answer."
+)
 
 TODO_RECONCILIATION_RULE = (
     "Before claiming this work is finished, reconcile the checklist with "
@@ -52,4 +93,19 @@ def open_todo_reminder(*, omh_home: str = "", session_ref: str = "") -> str:
     head = f"[OMH plan todo] {done}/{total} done"
     if active:
         head = f"{head} · active: {active}"
-    return f"{head}. {TODO_RECONCILIATION_RULE}"
+    unchanged = todo_unchanged_text(todo)
+    if not unchanged:
+        return f"{head}. {TODO_CONTINUATION_RULE} {TODO_RECONCILIATION_RULE}"
+    stall = todo.get("stall") if isinstance(todo.get("stall"), dict) else {}
+    # "no tool call in flight" is only true of the quiet finding. The busy one
+    # is the more interesting reading and saying the wrong one would make the
+    # line refutable on its face.
+    observed = (
+        "unchanged {age} while calls kept running".format(age=unchanged)
+        if stall.get("status") == "unchanged_while_busy"
+        else "unchanged {age}, no tool call in flight".format(age=unchanged)
+    )
+    return (
+        f"{head} · {observed}. "
+        f"{TODO_CONTINUATION_RULE} {TODO_RECONCILIATION_RULE} {TODO_UNCHANGED_RULE}"
+    )

--- a/tests/test_todo_reconciliation.py
+++ b/tests/test_todo_reconciliation.py
@@ -5,18 +5,26 @@ visible contradiction the user reported directly. An open plan is a
 state, not a phrasing, so the guard is stateful: while an established
 todo has open items, every pre_llm_call turn carries one compact
 reconciliation line; a finished, cleared, or absent plan carries none.
+
+The second half of the same failure is a plan nobody contradicts and
+nobody advances: while the reader's stall finding stands, the line also
+states how long the checklist has been unchanged.
 """
 
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from omh.plugin_bundle.omh.hooks.llm_hooks import pre_llm_call
 from omh.plugin_bundle.omh.todo_reconciliation import (
+    TODO_CONTINUATION_RULE,
     TODO_RECONCILIATION_RULE,
+    TODO_UNCHANGED_RULE,
     open_todo_reminder,
 )
-from omh.plugin_bundle.omh.todo_store import build_todo_record, write_todo
+from omh.plugin_bundle.omh.todo_store import build_todo_record, todo_path, write_todo
+from omh.plugin_bundle.omh.tool_bursts import record_tool_call, record_tool_call_close
 
 
 class TodoReconciliationReminderTest(unittest.TestCase):
@@ -25,15 +33,38 @@ class TodoReconciliationReminderTest(unittest.TestCase):
         self.addCleanup(self._tmp.cleanup)
         self.home = str(Path(self._tmp.name) / "omh")
 
-    def _write_plan(self, states, session_ref=""):
+    def _write_plan(self, states, session_ref="", minutes_ago=0):
         items = [
             {"text": f"task {index}", "state": state, "phase": "Review"}
             for index, state in enumerate(states)
         ]
-        write_todo(
-            Path(self.home),
-            build_todo_record("plan", items, source="test", session_ref=session_ref),
-        )
+        record = build_todo_record("plan", items, source="test", session_ref=session_ref)
+        if minutes_ago:
+            stamp = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+            record["updated_at"] = stamp.isoformat().replace("+00:00", "Z")
+        write_todo(Path(self.home), record)
+        return todo_path(Path(self.home), session_ref)
+
+    def _observe_a_closed_tool_call(self):
+        """Make liveness answerable with nothing left open.
+
+        Without an observed ``post_tool_call`` the reader cannot read
+        liveness either way and says so, so a stall test that skipped this
+        would be asserting the unanswerable branch by accident.
+        """
+        record_tool_call("Bash", omh_home=self.home, tool_call_id="call-1")
+        record_tool_call_close("call-1", omh_home=self.home)
+
+    def _observe_an_open_tool_call(self):
+        """Answerable liveness with one call still open.
+
+        A closed call first, so ``post_tool_call_observed`` is true and the
+        reader is not on its unanswerable branch; then an open one, which is
+        the state a busy-but-unmoving run is in.
+        """
+        record_tool_call("Bash", omh_home=self.home, tool_call_id="call-1")
+        record_tool_call_close("call-1", omh_home=self.home)
+        record_tool_call("Bash", omh_home=self.home, tool_call_id="call-2")
 
     def test_the_reminder_binds_to_the_turn_session_own_plan(self):
         # A Slack session's open plan is not the TUI session's open work:
@@ -71,6 +102,75 @@ class TodoReconciliationReminderTest(unittest.TestCase):
             self.assertIsNotNone(payload)
             self.assertIn("[OMH plan todo] 1/3 done", str(payload.get("context", "")))
             self.assertIn("reconcile the checklist", str(payload.get("context", "")))
+
+    def test_a_checklist_left_behind_for_hours_says_so_on_the_turn(self):
+        # The observed failure: one item active, three behind it, untouched
+        # for two hours while the session answered about other things and
+        # ended its turns. The HUD computed the age and nothing said it.
+        self._write_plan(["done", "active", "pending", "pending"], minutes_ago=120)
+        self._observe_a_closed_tool_call()
+
+        line = open_todo_reminder(omh_home=self.home)
+
+        self.assertIn("unchanged 2h 00m, no tool call in flight", line)
+        self.assertIn(TODO_UNCHANGED_RULE, line)
+        self.assertIn(TODO_RECONCILIATION_RULE, line)
+        self.assertNotIn("\n", line)
+        # The line reports; it never upgrades the todo's own claim boundary.
+        self.assertIn("not evidence that the work failed", line)
+        # And it does ask for the plan to move, with the stop condition stated
+        # in the same breath. A checklist that only ever catches a completion
+        # claim is a detector; `omh_todo` exists to carry a goal across turns.
+        self.assertIn(TODO_CONTINUATION_RULE, line)
+        self.assertIn("advance the next item in this turn", line)
+        self.assertIn("every item is done or an item is recorded blocked", line)
+
+    def test_a_plan_that_stops_moving_while_calls_run_is_still_a_finding(self):
+        # The correction that matters most. Liveness excuses a short pause and
+        # nothing longer: a run that spent 36 minutes retrying git workarounds
+        # opened and closed tool calls the whole time, so a signal suppressed by
+        # mere liveness would have stayed silent through the case it exists for.
+        self._write_plan(["done", "active", "pending", "pending"], minutes_ago=120)
+        self._observe_an_open_tool_call()
+
+        line = open_todo_reminder(omh_home=self.home)
+
+        self.assertIn("unchanged 2h 00m while calls kept running", line)
+        self.assertNotIn("no tool call in flight", line)
+        self.assertIn(TODO_CONTINUATION_RULE, line)
+
+    def test_a_recently_updated_checklist_adds_no_unchanged_clause(self):
+        # Negative control: the same open plan, moved just now. The clause
+        # must be a finding, not ambient text on every open plan.
+        self._write_plan(["done", "active", "pending"])
+        self._observe_a_closed_tool_call()
+
+        line = open_todo_reminder(omh_home=self.home)
+
+        self.assertIn(TODO_RECONCILIATION_RULE, line)
+        self.assertNotIn("unchanged", line)
+        self.assertNotIn(TODO_UNCHANGED_RULE, line)
+
+    def test_a_recent_checklist_stays_quiet_while_a_tool_call_is_open(self):
+        # Liveness excuses a SHORT pause: a call is open and the plan moved a
+        # minute ago, so the open call fully explains the gap and there is
+        # nothing to report. Past the threshold the same open call explains
+        # nothing, which is what the busy-finding test above pins -- an earlier
+        # version of this module suppressed on liveness alone and would have
+        # gone silent through a 36-minute retry loop.
+        self._write_plan(["done", "active", "pending"], minutes_ago=1)
+        self._observe_a_closed_tool_call()
+        record_tool_call("Bash", omh_home=self.home, tool_call_id="call-running")
+
+        self.assertNotIn("unchanged", open_todo_reminder(omh_home=self.home))
+
+    def test_an_old_checklist_stays_quiet_when_liveness_is_unanswerable(self):
+        # A host that never fires post_tool_call cannot answer "is anything
+        # running": its ledger entries can only expire, never close. Silence
+        # there must not be inverted into a stall.
+        self._write_plan(["done", "active", "pending"], minutes_ago=120)
+
+        self.assertNotIn("unchanged", open_todo_reminder(omh_home=self.home))
 
     def test_the_awareness_opt_out_suppresses_the_reminder(self):
         self._write_plan(["done", "active", "pending"])

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -377,7 +377,10 @@ class TuiWidgetPackTests(unittest.TestCase):
             widget,
         )
         self.assertIn("color: item.state === 'active' ? (live ? t.color.ok : t.color.warn)", widget)
-        self.assertIn("stallElapsed ? h(Text, { color: t.color.muted }, ` (stalled ${stallElapsed})`)", widget)
+        self.assertIn(
+            "unchangedElapsed ? h(Text, { color: t.color.muted }, ` (unchanged ${unchangedElapsed})`)",
+            widget,
+        )
         self.assertIn("const seconds = todo.updated_age_seconds", widget)
         self.assertNotIn("Date.parse(safeText(todo.updated_at)", widget)
 
@@ -692,7 +695,7 @@ class TuiWidgetPackTests(unittest.TestCase):
             "const live = answerable ? !!(payload.activity && payload.activity.live) : true",
             widget,
         )
-        self.assertIn("stalled ${stallElapsed}", widget)
+        self.assertIn("unchanged ${unchangedElapsed}", widget)
         self.assertNotIn("Number.MAX_SAFE_INTEGER", widget)
         # Changed on purpose: the parallel-shot badge moved off the bottom
         # status line onto the dock-top frame rule — the transcript's


### PR DESCRIPTION
## Capability

The OMH TODO reminder now drives an open plan forward until an explicit stop criterion, and a plan that stops moving is reported as a finding even while tool calls keep running.

## Motivation

On 2026-09-11 a session maintaining 13 PRs left its TODO unchanged for 36 minutes. Its active item pointed at a process that had already died; the session answered every completion notification with a status report and ended the turn. The plan never advanced and nothing said so:

- The stall verdict lived only in the TUI widget renderer, so the reader and the per-turn reminder never carried it.
- An open tool call suppressed the finding entirely. A long git-retry loop keeps calls open the whole time, so the exact incident was silent.
- The reminder described the plan; it never said to move it. An earlier framing ("not an instruction to resume") was rejected by the owner: the TODO exists so a long loop keeps going until the goal is met.

## Implementation

- `src/plugin_bundle/omh/runtime_reader.py`: `todo.stall` = `{status, threshold_seconds, claim_boundary}` with statuses `unobserved` / `unanswerable` / `live` / `idle` / `unchanged` / `unchanged_while_busy`. Past the threshold, liveness no longer excuses the plan: calls-still-running becomes `unchanged_while_busy`.
- `src/plugin_bundle/omh/todo_reconciliation.py`: `TODO_CONTINUATION_RULE` — open items mean not finished; advance the next item this turn rather than ending on a status report; stops when every item is done or an item is recorded blocked with its reason. Emitted on every reminder with open items; stall reminders add the elapsed time and whether calls were running.
- `src/omh/tui_widgets/omh-status.mjs`: renders `(unchanged <elapsed>)` from the reader's verdict instead of computing its own.

The stop criterion is the loop bound: every item done, or an item recorded blocked with a reason. This is a long loop with a termination condition, not an unbounded one.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` → 10982 tests OK (skipped=3)
- `tests/test_todo_reconciliation.py` 11/11 including `test_a_plan_that_stops_moving_while_calls_run_is_still_a_finding`
- `tests/test_tui_widget_pack.py` 15/15
- docs workflows/roles/claims/capability-families/ulw-inventory/ulw-site/navigation `--check`, ruff, compileall, `git diff --check` all clean

## Risks

- The reminder is prompt text on the Hermes path; OMH cannot force a turn to continue. It can only stop the plan from being silently forgotten.
- Threshold reuses `TOOL_CALL_OPEN_TTL_SECONDS` (15 min); a legitimately long single tool call past that shows as `unchanged_while_busy`, which is the intended reading — the plan should have been updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhN96KFcrfPRQySG4Txqnm
