### PR TITLE
feat(coding): name the execution states of a dispatched unit

### DIFF
--- a/src/coding/unit_execution_state.py
+++ b/src/coding/unit_execution_state.py
@@ -1,0 +1,77 @@
+"""Execution states of one dispatched unit, kept apart from process liveness.
+
+A unit's process being alive says nothing about whether its work is moving.
+The 2026-09-11 incident had a worker alive for 36 minutes, retrying the same
+git workaround, while the supervisor read "PID alive" as progress. These
+states name what OMH has actually observed about the WORK, so that every
+surface (inflight markers, status board, run summary, reminders) says the
+same thing and none of them renders "alive" as "progressing".
+"""
+
+from __future__ import annotations
+
+UNIT_EXECUTION_STATE_SCHEMA_VERSION = "unit_execution_state/v1"
+
+# The work is producing new evidence: output growing, tests starting and
+# ending, result records appearing. Only this state means "progressing".
+UNIT_STATE_RUNNING = "running"
+# The worker asked a question or is waiting on a prompt nobody will answer.
+UNIT_STATE_AWAITING_INPUT = "awaiting_input"
+# A permission or sandbox denial stopped the work (file write, git index,
+# network where forbidden). Retrying under the same permissions cannot clear it.
+UNIT_STATE_PERMISSION_BLOCKED = "permission_blocked"
+# The provider refused for account reasons: session or usage limit, quota.
+UNIT_STATE_ACCOUNT_LIMIT = "account_limit"
+# Objects the work needs are absent in its isolation: partial-clone blobs,
+# a missing base commit, a ref that was described but never fetched.
+UNIT_STATE_DATA_MISSING = "data_missing"
+# The process is alive but the work is not moving: no new output past the
+# threshold, or the same error and the same workaround repeating.
+UNIT_STATE_PROGRESS_STALLED = "progress_stalled"
+# The process ended without a verified result. An exit code of 0 with the
+# required result missing is this state, never `verified`.
+UNIT_STATE_FAILED = "failed"
+# The result record was validated against the contract and its verification
+# was observed. This is the only success state.
+UNIT_STATE_VERIFIED = "verified"
+
+UNIT_EXECUTION_STATES = (
+    UNIT_STATE_RUNNING,
+    UNIT_STATE_AWAITING_INPUT,
+    UNIT_STATE_PERMISSION_BLOCKED,
+    UNIT_STATE_ACCOUNT_LIMIT,
+    UNIT_STATE_DATA_MISSING,
+    UNIT_STATE_PROGRESS_STALLED,
+    UNIT_STATE_FAILED,
+    UNIT_STATE_VERIFIED,
+)
+
+# States that end a unit. Everything else is still someone's job to observe.
+UNIT_TERMINAL_STATES = frozenset({UNIT_STATE_FAILED, UNIT_STATE_VERIFIED})
+
+# States where the process may well be alive and the work is still not
+# moving. A supervisor must treat these as needing intervention, not waiting.
+UNIT_STUCK_STATES = frozenset(
+    {
+        UNIT_STATE_AWAITING_INPUT,
+        UNIT_STATE_PERMISSION_BLOCKED,
+        UNIT_STATE_ACCOUNT_LIMIT,
+        UNIT_STATE_DATA_MISSING,
+        UNIT_STATE_PROGRESS_STALLED,
+    }
+)
+
+UNIT_EXECUTION_STATE_CLAIM_BOUNDARY = (
+    "States describe what OMH observed about the unit's work, not whether its "
+    "process exists. `running` requires new evidence; a live process with no "
+    "new evidence is `progress_stalled`. `verified` requires a validated "
+    "result record; an exit code alone never reaches it."
+)
+
+
+def is_terminal(state: str) -> bool:
+    return state in UNIT_TERMINAL_STATES
+
+
+def is_stuck(state: str) -> bool:
+    return state in UNIT_STUCK_STATES

--- a/tests/test_unit_execution_state.py
+++ b/tests/test_unit_execution_state.py
@@ -1,0 +1,30 @@
+import unittest
+
+from omh.coding import unit_execution_state as ues
+
+
+class UnitExecutionStateVocabularyTests(unittest.TestCase):
+    def test_every_state_is_exactly_one_of_terminal_stuck_or_running(self):
+        for state in ues.UNIT_EXECUTION_STATES:
+            memberships = [
+                state in ues.UNIT_TERMINAL_STATES,
+                state in ues.UNIT_STUCK_STATES,
+                state == ues.UNIT_STATE_RUNNING,
+            ]
+            self.assertEqual(sum(memberships), 1, state)
+
+    def test_verified_is_the_only_success_state(self):
+        successes = [s for s in ues.UNIT_EXECUTION_STATES if s == ues.UNIT_STATE_VERIFIED]
+        self.assertEqual(successes, ["verified"])
+        self.assertTrue(ues.is_terminal("verified"))
+        self.assertTrue(ues.is_terminal("failed"))
+        self.assertFalse(ues.is_terminal("running"))
+
+    def test_a_stalled_unit_is_stuck_not_terminal_and_not_running(self):
+        self.assertTrue(ues.is_stuck("progress_stalled"))
+        self.assertFalse(ues.is_terminal("progress_stalled"))
+        self.assertNotEqual(ues.UNIT_STATE_PROGRESS_STALLED, ues.UNIT_STATE_RUNNING)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

A shared vocabulary for the execution state of one dispatched unit, kept apart from whether its process is alive: `running`, `awaiting_input`, `permission_blocked`, `account_limit`, `data_missing`, `progress_stalled`, `failed`, `verified`.

## Motivation

On 2026-09-11 a worker stayed alive for 36 minutes retrying the same git workaround while the supervisor read "PID alive" as progress. The operator's post-mortem asked for an explicit state vocabulary in which process-alive and work-progressing can never render the same. Today the inflight marker, status board, and run summary each describe a unit as in-flight or alive; none says whether the work is moving.

## Implementation

- `src/coding/unit_execution_state.py`: the eight states, `UNIT_TERMINAL_STATES` (`failed`, `verified`), `UNIT_STUCK_STATES` (the five that need intervention while the process may still be alive), `is_terminal`, `is_stuck`, and a claim boundary. `verified` is the only success state and requires a validated result record; `running` requires new evidence.
- No consumer yet. Four follow-up PRs branch from this commit and consume it: workspace preflight (A), progress evidence and rendering (B/C), cause-specific recovery (D), completion chain and maestro polling (E).

## Verification (observed)

- `tests/test_unit_execution_state.py` 3/3 — every state is exactly one of terminal / stuck / running.
- ruff clean.

## Risks

None in isolation — new module and test only. The partition is what the follow-ups depend on; changing it later moves all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhN96KFcrfPRQySG4Txqnm
