### PR TITLE
feat(coding): probe the unit's workspace before the spawn, not after the failure

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -728,6 +728,40 @@ Rules:
   work that cannot resolve an executor becomes an explicit user choice, not
   retained Hermes implementation).
 
+## Workspace preflight
+
+`git worktree add` creating the isolation, and an executor readiness probe
+saying the binary runs, together answer neither of the questions that matter
+next: can a file be written in that worktree, and does it hold the objects the
+work names? On 2026-09-11 both said yes and the unit spent 36 minutes unable to
+write a git index, against a `blob:none` partial clone with fetching forbidden
+and case-only filename collisions on a case-insensitive filesystem.
+
+So immediately after the worktree exists and before any process is spawned,
+dispatch runs `coding/workspace_preflight.py::probe_workspace` **in that
+worktree**, with a bounded timeout on every command and no network call. Four
+checks, in this order:
+
+| Check | What it observes |
+| --- | --- |
+| `file_write` | A scratch file is created, read back and removed in the worktree. |
+| `git_index_write` | A scratch blob is written to the object store and an index entry through a **temporary** `GIT_INDEX_FILE`, so the unit's real index is never touched. |
+| `objects_present` | `HEAD` and the base ref are commits that exist here, a merge base exists when both sides are named, and — when the clone is partial — no object the work needs is absent. A partial clone is reported, not failed; only an actually missing object blocks. |
+| `case_collision` | Whether the filesystem is case-insensitive is *observed*, not inferred from the platform; if it is, no two tracked paths in `HEAD` may differ only in case. |
+
+A failing check stops the unit **before the spawn**. It reports
+`status: worktree_failed` with `reason_code: workspace_preflight_blocked`,
+`failure_kind: workspace_blocked`, the `unit_state` the first blocking check
+implies (`permission_blocked` for a write refusal or a case collision,
+`data_missing` for absent objects), and the full `workspace_preflight/v1`
+payload naming every check and its detail. None of the four is cleared by
+running the unit again under the same conditions, which is why this is a
+refusal rather than a retry: the repair belongs at the preparation step, on the
+worktree that is left exactly as it is.
+
+Everything the probe writes it removes again — scratch paths only, inside the
+worktree or the git directory, never a tracked file and never the real index.
+
 ## Failure recovery
 
 A spawned agent CLI that dies because the provider quota is spent or the stored
@@ -737,8 +771,13 @@ way. This section is what dispatch does about that. It applies identically to
 funnel into the same engine.
 
 - **`failure_kind` is a closed enum on every failed unit envelope**:
-  `auth_shaped`, `limit_shaped`, `timeout`, `binary_missing`, or `crash` as the
-  fallback. Precedence is fixed and deterministic. The dispatcher's own
+  `auth_shaped`, `limit_shaped`, `timeout`, `binary_missing`,
+  `workspace_blocked`, or `crash` as the fallback. Precedence is fixed and
+  deterministic. `workspace_blocked` outranks everything because it is decided
+  before the spawn (see **Workspace preflight** above): there is no process, no
+  exit code and no output to classify, and it is never offered a recovery
+  retry because retrying is what cannot clear it. Among the rest, the
+  dispatcher's own
   synthetic exit codes classify first — 127 is `binary_missing`, 124 is
   `timeout` — because they are observations of the process rather than text the
   provider wrote. Text then classifies as `auth_shaped` **before**

--- a/src/coding/dispatch_failure_recovery.py
+++ b/src/coding/dispatch_failure_recovery.py
@@ -58,6 +58,11 @@ FAILURE_KIND_AUTH_SHAPED = "auth_shaped"
 FAILURE_KIND_LIMIT_SHAPED = "limit_shaped"
 FAILURE_KIND_TIMEOUT = "timeout"
 FAILURE_KIND_BINARY_MISSING = "binary_missing"
+# The one kind no exit code can produce. The workspace preflight found a
+# blocker inside the unit's isolation and the spawn never happened, so there is
+# no process, no exit code and no output to classify -- the dispatcher assigns
+# this kind directly. See `coding/workspace_preflight.py`.
+FAILURE_KIND_WORKSPACE_BLOCKED = "workspace_blocked"
 FAILURE_KIND_CRASH = "crash"
 
 FAILURE_KINDS: tuple[str, ...] = (
@@ -65,22 +70,29 @@ FAILURE_KINDS: tuple[str, ...] = (
     FAILURE_KIND_LIMIT_SHAPED,
     FAILURE_KIND_TIMEOUT,
     FAILURE_KIND_BINARY_MISSING,
+    FAILURE_KIND_WORKSPACE_BLOCKED,
     FAILURE_KIND_CRASH,
 )
 
 # The two kinds a recovery choice is offered for: both describe the provider
 # refusing to serve this owner right now, which another owner or a later attempt
-# can answer. A crash, a timeout, or a missing binary is not that.
+# can answer. A crash, a timeout, a missing binary, or a blocked workspace is
+# not that -- a workspace blocker in particular is the one failure retrying is
+# guaranteed not to clear, which is why it is refused before the spawn rather
+# than offered a retry after one.
 RECOVERABLE_FAILURE_KINDS: frozenset[str] = frozenset(
     {FAILURE_KIND_AUTH_SHAPED, FAILURE_KIND_LIMIT_SHAPED}
 )
 
 FAILURE_KIND_PRECEDENCE = (
-    "binary_missing (synthetic exit 127) and timeout (synthetic exit 124) are the dispatcher's own "
-    "observations of the process and classify before any text match. Text then classifies as "
-    "auth_shaped before limit_shaped: an invalid credential must be repaired before any attempt can "
-    "succeed, while a limit clears on its own, so an overlapping message belongs in the lane that "
-    "waiting cannot clear. Everything else is crash."
+    "workspace_blocked outranks every other kind because it is decided BEFORE the spawn: the "
+    "workspace preflight found a blocker in the unit's isolation, so no process exists and no "
+    "output can be classified. Among the kinds a finished process can produce, binary_missing "
+    "(synthetic exit 127) and timeout (synthetic exit 124) are the dispatcher's own observations of "
+    "the process and classify before any text match. Text then classifies as auth_shaped before "
+    "limit_shaped: an invalid credential must be repaired before any attempt can succeed, while a "
+    "limit clears on its own, so an overlapping message belongs in the lane that waiting cannot "
+    "clear. Everything else is crash."
 )
 
 # Deterministic auth-shape patterns, matched case-insensitively over the

--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -105,6 +105,29 @@ EXECUTOR_VERSION_POLICY = (
     "output at run time; the probe reports every PATH resolution it observed so a stale "
     "binary shadowing a newer install is visible instead of silently selected."
 )
+
+# What this probe actually observed, stated as a value so no reader has to
+# infer it from the absence of anything else. The probe runs one command and
+# reads its version line; it has no worktree, touches no repository, and
+# therefore cannot answer whether the work can be done anywhere.
+READINESS_OBSERVED_BINARY_VERSION_ONLY = "binary_version_only"
+
+# Appended to a ready summary. The workspace question is not left unanswered --
+# it is answered LATER, by `workspace_preflight` running in the unit's own
+# isolation immediately before the spawn, which is the only place a worktree
+# exists to probe.
+READINESS_WORKSPACE_PROBE_NOTE = (
+    "Binary runs; workspace not yet probed — the dispatch runs `workspace_preflight` in the unit's "
+    "isolation before spawning."
+)
+
+READINESS_BINARY_ONLY_CLAIM_BOUNDARY = (
+    "`available: true` means one command was run and it exited 0. It is not a claim that the work "
+    "can be done: file writes, git index writes, the presence of the commits the work needs, and "
+    "case-collision safety are properties of the unit's isolation, which this probe never sees. "
+    "The dispatch observes those four with `workspace_preflight` before it spawns anything. "
+    "Readiness is not dispatch, execution, verification, review, CI, or merge evidence."
+)
 _COMMANDS: dict[str, tuple[str, tuple[str, ...]]] = {
     "codex": ("codex", ("--version",)),
     "claude-code": ("claude", ("--version",)),
@@ -269,7 +292,15 @@ def probe_executor_readiness(
         )
         result = dict(cached)
         result["pre_handoff_readiness"] = verdict
-        result["claim_boundary"] = contract["claim_boundary"]
+        # A cached command probe keeps the boundary that describes what it
+        # observed. Replacing it with the generic contract sentence would put
+        # the "binary runs; the workspace was never probed" qualification back
+        # out of reach of exactly the readers who read a cached `ready`.
+        result["claim_boundary"] = (
+            READINESS_BINARY_ONLY_CLAIM_BOUNDARY
+            if result.get("observed") == READINESS_OBSERVED_BINARY_VERSION_ONLY
+            else contract["claim_boundary"]
+        )
         if verdict["usable"]:
             result["cache_status"] = "cached"
             result["first_use_skipped"] = True
@@ -492,6 +523,7 @@ def _run_probe(contract: dict[str, object]) -> dict[str, object]:
             {
                 "status": "missing",
                 "available": False,
+                "observed": READINESS_OBSERVED_BINARY_VERSION_ONLY,
                 "observed_once": True,
                 "summary": f"`{command}` was not found on PATH.",
                 "next_action": "choose_executor_or_configure_path",
@@ -511,6 +543,7 @@ def _run_probe(contract: dict[str, object]) -> dict[str, object]:
             {
                 "status": "blocked",
                 "available": False,
+                "observed": READINESS_OBSERVED_BINARY_VERSION_ONLY,
                 "observed_once": True,
                 "summary": str(exc),
                 "next_action": "choose_executor_or_configure_path",
@@ -527,10 +560,19 @@ def _run_probe(contract: dict[str, object]) -> dict[str, object]:
             f"{row['path']} ({row['observed_version']})" for row in resolutions[1:]
         )
         summary = f"{summary} — PATH also resolves: {others}"[:400]
+    if completed.returncode == 0:
+        # `available: true` used to be read as "this executor can do the work".
+        # It never meant that, and on 2026-09-11 the gap cost 36 minutes: the
+        # binary ran, and the isolation it was pointed at could not take a git
+        # index write. The sentence is appended to the summary rather than kept
+        # only in a field because the summary is what a person reads.
+        summary = f"{summary} {READINESS_WORKSPACE_PROBE_NOTE}"[:600]
     result.update(
         {
             "status": "ready" if completed.returncode == 0 else "blocked",
             "available": completed.returncode == 0,
+            "observed": READINESS_OBSERVED_BINARY_VERSION_ONLY,
+            "claim_boundary": READINESS_BINARY_ONLY_CLAIM_BOUNDARY,
             "observed_once": True,
             "exit_code": completed.returncode,
             "command_path": resolved,

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -59,6 +59,7 @@ from .dispatch_failure_recovery import (
     ON_FAILURE_WAIT,
     FAILURE_KIND_AUTH_SHAPED,
     FAILURE_KIND_LIMIT_SHAPED,
+    FAILURE_KIND_WORKSPACE_BLOCKED,
     FAILURE_RECOVERY_CLAIM_BOUNDARY,
     FAILURE_RECOVERY_SCHEMA_VERSION,
     auth_shaped_label,
@@ -140,6 +141,11 @@ from .fanout_retry import (
     evaluate_unit_retry,
 )
 from .unit_prompt_protocol import shared_unit_preamble_lines, unit_protocol_lines
+from .workspace_preflight import (
+    probe_workspace,
+    workspace_preflight_reason,
+    workspace_preflight_unit_state,
+)
 from .verification_execution import VerificationExecutionGate
 from .verification_integration import run_post_integration_verification
 from .verification_plan import VERIFICATION_PLAN_SCHEMA_VERSION, compile_verification_plan
@@ -3837,6 +3843,43 @@ def _dispatch_unit(
             **_dispatch_status_ladder(),
         }
     worktree = Path(str(worktree_record["worktree_path"]))
+    # The isolation now exists; whether the work can be DONE in it is a
+    # separate question, and the 2026-09-11 incident is what happens when only
+    # the first one is asked. A readiness probe says the executor binary runs.
+    # It cannot say that this worktree takes a file write, that its index can
+    # be written, that the commits the unit merges are present rather than
+    # promised by a partial clone, or that its tracked filenames survive a
+    # case-insensitive filesystem. Those four are observed HERE, in the path
+    # the unit was handed, before any process is spawned -- because none of
+    # them is cleared by running the unit and finding out.
+    #
+    # `target_ref` is deliberately None: the worktree was just created at
+    # `base_sha`, so the unit has no head of its own yet and HEAD is the only
+    # other commit there is to check.
+    workspace_preflight = probe_workspace(
+        worktree, base_ref=base_sha or None, target_ref=None, runner=runner
+    )
+    if not workspace_preflight["ok"]:
+        # `worktree_failed` rather than a new status word: the closed status
+        # vocabulary is a wire contract external wrappers gate on, and this IS
+        # a setup-phase failure of the worktree. `reason_code` is what
+        # separates "the worktree could not be created" from "the worktree was
+        # created and cannot be worked in"; `workspace_preflight` carries which
+        # check failed and why. The worktree is left exactly as it is -- the
+        # repair happens at the preparation step, on what is on disk.
+        return {
+            "unit_id": unit_id,
+            "run_ref": run_ref,
+            "owner": owner,
+            "status": "worktree_failed",
+            "attempt_id": attempt_id,
+            "reason_code": "workspace_preflight_blocked",
+            "failure_kind": FAILURE_KIND_WORKSPACE_BLOCKED,
+            "unit_state": workspace_preflight_unit_state(workspace_preflight),
+            "workspace_preflight": workspace_preflight,
+            "reason": workspace_preflight_reason(workspace_preflight),
+            **_dispatch_status_ladder(),
+        }
     session_capability = (negotiate_session_capability(owner, argv[0], env=child_env)
                           if argv and getattr(runner, 'accepts_output_capture', False) else None)
     if session_capability is not None:

--- a/src/coding/workspace_preflight.py
+++ b/src/coding/workspace_preflight.py
@@ -1,0 +1,539 @@
+"""Probe, in the isolation a unit will actually use, that the work can be done.
+
+`executor_readiness` answers one question: does the executor's binary run? On
+2026-09-11 that answer was `available: true` for a worker that then spent 36
+minutes unable to write a git index it had been told was complete. The clone
+was `blob:none` with network fetch forbidden, so objects the merge needed were
+simply absent, and case-only filename collisions on a case-insensitive
+filesystem blocked the checkout. Every one of those conditions was observable
+before the unit started, and none of them was observed.
+
+`--version` exiting 0 says the binary runs. It does not say a file can be
+written, an index can be updated, the commits the work names exist, or the
+tracked filenames can coexist on this filesystem. Those four are what this
+module observes, in the worktree path the unit was handed, with no network
+call and a bounded timeout on every subprocess.
+
+A failing check is a BLOCKER, not a retry hint. None of the four clears by
+running the same unit again under the same conditions: a permission denial
+stays denied, a missing object stays missing until someone fetches it, and a
+case collision is a property of the tree and the filesystem. The dispatcher
+therefore refuses the spawn and reports which check failed with its detail, so
+the repair happens at the preparation step where it belongs.
+
+Nothing here spawns an agent, reads a credential, or reaches a network. It
+runs `git` read/write commands against the given worktree, writes only scratch
+paths it removes again, and never touches a tracked file or the real index.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+from typing import Any, Callable
+from uuid import uuid4
+
+from .unit_execution_state import (
+    UNIT_STATE_DATA_MISSING,
+    UNIT_STATE_PERMISSION_BLOCKED,
+)
+
+WORKSPACE_PREFLIGHT_SCHEMA_VERSION = "workspace_preflight/v1"
+
+CHECK_FILE_WRITE = "file_write"
+CHECK_GIT_INDEX_WRITE = "git_index_write"
+CHECK_OBJECTS_PRESENT = "objects_present"
+CHECK_CASE_COLLISION = "case_collision"
+
+# Order is the order they run in, and the order a reader should read them: a
+# filesystem that cannot take a file explains an index that cannot be written,
+# which explains everything after it.
+WORKSPACE_PREFLIGHT_CHECKS: tuple[str, ...] = (
+    CHECK_FILE_WRITE,
+    CHECK_GIT_INDEX_WRITE,
+    CHECK_OBJECTS_PRESENT,
+    CHECK_CASE_COLLISION,
+)
+
+WORKSPACE_PREFLIGHT_CLAIM_BOUNDARY = (
+    "A workspace preflight observes four blockers inside the isolation the unit was handed: a file "
+    "can be written, the git index can be written, the commits the work names are present, and no "
+    "tracked filenames collide on a case-insensitive filesystem. A passing preflight is not a claim "
+    "that the work will succeed, and it is not execution, verification, review, CI, or merge "
+    "evidence -- only that these four blockers are absent right now."
+)
+
+# Which unit execution state a blocking check leaves the unit in. Permission
+# and case collision are both `permission_blocked`: neither is cleared by
+# retrying, and a case collision is a denial the filesystem issues rather than
+# data the repository lacks.
+_STATE_BY_CHECK: dict[str, str] = {
+    CHECK_FILE_WRITE: UNIT_STATE_PERMISSION_BLOCKED,
+    CHECK_GIT_INDEX_WRITE: UNIT_STATE_PERMISSION_BLOCKED,
+    CHECK_OBJECTS_PRESENT: UNIT_STATE_DATA_MISSING,
+    CHECK_CASE_COLLISION: UNIT_STATE_PERMISSION_BLOCKED,
+}
+
+# Every git call is bounded. A preflight that can hang is a preflight that
+# reproduces the incident it exists to prevent.
+_GIT_TIMEOUT_SECONDS = 30
+# Commits walked when scanning a partial clone for absent objects. The scan is
+# a blocker check, not an inventory: the first missing object already answers
+# the question, and an unbounded walk on a large history would cost more than
+# the spawn it is guarding.
+_MISSING_SCAN_COMMIT_LIMIT = 200
+# Colliding groups named in the detail. Enough to recognise the shape of the
+# problem, not an attempt to list a whole tree.
+_MAX_REPORTED_COLLISIONS = 3
+_MAX_DETAIL = 400
+# Exit code for a git that could not be run at all. Same convention
+# `worktree_creator._git` uses: an unanswerable question is a refusal.
+_GIT_UNRUNNABLE = 127
+
+
+def probe_workspace(
+    worktree: Path,
+    *,
+    base_ref: str | None,
+    target_ref: str | None,
+    runner: Callable[..., object] = subprocess.run,
+) -> dict[str, Any]:
+    """Observe the four pre-spawn blockers in `worktree`; never raise.
+
+    `base_ref` is the commit the unit's work will merge into and `target_ref`
+    the unit's own head when one already exists; either may be None, and the
+    checks that need them are reported as skipped rather than guessed.
+
+    All four checks always run. A file write that fails explains an index write
+    that fails, and an operator repairing the isolation wants both facts at
+    once rather than one per dispatch attempt.
+    """
+    root = Path(worktree)
+    env = _git_environment()
+    checks = [
+        _check_file_write(root),
+        _check_git_index_write(root, runner, env),
+        _check_objects_present(root, runner, env, base_ref, target_ref),
+        _check_case_collision(root, runner, env),
+    ]
+    blocking = [check["name"] for check in checks if not check["ok"]]
+    return {
+        "schema_version": WORKSPACE_PREFLIGHT_SCHEMA_VERSION,
+        "ok": not blocking,
+        "worktree": str(root),
+        "checks": checks,
+        "blocking": blocking,
+        "claim_boundary": WORKSPACE_PREFLIGHT_CLAIM_BOUNDARY,
+    }
+
+
+def workspace_preflight_unit_state(report: dict[str, Any]) -> str:
+    """The execution state a blocked preflight leaves the unit in, or an empty string.
+
+    The FIRST blocking check decides, because the checks run in dependency
+    order: a filesystem that refuses a write is why the index write failed, and
+    reporting the later symptom would send the repair to the wrong place.
+    """
+    blocking = report.get("blocking")
+    if not isinstance(blocking, list):
+        return ""
+    for name in blocking:
+        state = _STATE_BY_CHECK.get(str(name))
+        if state:
+            return state
+    return ""
+
+
+def workspace_preflight_reason(report: dict[str, Any]) -> str:
+    """One line naming every failing check and the first detail, for the envelope."""
+    failed = [
+        check
+        for check in report.get("checks", [])
+        if isinstance(check, dict) and not check.get("ok")
+    ]
+    if not failed:
+        return ""
+    names = ", ".join(str(check.get("name", "")) for check in failed)
+    return _bounded(f"workspace preflight failed in the unit's isolation ({names}): "
+                    f"{failed[0].get('detail', '')}")
+
+
+def _check(name: str, ok: bool, detail: str) -> dict[str, Any]:
+    return {"name": name, "ok": bool(ok), "detail": _bounded(detail)}
+
+
+def _bounded(text: object) -> str:
+    """One bounded line. Git stderr arrives multi-line and CRLF-terminated on Windows."""
+    collapsed = " ".join(str(text).split())
+    return collapsed[:_MAX_DETAIL]
+
+
+def _git_environment() -> dict[str, str]:
+    """The child environment for every git call here: no network, no prompts.
+
+    `GIT_NO_LAZY_FETCH` is what keeps a partial clone from reaching its
+    promisor remote mid-check (git 2.41+; older git ignores it, and
+    `--missing=print` already suppresses the fetch for the one command that
+    could trigger one). `GIT_TERMINAL_PROMPT=0` means a credential prompt fails
+    instead of hanging past the timeout, and `GIT_OPTIONAL_LOCKS=0` keeps a
+    read from taking the index lock a concurrent unit may hold.
+    """
+    env = dict(os.environ)
+    env["GIT_NO_LAZY_FETCH"] = "1"
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    return env
+
+
+def _stream(completed: object, name: str) -> str:
+    raw = getattr(completed, name, "")
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return str(raw or "")
+
+
+def _run_git(
+    runner: Callable[..., object],
+    worktree: Path,
+    argv: list[str],
+    *,
+    env: dict[str, str],
+) -> tuple[int, str, str]:
+    """Run one bounded git command in the worktree, returning (code, stdout, stderr).
+
+    `argv` arrives complete, `"git"` and its subcommand spelled as literals at
+    the call site. That is not decoration: `tests/test_handoff_safety_contract
+    _enforcement.py::NoRemoteMutation` proves structurally that no argv in
+    `src/` can reach a remote, and it can only do so while every subcommand is
+    a constant it can read out of the syntax tree.
+
+    A git that cannot be run at all reports `_GIT_UNRUNNABLE` rather than
+    raising: every caller is deciding whether a blocker is present, and an
+    unanswerable question is a blocker, not a crash.
+    """
+    try:
+        completed = runner(
+            argv,
+            cwd=str(worktree),
+            text=True,
+            capture_output=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return _GIT_UNRUNNABLE, "", f"{type(exc).__name__}: {exc}"
+    code = getattr(completed, "returncode", None)
+    # A runner that reports no usable exit code answered nothing; treating that
+    # as success would let an unchecked blocker through.
+    return (code if type(code) is int else 1), _stream(completed, "stdout"), _stream(completed, "stderr")
+
+
+def _scratch_name(suffix: str) -> str:
+    return f".omh-workspace-preflight-{uuid4().hex}{suffix}"
+
+
+def _check_file_write(worktree: Path) -> dict[str, Any]:
+    """Create, read back and remove one scratch file in the isolation.
+
+    The scratch path is removed on every exit. A scratch file that survives
+    would show up in the unit's own `git status` and change the work it
+    reports, so a removal that fails is itself a failure of this check rather
+    than a detail worth swallowing.
+    """
+    scratch = worktree / _scratch_name(".tmp")
+    payload = "omh workspace preflight\n"
+    try:
+        scratch.write_text(payload, encoding="utf-8")
+        read_back = scratch.read_text(encoding="utf-8")
+    except OSError as exc:
+        _remove(scratch)
+        return _check(CHECK_FILE_WRITE, False, f"could not write a scratch file in {worktree}: {exc}")
+    if read_back != payload:
+        _remove(scratch)
+        return _check(
+            CHECK_FILE_WRITE,
+            False,
+            f"scratch file in {worktree} read back different bytes than were written",
+        )
+    try:
+        scratch.unlink()
+    except OSError as exc:
+        return _check(
+            CHECK_FILE_WRITE,
+            False,
+            f"wrote {scratch} but could not remove it ({exc}); the unit would inherit a stray file",
+        )
+    return _check(CHECK_FILE_WRITE, True, f"wrote, read and removed a scratch file in {worktree}")
+
+
+def _remove(path: Path) -> None:
+    """Best-effort cleanup of one scratch path we created.
+
+    Deliberately silent: this runs only on a path that already failed, where
+    the failure is what gets reported and a second error about the cleanup
+    would bury it. The check that succeeded removes its own scratch path
+    explicitly and reports a failure to do so.
+    """
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
+def _check_git_index_write(
+    worktree: Path, runner: Callable[..., object], env: dict[str, str]
+) -> dict[str, Any]:
+    """Prove the object store and the index can be written, without dirtying either.
+
+    The write goes to a TEMPORARY index named by `GIT_INDEX_FILE`, so the real
+    index the unit will use is never touched, and to a scratch blob inside the
+    git directory rather than the worktree, so nothing appears in `git status`.
+    `hash-object -w` is what observes that the object store itself is
+    writable; `read-tree` plus `update-index --cacheinfo` is what observes that
+    the index machinery works. Both temporary paths are removed before this
+    returns.
+    """
+    code, stdout, stderr = _run_git(runner, worktree, ["git", "rev-parse", "--absolute-git-dir"], env=env)
+    if code != 0:
+        return _check(
+            CHECK_GIT_INDEX_WRITE,
+            False,
+            f"could not resolve the git directory of {worktree}: {stderr or stdout}",
+        )
+    git_dir = Path(stdout.strip())
+    if not git_dir.is_dir():
+        return _check(
+            CHECK_GIT_INDEX_WRITE,
+            False,
+            f"git reported {git_dir} as its directory, but it is not a directory",
+        )
+    blob_path = git_dir / _scratch_name(".blob")
+    index_path = git_dir / _scratch_name(".index")
+    try:
+        blob_path.write_text("omh workspace preflight\n", encoding="utf-8")
+    except OSError as exc:
+        return _check(
+            CHECK_GIT_INDEX_WRITE, False, f"could not write a scratch blob in {git_dir}: {exc}"
+        )
+    try:
+        code, stdout, stderr = _run_git(
+            runner, worktree, ["git", "hash-object", "-w", "--", str(blob_path)], env=env
+        )
+        if code != 0:
+            return _check(
+                CHECK_GIT_INDEX_WRITE,
+                False,
+                f"the object store under {git_dir} refused a write: {stderr or stdout}",
+            )
+        oid = stdout.strip()
+        index_env = dict(env)
+        index_env["GIT_INDEX_FILE"] = str(index_path)
+        code, stdout, stderr = _run_git(runner, worktree, ["git", "read-tree", "HEAD"], env=index_env)
+        if code != 0:
+            return _check(
+                CHECK_GIT_INDEX_WRITE,
+                False,
+                f"could not read HEAD into a temporary index at {index_path}: {stderr or stdout}",
+            )
+        code, stdout, stderr = _run_git(
+            runner,
+            worktree,
+            ["git", "update-index", "--add", "--cacheinfo", f"100644,{oid},omh-workspace-preflight"],
+            env=index_env,
+        )
+        if code != 0:
+            return _check(
+                CHECK_GIT_INDEX_WRITE,
+                False,
+                f"could not write an entry into a temporary index at {index_path}: {stderr or stdout}",
+            )
+    finally:
+        _remove(blob_path)
+        _remove(index_path)
+        _remove(index_path.with_name(index_path.name + ".lock"))
+    return _check(
+        CHECK_GIT_INDEX_WRITE,
+        True,
+        f"wrote a scratch blob and an index entry through a temporary index under {git_dir}",
+    )
+
+
+def _check_objects_present(
+    worktree: Path,
+    runner: Callable[..., object],
+    env: dict[str, str],
+    base_ref: str | None,
+    target_ref: str | None,
+) -> dict[str, Any]:
+    """Observe that the commits the work names exist here, and that nothing is promised-away.
+
+    A partial clone is not a failure by itself -- it is a normal, useful thing
+    to have. It becomes the incident's condition when objects the work needs
+    are absent AND the fetch that would supply them cannot happen. So the
+    promisor configuration is reported as a detail, and only an actually
+    missing object fails the check.
+    """
+    notes: list[str] = []
+    refs = [("HEAD", "HEAD")]
+    if base_ref:
+        refs.append(("base_ref", base_ref))
+    if target_ref:
+        refs.append(("target_ref", target_ref))
+    for label, ref in refs:
+        code, stdout, stderr = _run_git(runner, worktree, ["git", "cat-file", "-e", f"{ref}^{{commit}}"], env=env)
+        if code != 0:
+            return _check(
+                CHECK_OBJECTS_PRESENT,
+                False,
+                f"{label} {ref} is not a commit present in {worktree}: {stderr or stdout}",
+            )
+    notes.append(f"present: {', '.join(f'{label}={ref}' for label, ref in refs)}")
+    if base_ref and target_ref:
+        code, stdout, stderr = _run_git(
+            runner, worktree, ["git", "merge-base", base_ref, target_ref], env=env
+        )
+        if code != 0:
+            return _check(
+                CHECK_OBJECTS_PRESENT,
+                False,
+                f"no merge base between {base_ref} and {target_ref} in {worktree}: {stderr or stdout}",
+            )
+        notes.append(f"merge-base {stdout.strip()[:40]}")
+    else:
+        notes.append("merge-base not checked (only one side named)")
+    partial = _partial_clone_note(worktree, runner, env)
+    if not partial:
+        notes.append("not a partial clone")
+        return _check(CHECK_OBJECTS_PRESENT, True, "; ".join(notes))
+    notes.append(partial)
+    scan = (
+        [f"{base_ref}..{target_ref}"]
+        if base_ref and target_ref and base_ref != target_ref
+        else ["HEAD"]
+    )
+    code, stdout, stderr = _run_git(
+        runner,
+        worktree,
+        ["git", "rev-list", "--objects", "--missing=print", "-n", str(_MISSING_SCAN_COMMIT_LIMIT), *scan],
+        env=env,
+    )
+    if code != 0:
+        return _check(
+            CHECK_OBJECTS_PRESENT,
+            False,
+            f"could not scan {' '.join(scan)} for absent objects in this partial clone: {stderr or stdout}",
+        )
+    missing = [line for line in stdout.splitlines() if line.startswith("?")]
+    if missing:
+        return _check(
+            CHECK_OBJECTS_PRESENT,
+            False,
+            f"{len(missing)} object(s) the work needs are absent from this partial clone over "
+            f"{' '.join(scan)} and fetching them is not permitted here; first: {missing[0][:60]}",
+        )
+    notes.append(f"no absent objects over {' '.join(scan)} within {_MISSING_SCAN_COMMIT_LIMIT} commits")
+    return _check(CHECK_OBJECTS_PRESENT, True, "; ".join(notes))
+
+
+def _partial_clone_note(
+    worktree: Path, runner: Callable[..., object], env: dict[str, str]
+) -> str:
+    """A description of this clone's partial-clone configuration, or an empty string.
+
+    Read from config rather than inferred: `extensions.partialClone` names the
+    promisor remote and `remote.<name>.promisor` marks it, and either one alone
+    is enough to mean objects may be promised rather than present.
+    """
+    found: list[str] = []
+    for key in ("extensions.partialClone", "remote.origin.promisor", "remote.origin.partialclonefilter"):
+        code, stdout, _stderr = _run_git(runner, worktree, ["git", "config", "--get", key], env=env)
+        value = stdout.strip()
+        if code == 0 and value and value.casefold() != "false":
+            found.append(f"{key}={value[:60]}")
+    if not found:
+        return ""
+    code, stdout, _stderr = _run_git(
+        runner, worktree, ["git", "config", "--get", "core.repositoryFormatVersion"], env=env
+    )
+    version = stdout.strip() if code == 0 else ""
+    return "partial clone (" + ", ".join(found) + (f", repositoryFormatVersion={version}" if version else "") + ")"
+
+
+def _check_case_collision(
+    worktree: Path, runner: Callable[..., object], env: dict[str, str]
+) -> dict[str, Any]:
+    """On a case-insensitive filesystem, fail when two tracked paths differ only in case.
+
+    Case sensitivity is observed, never inferred from the platform: a macOS
+    machine can hold a case-sensitive volume and a Linux machine can mount a
+    case-insensitive one, and the wrong guess here is the difference between
+    a checkout that works and one that silently loses a file.
+    """
+    sensitivity = _case_sensitivity(worktree)
+    if sensitivity is None:
+        return _check(
+            CHECK_CASE_COLLISION,
+            False,
+            f"could not determine whether the filesystem under {worktree} is case-insensitive",
+        )
+    if sensitivity == "sensitive":
+        return _check(
+            CHECK_CASE_COLLISION,
+            True,
+            f"the filesystem under {worktree} is case-sensitive, so tracked filenames that differ "
+            "only in case cannot collide here",
+        )
+    code, stdout, stderr = _run_git(runner, worktree, ["git", "ls-tree", "-r", "--name-only", "HEAD"], env=env)
+    if code != 0:
+        return _check(
+            CHECK_CASE_COLLISION,
+            False,
+            f"could not list the tracked paths of HEAD in {worktree}: {stderr or stdout}",
+        )
+    groups: dict[str, list[str]] = {}
+    for line in stdout.splitlines():
+        path = line.strip()
+        if path:
+            groups.setdefault(path.casefold(), []).append(path)
+    collisions = [sorted(set(paths)) for paths in groups.values() if len(set(paths)) > 1]
+    if not collisions:
+        return _check(
+            CHECK_CASE_COLLISION,
+            True,
+            f"the filesystem under {worktree} is case-insensitive and no tracked path in HEAD "
+            "collides with another under casefolding",
+        )
+    collisions.sort()
+    named = "; ".join(" vs ".join(group) for group in collisions[:_MAX_REPORTED_COLLISIONS])
+    return _check(
+        CHECK_CASE_COLLISION,
+        False,
+        f"{len(collisions)} tracked path group(s) in HEAD differ only in case on a case-insensitive "
+        f"filesystem, which blocks checkout and merge here: {named}",
+    )
+
+
+def _case_sensitivity(worktree: Path) -> str | None:
+    """"sensitive", "insensitive", or None when the probe itself could not run."""
+    probe = worktree / _scratch_name("-case.tmp")
+    twin = probe.with_name(probe.name.upper())
+    try:
+        probe.write_text("case\n", encoding="utf-8")
+    except OSError:
+        _remove(probe)
+        return None
+    try:
+        # `exists()` on the uppercase twin is the whole test: only a
+        # case-insensitive filesystem resolves it to the file just written.
+        # The names differ in case by construction, so a false positive would
+        # require the twin to exist already, which a fresh uuid rules out.
+        insensitive = twin.exists()
+    except OSError:
+        # An unanswerable probe is reported as unanswerable. Defaulting to
+        # "sensitive" would skip the collision scan on exactly the filesystem
+        # least able to answer questions about itself.
+        return None
+    finally:
+        _remove(probe)
+    return "insensitive" if insensitive else "sensitive"

--- a/tests/test_dispatch_failure_recovery.py
+++ b/tests/test_dispatch_failure_recovery.py
@@ -25,7 +25,9 @@ from omh.coding.dispatch_failure_recovery import (  # noqa: E402
     FAILURE_KIND_CRASH,
     FAILURE_KIND_LIMIT_SHAPED,
     FAILURE_KIND_TIMEOUT,
+    FAILURE_KIND_WORKSPACE_BLOCKED,
     FAILURE_KINDS,
+    RECOVERABLE_FAILURE_KINDS,
     OnFailureModeError,
     auth_repair_command,
     auth_shaped_label,
@@ -112,7 +114,19 @@ class FailureKindClassificationTests(unittest.TestCase):
             classify_failure_kind(exit_code=1, limit_label="rate_limit"),
             classify_failure_kind(exit_code=1),
         }
-        self.assertEqual(answers, set(FAILURE_KINDS))
+        # `workspace_blocked` is the one kind the classifier can never answer:
+        # it is assigned before the spawn, when there is no exit code and no
+        # output to classify. Every OTHER member of the enum must still come
+        # out of the classifier, or the enum has grown a value nothing sets.
+        self.assertEqual(answers, set(FAILURE_KINDS) - {FAILURE_KIND_WORKSPACE_BLOCKED})
+        self.assertNotIn(FAILURE_KIND_WORKSPACE_BLOCKED, answers)
+
+    def test_workspace_blocked_is_never_offered_a_recovery_retry(self) -> None:
+        # A blocked workspace is the one failure another attempt cannot clear:
+        # the objects are still missing, the denial is still a denial, and the
+        # case collision is still in the tree.
+        self.assertIn(FAILURE_KIND_WORKSPACE_BLOCKED, FAILURE_KINDS)
+        self.assertNotIn(FAILURE_KIND_WORKSPACE_BLOCKED, RECOVERABLE_FAILURE_KINDS)
 
     def test_synthetic_exit_codes_map_before_any_text_match(self) -> None:
         # 127 and 124 are the dispatcher's own observations of the process, so

--- a/tests/test_executor_readiness_resolutions.py
+++ b/tests/test_executor_readiness_resolutions.py
@@ -101,6 +101,32 @@ class PathResolutionReportTests(unittest.TestCase):
             # contract encodes an expected version to fall behind.
             self.assertEqual(result["status"], "ready")
 
+    def test_a_ready_probe_says_it_observed_only_the_binary_version(self) -> None:
+        # The 2026-09-11 gap: `available: true` was read as "this executor can
+        # do the work". The probe has no worktree, so it cannot have observed
+        # anything about one, and the payload has to say that out loud.
+        with TemporaryDirectory() as only:
+            _fake_binary(only, "codex", "0.145.0")
+            result = self._probe(only)
+
+            self.assertEqual(result["status"], "ready")
+            self.assertTrue(result["available"])
+            self.assertEqual(result["observed"], "binary_version_only")
+            self.assertIn("workspace not yet probed", result["summary"])
+            self.assertIn("workspace_preflight", result["summary"])
+            self.assertIn("workspace_preflight", result["claim_boundary"])
+            self.assertIn("is not a claim that the work can be done", result["claim_boundary"])
+            # The observed version line is still there; the qualification is
+            # appended to it rather than replacing it.
+            self.assertIn("0.145.0", result["summary"])
+
+    def test_a_missing_binary_also_states_what_was_observed(self) -> None:
+        with TemporaryDirectory() as empty:
+            result = self._probe(empty)
+
+            self.assertEqual(result["status"], "missing")
+            self.assertEqual(result["observed"], "binary_version_only")
+
     def test_no_source_line_hardcodes_an_executor_version(self) -> None:
         # The guard for the structural rule itself: the module may print
         # versions it observed, never carry one of its own.

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -1706,6 +1706,79 @@ class FanoutDispatchEngineTests(unittest.TestCase):
             self.assertIn("already exists", by_unit["core"]["reason"])
 
 
+class FanoutWorkspacePreflightTests(unittest.TestCase):
+    """A worktree that cannot take the work must not be handed a spawned CLI."""
+
+    def test_a_failing_preflight_blocks_the_spawn_and_says_which_check_failed(self) -> None:
+        root_runner = _agent_runner()
+
+        def runner(argv, **kwargs):
+            # `git cat-file -e <ref>^{commit}` is the workspace preflight
+            # asking whether the commits the work names are present here. A
+            # non-zero answer is the incident's condition: the ref was
+            # described, and the object is not in this isolation.
+            if argv[:2] == ["git", "cat-file"]:
+                return _FakeCompleted(128, "")
+            return root_runner(argv, **kwargs)
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                only_units=["core"],
+                runner=runner,
+                readiness=_ready,
+            )
+
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+            self.assertEqual(core["status"], "worktree_failed")
+            self.assertEqual(core["reason_code"], "workspace_preflight_blocked")
+            self.assertEqual(core["failure_kind"], "workspace_blocked")
+            self.assertEqual(core["unit_state"], "data_missing")
+            self.assertFalse(core["process_succeeded"])
+            preflight = core["workspace_preflight"]
+            self.assertEqual(preflight["schema_version"], "workspace_preflight/v1")
+            self.assertEqual(preflight["blocking"], ["objects_present"])
+            self.assertIn("is not a commit present in", core["reason"])
+            # The point of the whole check: no agent CLI was started.
+            self.assertEqual(root_runner.spawned, [])
+
+    def test_a_healthy_worktree_reports_a_passing_preflight_and_still_spawns(self) -> None:
+        # The negative control for the test above: the same dispatch with git
+        # answering normally must not acquire a new way to refuse.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            repo, sha = _make_repo(root)
+            contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+            runner = _agent_runner()
+
+            summary = dispatch_fanout(
+                paths,
+                contract,
+                goal_text=_GOAL,
+                repo_root=repo,
+                base_sha=sha,
+                only_units=["core"],
+                runner=runner,
+                readiness=_ready,
+            )
+
+            core = {entry["unit_id"]: entry for entry in summary["units"]}["core"]
+            self.assertNotIn("workspace_preflight", core)
+            self.assertNotIn("failure_kind", core)
+            self.assertTrue(core["process_succeeded"])
+            self.assertEqual(len(runner.spawned), 1)
+
+
 class FanoutUnitRecoveryTests(unittest.TestCase):
     """A failed unit still owns its worktree; the summary must say what survived."""
 
@@ -2105,7 +2178,13 @@ class FanoutUnitRecoveryTests(unittest.TestCase):
         def runner(argv, **kwargs):
             # argv[:2], so `git worktree add` (which creates the unit worktree)
             # is not caught by the `add` arm and the probe is actually reached.
-            if argv[:2] in (["git", "diff"], ["git", "add"], ["git", "rev-parse"]):
+            # `--absolute-git-dir` is excluded for the same reason: that is the
+            # workspace preflight resolving the git directory before the spawn,
+            # and faulting it would block the unit before the recovery probe
+            # this test is about ever runs.
+            if argv[:2] in (["git", "diff"], ["git", "add"], ["git", "rev-parse"]) and argv[2:3] != [
+                "--absolute-git-dir"
+            ]:
                 return _NoReturnCode()
             if argv[0] == "git":
                 return subprocess.run(argv, **kwargs)

--- a/tests/test_handoff_safety_contract_enforcement.py
+++ b/tests/test_handoff_safety_contract_enforcement.py
@@ -137,6 +137,12 @@ def _imported_modules(tree: ast.Module) -> list[tuple[str, tuple[str, ...], int]
 # is reachable only from an explicit operator command; none sits on the chat or
 # handoff-preparation path.
 PROCESS_SPAWN_ALLOWLIST: dict[str, str] = {
+    "src/coding/workspace_preflight.py": (
+        "reached only from the explicit `omh coding fanout dispatch` bridge, after that unit's "
+        "worktree exists and before its agent CLI is spawned; runs only the bounded local git "
+        "probes enumerated in GIT_ARGV_ALLOWLIST below, under GIT_NO_LAZY_FETCH=1 so a partial "
+        "clone cannot reach its promisor remote, and starts no executor and no network client."
+    ),
     "src/coding/fanout_dispatch.py": (
         "`omh coding fanout dispatch` -- the one opt-in bridge that spawns local agent CLIs, "
         "documented as the scoped exception in CLAUDE.md."
@@ -634,6 +640,52 @@ FORGE_PROGRAMS = frozenset({"gh", "hub", "glab", "tea"})
 # The complete set of git argv literals in `src/`, keyed by file and by the run
 # of literal words that follow `git`. Every one is local; none names a remote.
 GIT_ARGV_ALLOWLIST: dict[tuple[str, tuple[str, ...]], str] = {
+    ("src/coding/workspace_preflight.py", ("rev-parse",)): (
+        "`git rev-parse --absolute-git-dir` locates the git directory of the unit's own worktree so "
+        "the index-write probe can put its temporary index and scratch blob there; read-only and "
+        "names no remote"
+    ),
+    ("src/coding/workspace_preflight.py", ("hash-object",)): (
+        "`git hash-object -w -- <scratch blob>` is the pre-spawn observation that this isolation's "
+        "object store accepts a write at all; it writes one unreferenced loose object from a scratch "
+        "file the probe creates and removes, and names no remote"
+    ),
+    ("src/coding/workspace_preflight.py", ("read-tree", "HEAD")): (
+        "`git read-tree HEAD` under a temporary GIT_INDEX_FILE, so the index-write probe never "
+        "touches the index the unit will use; read-only against local objects"
+    ),
+    ("src/coding/workspace_preflight.py", ("update-index",)): (
+        "`git update-index --add --cacheinfo` into that same temporary index: the one command that "
+        "actually proves an index entry can be written, which is what the 2026-09-11 incident could "
+        "not do for 36 minutes; local-only and discarded with the temporary index"
+    ),
+    ("src/coding/workspace_preflight.py", ("cat-file",)): (
+        "`git cat-file -e <ref>^{commit}` asks whether the commits the unit was told to work from "
+        "are actually present in this isolation; read-only and names no remote"
+    ),
+    ("src/coding/workspace_preflight.py", ("merge-base",)): (
+        "`git merge-base <base> <target>` proves the two sides share history before a unit starts "
+        "rather than after its merge fails; read-only, local-only, and not the forbidden `merge` verb"
+    ),
+    ("src/coding/workspace_preflight.py", ("rev-list",)): (
+        "`git rev-list --objects --missing=print -n <bound>` is the partial-clone scan: it PRINTS "
+        "absent objects rather than fetching them, runs under GIT_NO_LAZY_FETCH=1, and is the check "
+        "that turns the incident's silent blob:none clone into a named pre-spawn blocker"
+    ),
+    ("src/coding/workspace_preflight.py", ("config",)): (
+        "`git config --get` on extensions.partialClone, remote.origin.promisor and "
+        "remote.origin.partialclonefilter reads whether this clone promises objects it does not "
+        "hold; read-only, and reading a remote's config key is not contacting it"
+    ),
+    ("src/coding/workspace_preflight.py", ("config", "core.repositoryFormatVersion")): (
+        "`git config --get core.repositoryFormatVersion` is reported alongside the promisor keys "
+        "above, because a partial clone needs format version 1 and the number is what tells a "
+        "reader the detection is not a misread; read-only local config and names no remote"
+    ),
+    ("src/coding/workspace_preflight.py", ("ls-tree", "HEAD")): (
+        "`git ls-tree -r --name-only HEAD` lists the tracked paths whose casefolds are compared for "
+        "collisions on a case-insensitive filesystem; read-only and local-only"
+    ),
     ("src/coding/worktree_creator.py", ("worktree", "add")): (
         "creates a local isolated workspace for an executor; touches no remote"
     ),

--- a/tests/test_workspace_preflight.py
+++ b/tests/test_workspace_preflight.py
@@ -1,0 +1,401 @@
+"""The four pre-spawn blockers, observed against a real temporary git repository.
+
+Every pass case runs real `git`; the failure cases are built the most
+deterministic way each one allows, and the one case that cannot be built
+offline on every CI filesystem (a promisor clone with its objects gone) is
+driven through an injected runner, which is said so in the test name.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.unit_execution_state import (  # noqa: E402
+    UNIT_STATE_DATA_MISSING,
+    UNIT_STATE_PERMISSION_BLOCKED,
+)
+from omh.coding.workspace_preflight import (  # noqa: E402
+    CHECK_CASE_COLLISION,
+    CHECK_FILE_WRITE,
+    CHECK_GIT_INDEX_WRITE,
+    CHECK_OBJECTS_PRESENT,
+    WORKSPACE_PREFLIGHT_CHECKS,
+    WORKSPACE_PREFLIGHT_SCHEMA_VERSION,
+    probe_workspace,
+    workspace_preflight_reason,
+    workspace_preflight_unit_state,
+)
+
+
+def _git(repo: Path, *argv: str) -> str:
+    completed = subprocess.run(
+        ["git", *argv], cwd=str(repo), check=True, capture_output=True, text=True
+    )
+    return completed.stdout.strip()
+
+
+def _make_repo(root: Path, name: str = "repo") -> tuple[Path, str]:
+    repo = root / name
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "seed.txt")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "init")
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def _by_name(report: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {str(check["name"]): check for check in report["checks"]}  # type: ignore[index]
+
+
+def _case_insensitive(path: Path) -> bool:
+    probe = path / "omh-case-probe.tmp"
+    probe.write_text("x", encoding="utf-8")
+    try:
+        return (path / "OMH-CASE-PROBE.TMP").exists()
+    finally:
+        probe.unlink()
+
+
+class WorkspacePreflightPassTests(unittest.TestCase):
+    def test_a_healthy_worktree_passes_every_check_and_leaves_nothing_behind(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=sha)
+
+            self.assertEqual(report["schema_version"], WORKSPACE_PREFLIGHT_SCHEMA_VERSION)
+            self.assertTrue(report["ok"], report)
+            self.assertEqual(report["blocking"], [])
+            self.assertEqual(
+                [check["name"] for check in report["checks"]], list(WORKSPACE_PREFLIGHT_CHECKS)
+            )
+            self.assertIn("not a partial clone", str(_by_name(report)[CHECK_OBJECTS_PRESENT]["detail"]))
+            # The probe may not change what the unit would report as its work.
+            self.assertEqual(_git(repo, "status", "--porcelain"), "")
+            self.assertEqual(
+                sorted(entry.name for entry in repo.iterdir()), [".git", "seed.txt"]
+            )
+            # Nor may it leave scratch paths inside the git directory.
+            git_dir = Path(_git(repo, "rev-parse", "--absolute-git-dir"))
+            self.assertEqual(
+                [entry.name for entry in git_dir.iterdir() if "workspace-preflight" in entry.name],
+                [],
+            )
+
+    def test_a_passing_report_names_no_state_and_no_reason(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=None)
+
+            self.assertEqual(workspace_preflight_unit_state(report), "")
+            self.assertEqual(workspace_preflight_reason(report), "")
+
+    def test_the_real_index_is_never_touched_by_the_index_write_check(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+            index = Path(_git(repo, "rev-parse", "--absolute-git-dir")) / "index"
+            before = index.read_bytes()
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=None)
+
+            self.assertTrue(report["ok"], report)
+            self.assertEqual(index.read_bytes(), before)
+            self.assertEqual(_git(repo, "ls-files"), "seed.txt")
+
+
+class WorkspacePreflightFileWriteTests(unittest.TestCase):
+    def test_a_worktree_that_does_not_exist_blocks_on_file_write(self) -> None:
+        with TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "no-such-worktree"
+
+            report = probe_workspace(missing, base_ref=None, target_ref=None)
+
+            self.assertFalse(report["ok"])
+            self.assertIn(CHECK_FILE_WRITE, report["blocking"])
+            self.assertEqual(workspace_preflight_unit_state(report), UNIT_STATE_PERMISSION_BLOCKED)
+            self.assertIn("could not write a scratch file", workspace_preflight_reason(report))
+
+    @unittest.skipIf(
+        os.name != "posix", "directory mode bits are the POSIX way to make a path unwritable"
+    )
+    @unittest.skipIf(
+        os.geteuid() == 0 if hasattr(os, "geteuid") else False,
+        "root ignores the write bit, so a read-only directory proves nothing",
+    )
+    def test_an_unwritable_worktree_blocks_before_any_spawn(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+            os.chmod(repo, 0o500)
+            try:
+                report = probe_workspace(repo, base_ref=sha, target_ref=None)
+            finally:
+                os.chmod(repo, 0o700)
+
+            self.assertFalse(report["ok"])
+            self.assertIn(CHECK_FILE_WRITE, report["blocking"])
+            self.assertEqual(workspace_preflight_unit_state(report), UNIT_STATE_PERMISSION_BLOCKED)
+
+
+class WorkspacePreflightIndexWriteTests(unittest.TestCase):
+    def test_a_path_that_is_not_a_repository_blocks_on_index_write(self) -> None:
+        with TemporaryDirectory() as tmp:
+            plain = Path(tmp) / "plain"
+            plain.mkdir()
+
+            report = probe_workspace(plain, base_ref=None, target_ref=None)
+
+            self.assertFalse(report["ok"])
+            # The file write succeeds -- the directory is fine. What fails is
+            # everything that needs a repository, which is the distinction the
+            # per-check detail exists to make.
+            self.assertTrue(_by_name(report)[CHECK_FILE_WRITE]["ok"])
+            self.assertIn(CHECK_GIT_INDEX_WRITE, report["blocking"])
+            self.assertEqual(workspace_preflight_unit_state(report), UNIT_STATE_PERMISSION_BLOCKED)
+
+    def test_an_object_store_that_refuses_a_write_blocks_on_index_write(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+            git_dir = Path(_git(repo, "rev-parse", "--absolute-git-dir"))
+
+            def runner(argv, **kwargs):
+                if argv[:2] == ["git", "hash-object"]:
+                    return subprocess.CompletedProcess(argv, 128, "", "error: unable to write object")
+                return subprocess.run(argv, **kwargs)
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=None, runner=runner)
+
+            self.assertFalse(report["ok"])
+            self.assertIn(CHECK_GIT_INDEX_WRITE, report["blocking"])
+            self.assertIn(
+                "refused a write", str(_by_name(report)[CHECK_GIT_INDEX_WRITE]["detail"])
+            )
+            self.assertEqual(
+                [entry.name for entry in git_dir.iterdir() if "workspace-preflight" in entry.name],
+                [],
+            )
+
+    def test_a_runner_with_a_non_numeric_exit_code_is_treated_as_a_blocker(self) -> None:
+        # An unanswerable question is a blocker, never a pass: a probe that
+        # cannot observe the index write must not report that it observed one.
+        class _NoReturnCode:
+            returncode = None
+            stdout = ""
+            stderr = ""
+
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+
+            def runner(argv, **kwargs):
+                if argv[:2] == ["git", "update-index"]:
+                    return _NoReturnCode()
+                return subprocess.run(argv, **kwargs)
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=None, runner=runner)
+
+            self.assertFalse(report["ok"])
+            self.assertIn(CHECK_GIT_INDEX_WRITE, report["blocking"])
+
+    def test_a_git_binary_that_cannot_be_run_is_a_blocker_not_an_exception(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+
+            def runner(argv, **kwargs):
+                raise OSError("git is not executable here")
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=None, runner=runner)
+
+            self.assertFalse(report["ok"])
+            self.assertEqual(
+                sorted(report["blocking"]),
+                sorted([CHECK_GIT_INDEX_WRITE, CHECK_OBJECTS_PRESENT, CHECK_CASE_COLLISION])
+                if _case_insensitive(repo)
+                else sorted([CHECK_GIT_INDEX_WRITE, CHECK_OBJECTS_PRESENT]),
+            )
+
+
+class WorkspacePreflightObjectsTests(unittest.TestCase):
+    def test_a_base_ref_that_is_not_present_blocks_as_data_missing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo, _sha = _make_repo(Path(tmp))
+
+            report = probe_workspace(
+                repo, base_ref="0" * 40, target_ref=None
+            )
+
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["blocking"], [CHECK_OBJECTS_PRESENT])
+            self.assertEqual(workspace_preflight_unit_state(report), UNIT_STATE_DATA_MISSING)
+            self.assertIn("base_ref", str(_by_name(report)[CHECK_OBJECTS_PRESENT]["detail"]))
+
+    def test_two_histories_with_no_merge_base_block_as_data_missing(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo, sha = _make_repo(root)
+            # An orphan branch shares no commit with the base, which is the
+            # same answer the incident's missing merge-base produced.
+            _git(repo, "checkout", "-q", "--orphan", "other")
+            (repo / "other.txt").write_text("other\n", encoding="utf-8")
+            _git(repo, "add", "other.txt")
+            _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "orphan")
+            orphan = _git(repo, "rev-parse", "HEAD")
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=orphan)
+
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["blocking"], [CHECK_OBJECTS_PRESENT])
+            self.assertIn("no merge base", str(_by_name(report)[CHECK_OBJECTS_PRESENT]["detail"]))
+
+    def test_a_partial_clone_missing_objects_is_the_incident_condition(self) -> None:
+        # Driven through an injected runner rather than a real `--filter=blob:none`
+        # clone: building one offline needs a promisor remote whose objects are
+        # then removed, and whether git reaches for that remote varies by
+        # version and by whether `GIT_NO_LAZY_FETCH` is understood. The runner
+        # states the two facts the check reads -- the clone is partial, and the
+        # scan printed a missing object -- without depending on either.
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+
+            def runner(argv, **kwargs):
+                if argv[:3] == ["git", "config", "--get"]:
+                    if argv[3] == "extensions.partialClone":
+                        return subprocess.CompletedProcess(argv, 0, "origin\n", "")
+                    if argv[3] == "core.repositoryFormatVersion":
+                        return subprocess.CompletedProcess(argv, 0, "1\n", "")
+                if argv[:2] == ["git", "rev-list"]:
+                    return subprocess.CompletedProcess(
+                        argv, 0, f"{sha}\n?{'a' * 40}\n?{'b' * 40}\n", ""
+                    )
+                return subprocess.run(argv, **kwargs)
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=None, runner=runner)
+
+            self.assertFalse(report["ok"])
+            self.assertEqual(report["blocking"], [CHECK_OBJECTS_PRESENT])
+            self.assertEqual(workspace_preflight_unit_state(report), UNIT_STATE_DATA_MISSING)
+            detail = str(_by_name(report)[CHECK_OBJECTS_PRESENT]["detail"])
+            self.assertIn("2 object(s)", detail)
+            self.assertIn("fetching them is not permitted here", detail)
+
+    def test_a_partial_clone_with_every_object_present_still_passes(self) -> None:
+        # A partial clone is not a failure. It is reported, and only an
+        # actually absent object blocks.
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+
+            def runner(argv, **kwargs):
+                if argv[:4] == ["git", "config", "--get", "extensions.partialClone"]:
+                    return subprocess.CompletedProcess(argv, 0, "origin\n", "")
+                return subprocess.run(argv, **kwargs)
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=None, runner=runner)
+
+            self.assertTrue(report["ok"], report)
+            detail = str(_by_name(report)[CHECK_OBJECTS_PRESENT]["detail"])
+            self.assertIn("partial clone", detail)
+            self.assertIn("no absent objects", detail)
+
+    def test_the_missing_object_scan_never_reaches_a_network(self) -> None:
+        seen: list[list[str]] = []
+
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+
+            def runner(argv, **kwargs):
+                seen.append(list(argv))
+                self.assertEqual(kwargs["env"]["GIT_NO_LAZY_FETCH"], "1")
+                self.assertEqual(kwargs["env"]["GIT_TERMINAL_PROMPT"], "0")
+                if argv[:4] == ["git", "config", "--get", "extensions.partialClone"]:
+                    return subprocess.CompletedProcess(argv, 0, "origin\n", "")
+                return subprocess.run(argv, **kwargs)
+
+            probe_workspace(repo, base_ref=sha, target_ref=None, runner=runner)
+
+        for argv in seen:
+            self.assertNotIn(argv[1], {"fetch", "pull", "clone", "remote", "ls-remote"})
+        self.assertIn(["git", "rev-list", "--objects", "--missing=print", "-n", "200", "HEAD"], seen)
+
+
+class WorkspacePreflightCaseCollisionTests(unittest.TestCase):
+    def test_tracked_paths_differing_only_in_case_block_on_an_insensitive_filesystem(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo, _sha = _make_repo(Path(tmp))
+            # `update-index --cacheinfo` writes both spellings into the tree
+            # without either ever existing on disk, which is the only way to
+            # build this fixture on a case-insensitive filesystem.
+            blob = subprocess.run(
+                ["git", "hash-object", "-w", "--stdin"],
+                cwd=str(repo), input="x\n", text=True, capture_output=True, check=True,
+            ).stdout.strip()
+            for name in ("README.md", "readme.md"):
+                _git(repo, "update-index", "--add", "--cacheinfo", f"100644,{blob},{name}")
+            _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-q", "-m", "collide")
+            sha = _git(repo, "rev-parse", "HEAD")
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=None)
+
+            check = _by_name(report)[CHECK_CASE_COLLISION]
+            if not _case_insensitive(repo):
+                self.assertTrue(check["ok"])
+                self.assertIn("case-sensitive", str(check["detail"]))
+                return
+            self.assertFalse(report["ok"])
+            self.assertIn(CHECK_CASE_COLLISION, report["blocking"])
+            # It cannot be cleared by retrying, so it is a permission-shaped
+            # block rather than missing data.
+            self.assertEqual(workspace_preflight_unit_state(report), UNIT_STATE_PERMISSION_BLOCKED)
+            self.assertIn("README.md vs readme.md", str(check["detail"]))
+
+    def test_a_tree_without_collisions_passes_on_either_filesystem(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo, sha = _make_repo(Path(tmp))
+
+            report = probe_workspace(repo, base_ref=sha, target_ref=None)
+
+            check = _by_name(report)[CHECK_CASE_COLLISION]
+            self.assertTrue(check["ok"], check)
+            self.assertIn(
+                "case-insensitive" if _case_insensitive(repo) else "case-sensitive",
+                str(check["detail"]),
+            )
+
+
+class WorkspacePreflightReportingTests(unittest.TestCase):
+    def test_the_first_blocking_check_decides_the_state(self) -> None:
+        # File write is checked first because it EXPLAINS the index write, so
+        # a report carrying both must send the repair to the filesystem.
+        report = {
+            "blocking": [CHECK_FILE_WRITE, CHECK_OBJECTS_PRESENT],
+            "checks": [
+                {"name": CHECK_FILE_WRITE, "ok": False, "detail": "denied"},
+                {"name": CHECK_OBJECTS_PRESENT, "ok": False, "detail": "absent"},
+            ],
+        }
+
+        self.assertEqual(workspace_preflight_unit_state(report), UNIT_STATE_PERMISSION_BLOCKED)
+        reason = workspace_preflight_reason(report)
+        self.assertIn(CHECK_FILE_WRITE, reason)
+        self.assertIn(CHECK_OBJECTS_PRESENT, reason)
+        self.assertIn("denied", reason)
+
+    def test_every_check_name_maps_to_an_execution_state(self) -> None:
+        for name in WORKSPACE_PREFLIGHT_CHECKS:
+            report = {"blocking": [name], "checks": [{"name": name, "ok": False, "detail": "d"}]}
+            self.assertIn(
+                workspace_preflight_unit_state(report),
+                {UNIT_STATE_PERMISSION_BLOCKED, UNIT_STATE_DATA_MISSING},
+                name,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New `src/coding/workspace_preflight.py`: `probe_workspace(worktree, *, base_ref, target_ref, runner)` observes four pre-spawn blockers **inside the isolation the unit was handed** and returns a `workspace_preflight/v1` report.
- `omh coding fanout dispatch` runs it immediately after `git worktree add` and **before any process is spawned**. A failing check ends the unit without spawning.
- New closed-enum member `FAILURE_KIND_WORKSPACE_BLOCKED = "workspace_blocked"` in `dispatch_failure_recovery.py`, placed above `crash` in `FAILURE_KIND_PRECEDENCE` and deliberately outside `RECOVERABLE_FAILURE_KINDS`.
- Executor readiness stops claiming more than it observed: `observed: "binary_version_only"`, a claim boundary that names what a version probe cannot see, and a summary sentence pointing at where the workspace question is actually answered.
- `docs/FANOUT.md`: new **Workspace preflight** section; the failure-recovery enum list gains the new member.

### Why This Exists

On 2026-09-11 a recovery run had a runnable CLI (`--version` exited 0) and a freshly created worktree, and then spent 36 minutes unable to write a git index it had been told was complete: a `blob:none` partial clone with network fetch forbidden, plus case-only filename collisions on a case-insensitive filesystem. It retried workarounds (clone mode, skip-worktree, sparse checkout) for a condition retrying cannot clear, and never reported itself blocked.

Every one of those conditions was observable before the unit started. `--version` exiting 0 says the binary runs; it does not say a file can be written, an index can be updated, the commits the work names exist, or the tracked filenames can coexist on this filesystem.

### User / Operator Impact

A unit that cannot do its work now fails in under a second with the check name and the detail, instead of burning a session on retries. The operator gets `reason_code: workspace_preflight_blocked`, a `unit_state` that says whether it is a denial or missing data, and the full per-check report. The worktree is left exactly as it is, because the repair belongs at the preparation step.

### How It Works

| Check | What it observes | Blocked state |
| --- | --- | --- |
| `file_write` | scratch file created, read back, removed in the worktree | `permission_blocked` |
| `git_index_write` | scratch blob written to the object store, plus an index entry through a **temporary** `GIT_INDEX_FILE` so the unit's real index is untouched | `permission_blocked` |
| `objects_present` | `HEAD` and the base ref are present commits; a merge base exists when both sides are named; a partial clone is reported, and only an **actually absent** object fails the check | `data_missing` |
| `case_collision` | case sensitivity is **observed** (write `x.tmp`, look for `X.TMP`), never inferred from the platform; if insensitive, no two tracked paths in `HEAD` may casefold to the same name | `permission_blocked` |

Every git command is bounded (30s), runs under `GIT_NO_LAZY_FETCH=1` / `GIT_TERMINAL_PROMPT=0` / `GIT_OPTIONAL_LOCKS=0`, and the partial-clone scan uses `rev-list --objects --missing=print`, which **prints** absent objects rather than fetching them. No network call. Every scratch path is removed; a removal that fails is itself reported as a failed check rather than silently leaving a file in the unit's `git status`. A subprocess failure is a failed check carrying its stderr tail — never an exception out of `probe_workspace`.

The blocked unit reports `status: "worktree_failed"` rather than a new status word. The dispatch status vocabulary is a wire contract (`src/evidence/labels.py`, `src/coding/status_board.py`, `src/plugin_bundle/…`, `_dependency_failed`) and this genuinely is a setup-phase worktree failure; `reason_code: workspace_preflight_blocked` is what separates "the worktree could not be created" from "the worktree was created and cannot be worked in".

### Files And Contracts Touched

- `src/coding/workspace_preflight.py` (new) — `workspace_preflight/v1`, `probe_workspace`, `workspace_preflight_unit_state`, `workspace_preflight_reason`.
- `src/coding/fanout_dispatch.py` — one insertion point after `worktree = Path(worktree_record["worktree_path"])`, one early return; nothing else moved.
- `src/coding/dispatch_failure_recovery.py` — `FAILURE_KIND_WORKSPACE_BLOCKED`, `FAILURE_KINDS`, `FAILURE_KIND_PRECEDENCE`, `RECOVERABLE_FAILURE_KINDS` comment.
- `src/coding/executor_readiness.py` — `READINESS_OBSERVED_BINARY_VERSION_ONLY`, `READINESS_WORKSPACE_PROBE_NOTE`, `READINESS_BINARY_ONLY_CLAIM_BOUNDARY`; the cached-probe branch keeps the narrower boundary.
- `tests/test_handoff_safety_contract_enforcement.py` — one `PROCESS_SPAWN_ALLOWLIST` entry and ten `GIT_ARGV_ALLOWLIST` entries, each stating the command is local and read-only (the `update-index`/`hash-object` pair says exactly what it writes and where).
- `docs/FANOUT.md`.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke … release hermes-smoke …`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- Full suite, run through the repo's own shard planner: 4 shards × 2728 tests, **all OK** (`OK (skipped=1)`, `OK (skipped=2)`, `OK`, `OK`), plus the quarantine group `Ran 71 tests … OK`. 10,983 discovered / 10,912 sharded / 71 quarantined. (An earlier single-process `discover` here exited 144 with no summary. That was **not** a sandbox signal, as this line previously said — a sibling worktree ran a machine-wide `pkill -f "unittest discover"`, which kills every worktree's suite, including this one. The sharded runs above completed untouched and are the evidence; the earlier attribution was wrong and is corrected here rather than left standing.)
- `tests/test_workspace_preflight.py` — 18 cases against real temporary git repositories: pass case (and that it leaves `git status` empty and no scratch path in the git dir), the real index byte-identical afterwards, unwritable worktree (POSIX-only, skipped as root with a stated reason), non-repository path, object store refusing a write, non-numeric runner exit code, unrunnable git, missing base ref, no merge base (orphan branch), partial clone with missing objects, partial clone with everything present, no-network argv assertion, and a real case-collision tree built with `update-index --cacheinfo` so it works on a case-insensitive filesystem.
- `tests/test_fanout_dispatch.py::FanoutWorkspacePreflightTests` — a failing preflight produces `failure_kind == "workspace_blocked"`, `unit_state == "data_missing"`, the preflight payload, and **`runner.spawned == []`**; the negative control asserts a healthy worktree still spawns exactly one CLI and carries no preflight key.
- `tests/test_handoff_safety_contract_enforcement.py` — 28 tests OK, including `NoRemoteMutation`, which initially **failed** this change (`["git", *argv]` made the subcommand a runtime value) and was fixed by spelling `"git"` plus the literal subcommand at every call site.
- `uv run python -m omh.cli docs {workflows,roles,capability-families,ulw-inventory,ulw-site,navigation} --check` all pass; `docs claims --check --json` reports `ok: true`.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, the install smoke and the manual Hermes/TUI check: this change touches no skill catalog, no install manifest, no router and no TUI surface — it adds one module under `src/coding/` reached only from the explicit fanout dispatch bridge.
- A real `git clone --filter=blob:none` whose promisor objects are then removed. Building one offline is fragile across git versions (whether `GIT_NO_LAZY_FETCH` is understood, whether the promisor is consulted), so that one case is driven through an injected `runner` that states the two facts the check reads; the test name and its comment say so explicitly.
- The **CLI exit code** for a blocked unit. `_fanout_dispatch_exit_code` on this base still returns 0 for any unit-level failure; PR #1486 is the change that makes it 1 for any `failure_kind`, and this envelope carries exactly the field that mapper reads. Not claimed as observed here.
- `omh --help` / the `/tmp` install smoke: no CLI surface, argument, or install artifact changed.

## Risk

- The preflight runs on every dispatched unit, adding ~8 bounded local git commands before each spawn (measured well under a second on a real repo). A unit whose worktree is fine sees no behavioral change.
- A new *refusal* path: a runner that cannot answer `git rev-parse --absolute-git-dir` now blocks the unit rather than spawning into an unproven workspace. That is the intended fail-closed direction (an unanswerable question is a blocker), and it surfaced exactly once in the existing suite, where the test's fake runner deliberately faults `git rev-parse`; that fault is now narrowed to the invocations the recovery probe uses, with the reason in a comment.
- `src/coding/fanout_dispatch.py` is touched by three parallel workstreams. The edit here is one import block, one `probe_workspace` call and one early return at a single insertion point, so a rebase stays mechanical.

## Compatibility / Rollout

Additive. Existing envelopes are unchanged; a passing preflight adds no key at all. `workspace_blocked` is a new member of an existing closed enum, and readers that branch on `failure_kind` already have a default path. Readiness payloads gain two fields and a longer summary; the observed version line is still inside the summary, appended to rather than replaced.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- `_fanout_dispatch_exit_code` must return non-zero for a unit carrying `failure_kind` — owned by PR #1486, verified here only as "this envelope carries the field".
- This branch branched from `claude/unit-execution-state`, which has since merged to main (#1488), so the PR carries only its own three commits.
- `unit_execution_state.py` needed no new state: `permission_blocked` and `data_missing` describe all four blockers exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTAg6swdLJiUTYBoq7noV8

