### PR TITLE
feat(coding): tell a stuck unit apart from a live process

### DIFF
--- a/docs/CODING-OBSERVABILITY.md
+++ b/docs/CODING-OBSERVABILITY.md
@@ -57,6 +57,39 @@ executor reported. An absent count renders as the literal `unknown`, never as
 identical to one left by a process still working, so the board reports an
 observed start without an observed end rather than claiming the unit is alive.
 
+**A live process is not moving work.** On 2026-09-11 a unit stayed alive for
+36 minutes retrying the same git workaround while its supervisor read "PID
+alive" as progress. So "a process exists" and "the work is moving" are now two
+different readings with two different words. The dispatch word (`running`,
+`completed`, `failed`, …) stays on the row's `status`, and what the unit's own
+stdout showed goes in `unit_state` beside it — see the table below. Anything
+`unit_state` calls stuck replaces the dispatch word wherever a row is rendered:
+the status board, the plugin running-work block, and the DAG line in the TUI
+widget. A unit with no assessed snapshot carries no `unit_state` at all, which
+is not the same as "moving".
+
+### Unit execution states
+
+Vocabulary in `src/coding/unit_execution_state.py`; the mid-run verdict is
+derived by `src/coding/unit_progress.py` from the stdout snapshots the dispatch
+already takes, and the two terminal states are assigned only after exit.
+
+| State | What was observed | Terminal |
+| --- | --- | --- |
+| `running` | The work is producing new evidence: output growing, tests starting and ending, result records appearing. The only state that means progressing. | no |
+| `awaiting_input` | The output ends at a question or a prompt and has stopped growing. Nobody is going to answer it. | no |
+| `permission_blocked` | A permission or sandbox denial stopped the work. Retrying under the same permissions cannot clear it. | no |
+| `account_limit` | The provider refused for account reasons: session or usage limit, quota, credits. | no |
+| `data_missing` | Objects the work needs are absent in its isolation — partial-clone blobs, a missing base commit, a ref that was described but never fetched. | no |
+| `progress_stalled` | The process is alive and the work is not moving: no new output past the threshold (15 minutes, `UNIT_STALL_AFTER_SECONDS`), **or** the same line repeating three times even while bytes grow. | no |
+| `failed` | The process ended without a verified result. Exit code 0 with the required result record missing is this state, with reason `result_missing` — never `verified`. | yes |
+| `verified` | The result record validated against the contract and its verification was observed. The only success state. | yes |
+
+The three non-`running` mid-run states above the stall are conditions retrying
+cannot clear, so they are reported the moment the tail matches rather than
+waited out. A matched shape is not provider, filesystem, or repository truth —
+it is what the output looked like.
+
 **Runtimes without structured output report `unknown` and say so.** The
 omo-runtime lane (pi / senpi / opencode) has no structured token surface, so
 its token columns stay unknown by design rather than being filled with a guess.
@@ -93,7 +126,7 @@ normalizes both vocabularies onto one set of keys.
 
 | Source | Provides |
 | --- | --- |
-| `~/.omh/coding/fanout/<id>/inflight/<unit>.json` | mid-flight `running` state and start time |
+| `~/.omh/coding/fanout/<id>/inflight/<unit>.json` | start time, and the last assessed `unit_state` with its reason, stall age, repeat count, and phase markers |
 | `dispatch_summary.json` | owner, model, effort, status, duration, tokens, session |
 | executor progress bindings | live cross-unit state and latest observed event |
 

--- a/docs/CODING-OBSERVABILITY.md
+++ b/docs/CODING-OBSERVABILITY.md
@@ -75,7 +75,11 @@ A supervisor polls the same answer machine-readably with
 exits, `none` when nothing observed it), and `progress.reason` /
 `progress.seconds_since_new_output`. The roster carries `all_units_terminal`
 and `stuck_units` so the loop's stop condition is computed once rather than
-re-derived per caller. None of this moves `lifecycle_state`, which still
+re-derived per caller. `terminal` follows the SOURCE, not the state word: a
+dispatch-summary row is written after the dispatch ended, so it is terminal
+whatever word it carries — including a unit the workspace preflight refused
+before its spawn, which is stuck, needs a human, and will never move on its
+own. A marker means the unit is in flight now, so its state is read literally. None of this moves `lifecycle_state`, which still
 advances on journal events alone — and `all_units_terminal` is false for an
 empty roster, because "nothing to wait for" and "everything finished" are
 different answers.
@@ -89,11 +93,11 @@ already takes, and the two terminal states are assigned only after exit.
 | State | What was observed | Terminal |
 | --- | --- | --- |
 | `running` | The work is producing new evidence: output growing, tests starting and ending, result records appearing. The only state that means progressing. | no |
-| `awaiting_input` | The output ends at a question or a prompt and has stopped growing. Nobody is going to answer it. | no |
+| `awaiting_input` | The output ends at a question or a prompt and has been still for `UNIT_PROMPT_QUIET_SECONDS` (60s). The quiet window is the guard: one poll step of silence after a question mark is a tool call in progress, not a unit blocked on a human. | no |
 | `permission_blocked` | A permission or sandbox denial stopped the work. Retrying under the same permissions cannot clear it. | no |
 | `account_limit` | The provider refused for account reasons: session or usage limit, quota, credits. | no |
 | `data_missing` | Objects the work needs are absent in its isolation — partial-clone blobs, a missing base commit, a ref that was described but never fetched. | no |
-| `progress_stalled` | The process is alive and the work is not moving: no new output past the threshold (15 minutes, `UNIT_STALL_AFTER_SECONDS`), **or** the same line repeating three times even while bytes grow. | no |
+| `progress_stalled` | The process is alive and the work is not moving: no new output past the threshold (15 minutes, `UNIT_STALL_AFTER_SECONDS`), **or** the same *failure-shaped* line repeating three times even while bytes grow. Repetition alone is not a stall — a green run prints `... ok` endlessly — so only lines matching `_FAILURE_SHAPED_WORDS` are counted. | no |
 | `failed` | The process ended without a verified result. Exit code 0 with the required result record missing is this state, with reason `result_missing` — never `verified`. | yes |
 | `verified` | The result record validated against the contract and its verification was observed. The only success state. | yes |
 

--- a/docs/CODING-OBSERVABILITY.md
+++ b/docs/CODING-OBSERVABILITY.md
@@ -68,6 +68,18 @@ the status board, the plugin running-work block, and the DAG line in the TUI
 widget. A unit with no assessed snapshot carries no `unit_state` at all, which
 is not the same as "moving".
 
+A supervisor polls the same answer machine-readably with
+`omh coding fanout status --fanout-id <id> --json`. Every roster row carries
+`unit_state`, `terminal` (via `is_terminal`), `unit_state_source`
+(`inflight_marker` while the unit is in flight, `dispatch_summary` after it
+exits, `none` when nothing observed it), and `progress.reason` /
+`progress.seconds_since_new_output`. The roster carries `all_units_terminal`
+and `stuck_units` so the loop's stop condition is computed once rather than
+re-derived per caller. None of this moves `lifecycle_state`, which still
+advances on journal events alone — and `all_units_terminal` is false for an
+empty roster, because "nothing to wait for" and "everything finished" are
+different answers.
+
 ### Unit execution states
 
 Vocabulary in `src/coding/unit_execution_state.py`; the mid-run verdict is

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -140,6 +140,12 @@ from .fanout_retry import (
     classify_unit_failure,
     evaluate_unit_retry,
 )
+from .unit_execution_state import UNIT_STATE_FAILED, UNIT_STATE_VERIFIED
+from .unit_progress import (
+    assess_progress,
+    empty_progress_evidence,
+    stalled_for_seconds,
+)
 from .unit_prompt_protocol import shared_unit_preamble_lines, unit_protocol_lines
 from .workspace_preflight import (
     probe_workspace,
@@ -3120,6 +3126,83 @@ def _write_inflight(paths: OmhPaths, fanout_id: str, unit_id: str, fields: dict[
         return
 
 
+class _UnitProgressObserver:
+    """Turns the mid-run stdout snapshots into a verdict on the unit's WORK.
+
+    The snapshots `_communicate_with_output_polls` already takes were used
+    only for token telemetry, so every surface downstream could say a process
+    existed and none could say whether the work was moving -- the exact gap
+    the 2026-09-11 incident fell into (36 minutes of new output that was the
+    same git workaround again, read as progress because the PID was alive).
+    This holds the previous evidence, assesses each snapshot against it, and
+    writes the answer onto the in-flight marker so another session reads the
+    state rather than inferring one from a file's existence.
+
+    Best-effort throughout, like every other marker write on this path:
+    observability must never fail a dispatch.
+    """
+
+    def __init__(self, paths: OmhPaths, fanout_id: str, unit_id: str, fields: dict[str, str]) -> None:
+        self._paths = paths
+        self._fanout_id = fanout_id
+        self._unit_id = unit_id
+        # The SAME dict the dispatch keeps its marker fields in, so a pid
+        # recorded after the spawn is carried by every later progress write
+        # instead of being erased by one.
+        self._fields = fields
+        self._evidence: dict[str, Any] = empty_progress_evidence(now=time.monotonic())
+        # Wall-clock twin of the evidence's monotonic `last_new_output_at`,
+        # restamped only when that reading moves. A reader in another process
+        # can subtract this from its own clock; it can do nothing at all with
+        # a monotonic value from a process it never ran.
+        self._last_new_output_stamp = utc_now()
+
+    def observe(self, stdout_snapshot: str) -> None:
+        self._assess(stdout_snapshot, result_record_present=False)
+        self._fields.update(
+            _inflight_progress_fields(self._evidence, last_new_output_at=self._last_new_output_stamp)
+        )
+        _write_inflight(self._paths, self._fanout_id, self._unit_id, self._fields)
+
+    def finalize(self, stdout_text: str, *, result_record_present: bool) -> dict[str, Any]:
+        """One last assessment after exit, with the result record's answer in.
+
+        Still non-terminal: `failed` and `verified` are the caller's to assign
+        from the evidence ladder, not this module's to guess from stdout.
+        """
+        self._assess(stdout_text, result_record_present=result_record_present)
+        return self._evidence
+
+    def _assess(self, stdout_text: str, *, result_record_present: bool) -> None:
+        previous_new_output_at = self._evidence.get("last_new_output_at")
+        try:
+            self._evidence = assess_progress(
+                self._evidence,
+                stdout_text,
+                now=time.monotonic(),
+                result_record_present=result_record_present,
+            )
+        except (TypeError, ValueError, re.error):
+            # A malformed snapshot must not cost the dispatch its run; the
+            # previous evidence stands and the next snapshot tries again.
+            return
+        if self._evidence.get("last_new_output_at") != previous_new_output_at:
+            self._last_new_output_stamp = utc_now()
+
+
+def _inflight_progress_fields(evidence: Mapping[str, Any], *, last_new_output_at: str) -> dict[str, str]:
+    """Progress evidence as the marker's flat, scalar, string-only fields."""
+    markers = evidence.get("phase_markers")
+    return {
+        "unit_state": str(evidence.get("state", "") or ""),
+        "state_reason": str(evidence.get("reason", "") or ""),
+        "last_new_output_at": last_new_output_at,
+        "stalled_for_seconds": str(stalled_for_seconds(evidence)),
+        "repeat_count": str(evidence.get("repeat_count", 0) or 0),
+        "phase_markers": ",".join(str(marker) for marker in markers) if isinstance(markers, list) else "",
+    }
+
+
 def _clear_inflight(paths: OmhPaths, fanout_id: str, unit_id: str) -> None:
     """Runs inside `finally`, so it must never mask the dispatch exception."""
     if not fanout_id:
@@ -3980,20 +4063,23 @@ def _dispatch_unit(
     # the whole unit, so the dispatching process cannot report on itself; the
     # marker is what lets ANOTHER session see that this unit is running and
     # compute its elapsed time. Marker failures never block a dispatch.
-    _write_inflight(
-        paths,
-        fanout_id,
-        unit_id,
-        {
-            "owner": owner,
-            "owner_host": owner_host,
-            "model": routed_model,
-            "reasoning_effort": routed_effort,
-            "run_ref": run_ref,
-            "worktree": str(worktree),
-            "started_at": started_at,
-        },
-    )
+    # One dict for the unit's whole lifetime: the pid recorded after the spawn
+    # and the progress evidence written from each stdout snapshot both update
+    # it in place, so no later write erases what an earlier one recorded.
+    marker_fields: dict[str, str] = {
+        "owner": owner,
+        "owner_host": owner_host,
+        "model": routed_model,
+        "reasoning_effort": routed_effort,
+        "run_ref": run_ref,
+        "worktree": str(worktree),
+        "started_at": started_at,
+    }
+    _write_inflight(paths, fanout_id, unit_id, marker_fields)
+    # Holds the evidence across snapshots. Opened here rather than beside the
+    # on_output wiring below so the post-exit record has one to finalize even
+    # when the runner never accepted the snapshot hook at all.
+    progress_observer = _UnitProgressObserver(paths, fanout_id, unit_id, marker_fields)
     # Best-effort HUD row for this unit: opened inside the same try whose
     # finally below closes it, so the row can never outlive the process it
     # describes -- opening it BEFORE the try left a window (a Ctrl-C during
@@ -4038,21 +4124,8 @@ def _dispatch_unit(
                 nonlocal progress_binding
                 if getattr(runner, 'accepts_launch', False):
                     dispatch_observed()
-                _write_inflight(
-                    paths,
-                    fanout_id,
-                    unit_id,
-                    {
-                        "owner": owner,
-                        "owner_host": owner_host,
-                        "model": routed_model,
-                        "reasoning_effort": routed_effort,
-                        "run_ref": run_ref,
-                        "worktree": str(worktree),
-                        "started_at": started_at,
-                        "pid": str(process.pid),
-                    },
-                )
+                marker_fields["pid"] = str(process.pid)
+                _write_inflight(paths, fanout_id, unit_id, marker_fields)
                 progress_binding = _record_fanout_progress_pid(paths, progress_binding, process.pid)
 
             spawn_kwargs["on_spawn"] = _record_pid
@@ -4067,7 +4140,7 @@ def _dispatch_unit(
                 nonlocal progress_binding
                 progress_binding = updated
 
-            spawn_kwargs["on_output"] = _live_unit_telemetry_reporter(
+            telemetry_reporter = _live_unit_telemetry_reporter(
                 paths,
                 owner=owner,
                 routed_model=routed_model,
@@ -4076,6 +4149,17 @@ def _dispatch_unit(
                 binding_ref=lambda: progress_binding,
                 binding_set=_replace_binding,
             )
+
+            def _observe_snapshot(stdout_snapshot: str) -> None:
+                # The same snapshot answers two different questions: how many
+                # tokens the unit has spent (the HUD row) and whether its work
+                # is moving at all (the marker). The progress verdict goes
+                # first: it is the one a supervisor acts on, and the telemetry
+                # reporter's own throttle can swallow a whole poll.
+                progress_observer.observe(stdout_snapshot)
+                telemetry_reporter(stdout_snapshot)
+
+            spawn_kwargs["on_output"] = _observe_snapshot
         confinement_command = confinement.command(argv) if confinement is not None else None
         if confinement_command is not None:
             spawn_kwargs["confinement_command"] = confinement_command
@@ -4450,6 +4534,37 @@ def _dispatch_unit(
                 and producer_head == unit_result.get("producer_head_sha")
             ),
         ) or {}
+    # The ladder's own two rungs, read once so the envelope and the unit state
+    # below it cannot disagree about what was observed.
+    result_schema_valid = bool(unit_result.get("result_schema_valid"))
+    verification_observed = _unit_verification_is_observed(paths, run_ref)
+    # `unit_result_missing` is the intake path's word for "no result record
+    # appeared at all", as opposed to one that appeared and failed validation.
+    result_record_present = str(unit_result.get("unit_result_status", "")) != "unit_result_missing"
+    progress_evidence = progress_observer.finalize(
+        stdout_text, result_record_present=result_record_present
+    )
+    # `observed_at` and `last_new_output_at` inside the evidence are monotonic
+    # readings from THIS process and mean nothing in a reader's. The
+    # difference between them does, so the record carries it derived rather
+    # than leaving a reader to subtract two numbers it cannot interpret.
+    progress_evidence = {
+        **progress_evidence,
+        "stalled_for_seconds": stalled_for_seconds(progress_evidence),
+    }
+    # The only terminal answer, and it is the ladder's, never the exit code's:
+    # a unit that exited 0 without a validated result and an observed
+    # verification has not verified anything. `result_missing` is called out by
+    # name because exit 0 with no record at all is the shape that used to read
+    # as success everywhere.
+    if result_schema_valid and verification_observed:
+        unit_state, unit_state_reason = UNIT_STATE_VERIFIED, ""
+    elif not result_record_present:
+        unit_state, unit_state_reason = UNIT_STATE_FAILED, "result_missing"
+    elif not result_schema_valid:
+        unit_state, unit_state_reason = UNIT_STATE_FAILED, "result_invalid"
+    else:
+        unit_state, unit_state_reason = UNIT_STATE_FAILED, "verification_not_observed"
     result = {
         "unit_id": unit_id,
         "run_ref": run_ref,
@@ -4458,6 +4573,9 @@ def _dispatch_unit(
         "reasoning_effort": routed_effort,
         "status": "completed" if exit_code == 0 else "failed",
         "exit_code": exit_code,
+        "unit_state": unit_state,
+        "unit_state_reason": unit_state_reason,
+        "progress": progress_evidence,
         "worktree_path": str(worktree),
         "filesystem_confinement": filesystem_confinement,
         "child_environment_policy": child_environment.receipt,
@@ -4465,8 +4583,8 @@ def _dispatch_unit(
         "shared_artifacts": shared_artifacts,
         **_dispatch_status_ladder(
             process_succeeded=exit_code == 0,
-            result_schema_valid=bool(unit_result.get("result_schema_valid")),
-            unit_verification_observed=_unit_verification_is_observed(paths, run_ref),
+            result_schema_valid=result_schema_valid,
+            unit_verification_observed=verification_observed,
         ),
         **unit_result,
         **verification,

--- a/src/coding/fanout_status.py
+++ b/src/coding/fanout_status.py
@@ -69,9 +69,11 @@ import json
 
 FANOUT_STATUS_SCHEMA_VERSION = "fanout_status_roster/v1"
 FANOUT_STATUS_CLAIM_BOUNDARY = (
-    "A fanout status roster projects dispatcher-observed journal events only. It is not verification, "
-    "review, CI, merge-readiness, or merge evidence, and a unit's state never advances on an executor's "
-    "own report."
+    "A fanout status roster projects dispatcher-observed journal events; `lifecycle_state` advances on "
+    "those alone and never on an executor's own report. The `unit_state` / `terminal` / `progress` keys "
+    "are a separate reading of whether the work is moving, taken from the in-flight marker while a unit "
+    "runs and the dispatch summary after it exits, and they move no rung. It is not verification, review, "
+    "CI, merge-readiness, or merge evidence."
 )
 # The ladder todo 3 froze for dispatch summaries, restated here as the roster's
 # display vocabulary plus the two pre-success rungs a roster must be able to

--- a/src/coding/fanout_status.py
+++ b/src/coding/fanout_status.py
@@ -290,13 +290,36 @@ def _apply_unit_progress(paths: OmhPaths, fanout_id: str, units: list[dict[str, 
             state, reason, stalled, source = observed
         unit["unit_state"] = state
         unit["unit_state_source"] = source
-        unit["terminal"] = is_terminal(state)
+        unit["terminal"] = _row_is_terminal(state, source)
         unit["progress"] = {
             "reason": reason,
             # None, never 0, when no assessment recorded one: a zero here
             # would read as "output moved this instant".
             "seconds_since_new_output": stalled,
         }
+
+
+def _row_is_terminal(state: str, source: str) -> bool:
+    """Whether anything will ever move this unit again.
+
+    The SOURCE decides, not the state word alone. `is_terminal` answers for the
+    execution vocabulary, where every stuck state is non-terminal because a
+    stuck unit is one a supervisor can still act on. A dispatch-summary row is
+    different: that file is written once, after the whole dispatch has ended
+    (see the write site at the foot of `dispatch_fanout`), so a unit recorded
+    in it is over whatever word it carries.
+
+    The case that forces this is the workspace preflight (#1489): a unit
+    refused before its spawn is recorded with a stuck `unit_state`, no marker
+    and no progress evidence, and nothing exists to move it. Reporting it as
+    non-terminal would hang a supervisor's poll loop forever on a unit that
+    never started -- the precise failure this whole lane exists to prevent.
+
+    A marker means the unit is in flight NOW, so its state is read literally.
+    """
+    if source == "dispatch_summary":
+        return True
+    return is_terminal(state)
 
 
 def _marker_progress(paths: OmhPaths, fanout_id: str) -> dict[str, tuple[str, str, int | None, str]]:
@@ -342,7 +365,17 @@ def _summary_progress(paths: OmhPaths, fanout_id: str) -> dict[str, tuple[str, s
         progress = entry.get("progress")
         rows[unit_id] = (
             state,
-            str(entry.get("unit_state_reason", "") or ""),
+            # `unit_state_reason` is what a dispatched unit's record carries.
+            # A unit refused before its spawn never reached that code and
+            # carries the preflight's own `reason` instead, so both are read
+            # rather than the pre-spawn case rendering with no explanation at
+            # all; `failure_kind` is the last resort, and is still a word.
+            str(
+                entry.get("unit_state_reason", "")
+                or entry.get("reason", "")
+                or entry.get("failure_kind", "")
+                or ""
+            ),
             _non_negative_int(progress.get("stalled_for_seconds")) if isinstance(progress, Mapping) else None,
             "dispatch_summary",
         )

--- a/src/coding/fanout_status.py
+++ b/src/coding/fanout_status.py
@@ -6,7 +6,19 @@ restart a unit would be a control plane, and the only durable evidence this
 layer trusts is what the dispatcher already recorded.
 
 Only the observation journal supplies lifecycle and session evidence. Executor
-stdout, dispatch summaries, and in-flight markers are NOT evidence inputs.
+stdout, dispatch summaries, and in-flight markers are NOT evidence inputs for
+any lifecycle rung -- `lifecycle_state` still advances on journal events alone,
+and nothing below can move it.
+
+One narrowly-scoped exception, added for the supervisor poll loop: the
+`unit_state` / `terminal` / `progress` fields answer "is this unit's WORK
+moving, and is it over?", which the journal cannot answer while a unit is still
+running. Those three come from the in-flight marker while the unit is in flight
+and from the dispatch summary record after it exits, and they are kept in their
+own keys so no reader can mistake them for a ladder rung. The marker is read
+through `inflight.read_inflight_markers` -- the same single reader the status
+board uses -- rather than a second parser.
+
 Copy-only session actions additionally require a bounded frozen-contract read
 and fresh, read-only workspace and executable observations. The unit rows therefore carry exactly what the journal knows:
 which rung of the dispatch ladder has dispatcher-observed backing, who ran it,
@@ -49,6 +61,9 @@ from .fanout_executor_sessions import (
 from .executor_readiness import observe_session_binary
 from .fanout_capacity import read_capacity_fields
 from .fanout_artifacts import fanout_contract_digest, fanout_dispatch_summary_path
+from ..system.local_store import read_json_object_result
+from .inflight import read_inflight_markers
+from .unit_execution_state import UNIT_STUCK_STATES, is_terminal
 from ..workflows.observation_journal import project_run_executor_session
 import json
 
@@ -71,6 +86,11 @@ FANOUT_UNIT_STATES = (
     "integration_ready",
 )
 _UNKNOWN = "unknown"
+# Marker read ceiling for one fanout. `read_inflight_markers` filters by
+# fanout id BEFORE this slice, so a busy machine's other fanouts cannot push
+# this one's units off the end; the number only bounds a single fanout's own
+# unit count, which the contract builder already caps well below it.
+_MARKER_READ_LIMIT = 200
 
 _FANOUT_ID_RE = re.compile(FANOUT_ID_PATTERN)
 # Journal events that name a dispatched unit. `worker_dispatch` /
@@ -136,6 +156,7 @@ def project_fanout_status(paths: OmhPaths, fanout_id: str, *, unit_id: str | Non
             if attempt == current and event.get('event') == 'capacity_admission_observed':
                 capacity = read_capacity_fields(event)
         unit.update(capacity)
+    _apply_unit_progress(paths, validated_id, units)
     if unit_id is not None:
         units = [unit for unit in units if unit['unit_id'] == unit_id]
         if not units:
@@ -149,6 +170,14 @@ def project_fanout_status(paths: OmhPaths, fanout_id: str, *, unit_id: str | Non
             unit["unit_id"] for unit in units if unit["lifecycle_state"] == "integration_ready"
         ],
         "journal_event_count": len(fanout_events),
+        # The supervisor poll loop's own stop condition, computed once rather
+        # than re-derived by every caller: a fanout with no units is NOT done,
+        # because "nothing to wait for" and "everything finished" are different
+        # answers and only one of them means the work happened.
+        "all_units_terminal": bool(units) and all(bool(unit.get("terminal")) for unit in units),
+        "stuck_units": [
+            str(unit["unit_id"]) for unit in units if unit.get("unit_state") in UNIT_STUCK_STATES
+        ],
         "claim_boundary": FANOUT_STATUS_CLAIM_BOUNDARY,
     }
     if read_errors:
@@ -173,6 +202,9 @@ def render_fanout_status_text(roster: Mapping[str, Any]) -> str:
             f"{_age_phrase(unit.get('last_event_age_seconds'))} "
             f"| evidence refs {unit.get('evidence_ref_count', 0)}"
         )
+        progress_line = _unit_progress_phrase(unit)
+        if progress_line:
+            lines.append(f"  work: {progress_line}")
         capacity = read_capacity_fields(unit).get('capacity')
         if is_string_map(capacity):
             lines.append(f"  capacity: {capacity['status']}; next action: {capacity['next_action']}")
@@ -188,8 +220,141 @@ def render_fanout_status_text(roster: Mapping[str, Any]) -> str:
         )
         if diagnostic is not None:
             lines.append(f"  diagnostic: {failure_diagnostic_text(diagnostic)}")
+    stuck = [str(name) for name in roster.get("stuck_units", []) if name]
+    if stuck:
+        # Named on its own line, because the per-unit rows scroll and this is
+        # the line a supervisor has to act on.
+        lines.append(f"Stuck, needs intervention: {', '.join(stuck)}")
     lines.append(str(roster.get("claim_boundary", FANOUT_STATUS_CLAIM_BOUNDARY)))
     return "\n".join(lines)
+
+
+def _unit_progress_phrase(unit: Mapping[str, object]) -> str:
+    """`progress_stalled (no_new_output, 1920s since new output)`, or "".
+
+    Empty when nothing observed the unit's work, so a roster projected from a
+    journal that predates progress evidence renders exactly as it did before.
+    """
+    state = str(unit.get("unit_state", "") or "")
+    if not state or state == _UNIT_STATE_UNKNOWN:
+        return ""
+    progress = unit.get("progress")
+    parts: list[str] = []
+    if isinstance(progress, Mapping):
+        reason = str(progress.get("reason", "") or "")
+        if reason:
+            parts.append(reason)
+        stalled = progress.get("seconds_since_new_output")
+        if isinstance(stalled, int) and not isinstance(stalled, bool) and stalled > 0:
+            parts.append(f"{stalled}s since new output")
+    detail = f" ({', '.join(parts)})" if parts else ""
+    return f"{state}{detail}" if unit.get("terminal") else f"{state}{detail}, not terminal"
+
+
+# `unit_state` when nothing has observed the unit's work yet. Distinct from
+# every real state: absent evidence is not `running`, and it is not terminal.
+_UNIT_STATE_UNKNOWN = "unknown"
+# Where a row's `unit_state` came from, so a reader can tell a live reading
+# from a post-exit record from no reading at all.
+_PROGRESS_SOURCES = ("inflight_marker", "dispatch_summary", "none")
+
+
+def _apply_unit_progress(paths: OmhPaths, fanout_id: str, units: list[dict[str, Any]]) -> None:
+    """Attach `unit_state`, `terminal`, and `progress` to every roster row.
+
+    The supervisor poll loop (`omh coding fanout status --json`, driven by the
+    ulw-maestro skill) needs two things the journal cannot give it: whether a
+    still-running unit's WORK is moving, and whether a unit is over. Neither is
+    a ladder rung and neither touches `lifecycle_state` -- see the module
+    docstring's exception.
+
+    An in-flight marker wins over the dispatch summary for the same unit, the
+    same precedence the status board's `SOURCE_ORDER` already uses: a marker
+    means this unit is in flight NOW, and a summary row from an earlier
+    dispatch of the same id must not report over it.
+
+    Best-effort: an unreadable marker directory or summary leaves every row at
+    `unknown`, which is honest and keeps a poll loop waiting rather than
+    concluding the work finished.
+    """
+    from_markers = _marker_progress(paths, fanout_id)
+    from_summary = _summary_progress(paths, fanout_id)
+    for unit in units:
+        row_id = str(unit.get("unit_id", ""))
+        observed = from_markers.get(row_id) or from_summary.get(row_id)
+        if observed is None:
+            state, reason, stalled, source = _UNIT_STATE_UNKNOWN, "", None, "none"
+        else:
+            state, reason, stalled, source = observed
+        unit["unit_state"] = state
+        unit["unit_state_source"] = source
+        unit["terminal"] = is_terminal(state)
+        unit["progress"] = {
+            "reason": reason,
+            # None, never 0, when no assessment recorded one: a zero here
+            # would read as "output moved this instant".
+            "seconds_since_new_output": stalled,
+        }
+
+
+def _marker_progress(paths: OmhPaths, fanout_id: str) -> dict[str, tuple[str, str, int | None, str]]:
+    """Live progress readings, keyed by unit id, from this fanout's markers."""
+    rows: dict[str, tuple[str, str, int | None, str]] = {}
+    for marker in read_inflight_markers(paths, fanout_id=fanout_id, limit=_MARKER_READ_LIMIT):
+        if not isinstance(marker, Mapping) or marker.get("marker_status") != "present":
+            continue
+        unit_id = str(marker.get("unit_id", "") or "")
+        state = str(marker.get("unit_state", "") or "")
+        if not unit_id or not state:
+            # A marker written before the first stdout snapshot carries no
+            # state. It proves a spawn, not that the work is moving, so it
+            # contributes nothing here rather than a fabricated `running`.
+            continue
+        rows[unit_id] = (
+            state,
+            str(marker.get("state_reason", "") or ""),
+            _non_negative_int(marker.get("stalled_for_seconds")),
+            "inflight_marker",
+        )
+    return rows
+
+
+def _summary_progress(paths: OmhPaths, fanout_id: str) -> dict[str, tuple[str, str, int | None, str]]:
+    """Post-exit progress readings, keyed by unit id, from the dispatch summary."""
+    summary, error = read_json_object_result(fanout_dispatch_summary_path(paths, fanout_id))
+    if error is not None or not isinstance(summary, Mapping):
+        return {}
+    entries = summary.get("units")
+    if not isinstance(entries, list):
+        return {}
+    rows: dict[str, tuple[str, str, int | None, str]] = {}
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        unit_id = str(entry.get("unit_id", "") or "")
+        state = str(entry.get("unit_state", "") or "")
+        if not unit_id or not state:
+            # A record written before this contract existed. Absent, not
+            # `unknown`, so the caller's fallback chain stays in one place.
+            continue
+        progress = entry.get("progress")
+        rows[unit_id] = (
+            state,
+            str(entry.get("unit_state_reason", "") or ""),
+            _non_negative_int(progress.get("stalled_for_seconds")) if isinstance(progress, Mapping) else None,
+            "dispatch_summary",
+        )
+    return rows
+
+
+def _non_negative_int(value: object) -> int | None:
+    """A whole-second count, or None. A string marker field parses; junk does not."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    text = str(value or "").strip()
+    return int(text) if text.isdigit() else None
 
 
 def _validated_fanout_id(value: object) -> str:

--- a/src/coding/inflight.py
+++ b/src/coding/inflight.py
@@ -44,6 +44,15 @@ from ..system.paths import OmhPaths
 from .fanout_artifacts import _managed_fanout_dir
 from .fanout_contracts import FANOUT_ID_PATTERN
 
+# Held at v1 through the 2026-09 progress-evidence fields below on purpose.
+# Every reader of this file (`read_inflight_markers` here, `_merge_inflight` in
+# `plugin_bundle/omh/status_board_reader.py`) compares the version for EXACT
+# equality and counts a mismatch as `unreadable`, and the plugin copy on a live
+# machine is refreshed by `omh update` rather than in lockstep with core. A bump
+# for a purely additive field set would therefore blank the running-work board
+# on every machine whose plugin lags its core by one update, which is a worse
+# outcome than an older reader ignoring keys it does not know. Bump when a
+# field's MEANING changes; not when one is added.
 INFLIGHT_MARKER_SCHEMA_VERSION: Final[str] = "omh_inflight_marker/v1"
 
 INFLIGHT_CLAIM_BOUNDARY: Final[str] = (
@@ -81,6 +90,22 @@ INFLIGHT_MARKER_FIELDS: Final[tuple[str, ...]] = (
     # runner. It does not upgrade the liveness claim — presence is still not
     # liveness — but it is the only pid the fanout reaper will ever touch.
     "pid",
+    # What `unit_progress.assess_progress` made of the unit's stdout at the
+    # last mid-run snapshot. This is the only field group on the marker that
+    # says anything about the WORK; everything above it is dispatch
+    # bookkeeping. Unset means no snapshot has been assessed yet — never that
+    # the work is moving. `unit_state` carries a value of
+    # `unit_execution_state.UNIT_EXECUTION_STATES`; `stalled_for_seconds` is
+    # the derived elapsed since output last grew, recorded instead of the
+    # assessment's own readings because those are monotonic and mean nothing
+    # in a reading process; `phase_markers` is comma-joined because every
+    # marker value is a scalar string.
+    "unit_state",
+    "state_reason",
+    "last_new_output_at",
+    "stalled_for_seconds",
+    "repeat_count",
+    "phase_markers",
 )
 
 DEFAULT_INFLIGHT_READ_LIMIT: Final[int] = 20

--- a/src/coding/status_board.py
+++ b/src/coding/status_board.py
@@ -48,6 +48,7 @@ from .fanout_failure_diagnostics import FailureDiagnostic, is_object_list, is_st
 from .context_safety import sanitize_user_facing_progress_text
 from .executor_progress import project_active_executor_status
 from .inflight import read_inflight_markers
+from .unit_execution_state import is_stuck
 from .routing_observation import (
     authenticate_executor_observation,
     build_routing_observation,
@@ -146,11 +147,19 @@ def build_status_board(paths: OmhPaths, *, limit: int = DEFAULT_LIMIT, now: str 
 
     units = sorted(merged.values(), key=_board_sort_key)
     running_count = sum(1 for unit in units if unit["status"] == "running")
+    # Counted apart from `running_count` rather than subtracted out of it:
+    # `running_count` is the DISPATCH tally (how many units have a live-looking
+    # marker) and existing consumers gate on it, so its meaning stays put. What
+    # changes is that the header no longer reports that tally alone, because
+    # "2 running" over a board with a unit stuck for half an hour is the exact
+    # reading the 2026-09-11 incident acted on.
+    stuck_count = sum(1 for unit in units if is_stuck(str(unit.get("unit_state", "") or "")))
     return {
         "schema_version": CODING_STATUS_BOARD_SCHEMA_VERSION,
         "observed_at": observed_at,
         "unit_count": len(units),
         "running_count": running_count,
+        "stuck_count": stuck_count,
         "units": units[:effective_limit],
         "sources_used": [source for source in SOURCE_ORDER if source in sources_used],
         "claim_boundary": CODING_STATUS_BOARD_CLAIM_BOUNDARY,
@@ -276,10 +285,21 @@ def status_text_for(unit: Mapping[str, Any]) -> str:
     the same cell rather than in a column of its own, so a board with nothing
     refused is byte-identical to the one this repo already renders.
 
+    A unit whose `unit_state` is stuck replaces the cell outright. `running`
+    here only ever meant "a process was spawned and its marker is still
+    there", and rendering that word over a unit that has been repeating one
+    error for half an hour is the failure this whole surface exists to stop;
+    the stuck word, its reason, and how long output has been still take the
+    cell instead. A `running` or absent `unit_state` changes nothing, so a
+    board of healthy units renders exactly as it did before.
+
     Hand-mirrored by `plugin_bundle/omh/status_board_reader._status_text`, which
     cannot import this module; `tests/test_coding_status_board.py` gates the two
     against each other.
     """
+    stuck = stuck_state_text(unit)
+    if stuck:
+        return stuck
     # Every row on this board is a coding unit, so `Code` is the phase when the
     # value does not imply a more specific one (`worktree_failed` implies
     # `Setup`). The wire value stays in `unit["status"]` for anything parsing
@@ -287,6 +307,28 @@ def status_text_for(unit: Mapping[str, Any]) -> str:
     status = status_label(str(unit.get("status", "") or UNKNOWN), default_phase=PHASE_CODE)
     source = str(unit.get("unmapped_source_status", "") or "")
     return f"{status} (reported {source})" if source else status
+
+
+def stuck_state_text(unit: Mapping[str, Any]) -> str:
+    """`progress_stalled (no_new_output, 1920s since new output)`, or "".
+
+    Empty for every unit whose observed state is `running`, absent, or not a
+    stuck one -- `is_stuck` owns that judgement, so a state added to the
+    vocabulary starts rendering here without a second list to update.
+
+    Hand-mirrored by `plugin_bundle/omh/status_board_reader._stuck_state_text`.
+    """
+    state = str(unit.get("unit_state", "") or "")
+    if not is_stuck(state):
+        return ""
+    parts: list[str] = []
+    reason = str(unit.get("state_reason", "") or "")
+    if reason:
+        parts.append(reason)
+    elapsed = str(unit.get("stalled_for_seconds", "") or "")
+    if elapsed.isdigit() and int(elapsed) > 0:
+        parts.append(f"{elapsed}s since new output")
+    return f"{state} ({', '.join(parts)})" if parts else state
 
 
 def _merge_unit(
@@ -333,6 +375,12 @@ def _inflight_units(paths: OmhPaths, observed_at: str) -> list[dict[str, Any]]:
                 runtime_host=str(marker.get("owner_host", "") or ""),
                 model=str(marker.get("model", "") or ""),
                 reasoning_effort=str(marker.get("reasoning_effort", "") or ""),
+                # `status` stays the dispatch word: a marker exists, so a
+                # process was spawned. Whether the WORK is moving is a
+                # different question, carried beside it in `unit_state` and
+                # rendered by `status_text_for`. Keeping the two apart is the
+                # point -- `STATUS_VOCABULARY` is read as a closed enum by the
+                # graph roster, and "alive" must never render as "progressing".
                 status="running",
                 elapsed_seconds=elapsed,
                 # A running unit has reported no total yet. Anything we put here
@@ -343,6 +391,9 @@ def _inflight_units(paths: OmhPaths, observed_at: str) -> list[dict[str, Any]]:
                 # The worktree path is deliberately not shown: it is a local
                 # filesystem path, not observed progress.
                 summary="",
+                unit_state=str(marker.get("unit_state", "") or ""),
+                state_reason=str(marker.get("state_reason", "") or ""),
+                stalled_for_seconds=str(marker.get("stalled_for_seconds", "") or ""),
             )
         )
     return units
@@ -478,6 +529,9 @@ def _unit_row(
     session_ref: str,
     summary: str,
     unmapped_source_status: str = "",
+    unit_state: str = "",
+    state_reason: str = "",
+    stalled_for_seconds: str = "",
     routing_observation: Mapping[str, object] | None = None,
     failure_diagnostic: FailureDiagnostic | None = None,
 ) -> dict[str, Any]:
@@ -506,6 +560,15 @@ def _unit_row(
     # status was accepted verbatim -- never that nothing was checked.
     if unmapped_source_status:
         row["unmapped_source_status"] = unmapped_source_status
+    # Absent unless a stdout snapshot was actually assessed. An absent
+    # `unit_state` means nothing observed the work, which is exactly what a
+    # reader must not confuse with "the work is moving".
+    if unit_state:
+        row["unit_state"] = unit_state
+    if state_reason:
+        row["state_reason"] = state_reason
+    if stalled_for_seconds:
+        row["stalled_for_seconds"] = stalled_for_seconds
     if routing_observation is not None:
         row["routing_observation"] = dict(routing_observation)
         row["routing_status_rows"] = list(render_routing_status_rows(routing_observation))
@@ -641,10 +704,18 @@ def _bullet_line(unit: dict[str, Any]) -> str:
 def _header_line(payload: dict[str, Any], *, korean: bool) -> str:
     running = int(payload.get("running_count", 0) or 0)
     total = int(payload.get("unit_count", 0) or 0)
+    # Stuck units are SUBTRACTED from the headline count and named separately.
+    # They still carry `status: running` on the wire (a marker exists), but a
+    # header that folds them into "N running" is the one line a reader takes
+    # at a glance, and it must not say work is moving when it is not.
+    stuck = min(int(payload.get("stuck_count", 0) or 0), running)
+    moving = running - stuck
     observed_at = str(payload.get("observed_at", "") or UNKNOWN)
     if korean:
-        return f"코딩 작업 현황 (실행 중 {running} / 전체 {total}) — 관측 시각 {observed_at}"
-    return f"Coding status board ({running} running of {total} observed) — observed at {observed_at}"
+        stuck_text = f", 멈춤 {stuck}" if stuck else ""
+        return f"코딩 작업 현황 (실행 중 {moving}{stuck_text} / 전체 {total}) — 관측 시각 {observed_at}"
+    stuck_text = f", {stuck} stuck" if stuck else ""
+    return f"Coding status board ({moving} running{stuck_text} of {total} observed) — observed at {observed_at}"
 
 
 def _empty_line(*, korean: bool) -> str:

--- a/src/coding/unit_progress.py
+++ b/src/coding/unit_progress.py
@@ -283,8 +283,8 @@ def assess_progress(
     """
     text = stdout_so_far or ""
     prior = dict(previous) if isinstance(previous, Mapping) else None
-    previous_bytes = _int_at(prior, "output_bytes", 0) if prior else 0
-    last_new_output_at = _float_at(prior, "last_new_output_at", float(now)) if prior else float(now)
+    previous_bytes = _int_at(prior, "output_bytes", 0)
+    last_new_output_at = _float_at(prior, "last_new_output_at", float(now))
     grew = len(text) > previous_bytes
     if grew or prior is None:
         last_new_output_at = float(now)

--- a/src/coding/unit_progress.py
+++ b/src/coding/unit_progress.py
@@ -91,6 +91,15 @@ UNIT_STALL_AFTER_SECONDS: Final[float] = 15 * 60.0
 # cannot be a pair of adjacent identical log lines.
 UNIT_REPEAT_THRESHOLD: Final[int] = 3
 
+# How long output must have been still before a trailing question counts as a
+# unit waiting on an answer. Without it the rule fires on one poll step (five
+# seconds): a headless CLI that prints a sentence ending in "?" and then spends
+# ten seconds inside a tool call would read as blocked on a human. Sixty
+# seconds is well past any single tool call and well short of the stall
+# threshold, so a real prompt is still caught fourteen minutes before silence
+# alone would report it.
+UNIT_PROMPT_QUIET_SECONDS: Final[float] = 60.0
+
 # Lines of tail the repetition rule looks at. Long enough to hold several
 # turns of a retry loop, short enough that an hour of unrelated output ahead
 # of it cannot dilute the count.
@@ -195,6 +204,42 @@ _DATA_MISSING_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
     ("bad_object", "fatal: bad object"),
 )
 
+# Words that make a line a report of something going WRONG. The repeat rule
+# counts only lines matching one of these, because the incident's signal was
+# the same FAILURE repeating -- not repetition as such. Healthy runs repeat
+# lines constantly: verbose unittest prints `... ok` once per test, pytest
+# prints `PASSED`, a compiler prints one warning per file, and the digit
+# collapse above folds `test (3.11, 0)` and `test (3.12, 1)` into one line. Any
+# of those would otherwise pin a green run at `progress_stalled` for the rest
+# of its life, since this rule outranks `running`.
+#
+# Matched case-insensitively as substrings of the canonical line. One row per
+# thing that emits it; the table is deliberately small, because a word added
+# here silently converts a class of healthy output into a stall verdict.
+_FAILURE_SHAPED_WORDS: Final[tuple[tuple[str, str], ...]] = (
+    # git, compilers, and most CLIs prefix a diagnostic line with these.
+    ("error", "error"),
+    ("fatal", "fatal"),
+    # Test runners and build tools reporting a failed step.
+    ("failed", "failed"),
+    ("failure", "failure"),
+    # Permission and capability refusals, in the spellings tools use.
+    ("cannot", "cannot"),
+    ("could_not", "could not"),
+    ("unable", "unable"),
+    ("denied", "denied"),
+    ("refused", "refused"),
+    ("rejected", "rejected"),
+    # The loop itself: a worker announcing it is going round again is the
+    # single clearest sign that the same workaround is being retried.
+    ("retry", "retry"),
+    ("retrying", "retrying"),
+    # A step that ran out of time, and a merge/checkout that could not apply.
+    ("timed_out", "timed out"),
+    ("timeout", "timeout"),
+    ("conflict", "conflict"),
+)
+
 # A prompt the unit is sitting at. Matched against the LAST non-empty line
 # only, and only once output has stopped growing -- a model that merely
 # prints a sentence ending in `?` keeps producing bytes and stays `running`.
@@ -249,6 +294,7 @@ def assess_progress(
     result_record_present: bool = False,
     stall_after_seconds: float = UNIT_STALL_AFTER_SECONDS,
     repeat_threshold: int = UNIT_REPEAT_THRESHOLD,
+    prompt_quiet_seconds: float = UNIT_PROMPT_QUIET_SECONDS,
 ) -> dict[str, Any]:
     """Derive one unit's progress evidence from its stdout so far.
 
@@ -258,11 +304,16 @@ def assess_progress(
     1. A limit, permission, or missing-object shape in the tail. Each is a
        condition retrying under the same conditions cannot clear, so it must
        be reported the moment it is seen rather than waited out.
-    2. The same canonical line repeating `repeat_threshold` times in the
-       tail -- EVEN WHILE bytes grow. This is the 2026-09-11 incident:
-       36 minutes of new output that was the same workaround again.
-    3. A prompt at the end of output with no new bytes since the previous
-       assessment: `awaiting_input`.
+    2. The same FAILURE-SHAPED canonical line repeating `repeat_threshold`
+       times in the tail -- EVEN WHILE bytes grow. This is the 2026-09-11
+       incident: 36 minutes of new output that was the same workaround again.
+       Only lines matching `_FAILURE_SHAPED_WORDS` are counted; a healthy run
+       repeats `... ok` or one warning per file endlessly and must stay
+       `running`.
+    3. A prompt at the end of output with no new bytes for
+       `prompt_quiet_seconds`: `awaiting_input`. The quiet window is the whole
+       guard -- one poll step of silence after a question mark is just a tool
+       call in progress.
     4. No new bytes for `stall_after_seconds`: `progress_stalled`.
     5. Otherwise `running`.
 
@@ -306,11 +357,12 @@ def assess_progress(
         evidence["state"] = UNIT_STATE_PROGRESS_STALLED
         evidence["reason"] = f"{REASON_REPEATED_ERROR_PREFIX}{repeated_line[:_REASON_LINE_LIMIT]}"
         return evidence
-    if prior is not None and not grew and _ends_at_prompt(text):
+    quiet_for = float(now) - last_new_output_at
+    if prior is not None and quiet_for >= float(prompt_quiet_seconds) and _ends_at_prompt(text):
         evidence["state"] = UNIT_STATE_AWAITING_INPUT
         evidence["reason"] = REASON_PROMPT_AT_END
         return evidence
-    if float(now) - last_new_output_at >= float(stall_after_seconds):
+    if quiet_for >= float(stall_after_seconds):
         evidence["state"] = UNIT_STATE_PROGRESS_STALLED
         evidence["reason"] = REASON_NO_NEW_OUTPUT
     return evidence
@@ -404,11 +456,16 @@ def _ends_at_prompt(text: str) -> bool:
 
 
 def _most_repeated_line(text: str) -> tuple[str, int]:
-    """The tail's most frequent canonical non-empty line, and its count."""
+    """The tail's most frequent canonical FAILURE-SHAPED line, and its count.
+
+    Non-failure lines are not counted at all, rather than counted and then
+    filtered: a green run's `... ok` would otherwise be the most common line
+    and would mask a failure repeating underneath it.
+    """
     counts = Counter(
         canonical
         for canonical in (_canonical_line(line) for line in text.splitlines()[-_TAIL_LINES:])
-        if canonical
+        if canonical and _is_failure_shaped(canonical)
     )
     if not counts:
         return "", 0
@@ -416,6 +473,12 @@ def _most_repeated_line(text: str) -> tuple[str, int]:
     # order, so the same text always names the same line.
     line, count = counts.most_common(1)[0]
     return (line, count) if count > 1 else ("", 0)
+
+
+def _is_failure_shaped(canonical_line: str) -> bool:
+    """True when the line reports something going wrong. See the table."""
+    lowered = canonical_line.casefold()
+    return any(needle in lowered for _label, needle in _FAILURE_SHAPED_WORDS)
 
 
 def _canonical_line(line: str) -> str:

--- a/src/coding/unit_progress.py
+++ b/src/coding/unit_progress.py
@@ -164,16 +164,6 @@ _PHASE_MARKER_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
     (PHASE_MARKER_COMMIT_CREATED, r"^\[\S+ [0-9a-f]{7,40}\] "),
 )
 
-# Additional limit shapes this lane needs that
-# `fanout_dispatch._LIMIT_SHAPED_PATTERNS` does not carry on this branch. The
-# incident's exact refusal was "You've hit your session limit · resets
-# 6:10pm", which matches none of that tuple's anchors. PR #1486 adds the same
-# classification there; the union below is de-duplicated by label and text,
-# so the two landing together is a no-op rather than a double entry.
-_ADDITIONAL_LIMIT_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
-    ("session_limit", "session limit"),
-)
-
 # Permission and sandbox denials. Retrying under the same permissions cannot
 # clear any of these, which is why they are their own state rather than a
 # stall to be waited out.
@@ -381,26 +371,26 @@ _LIMIT_PATTERN_CACHE: list[tuple[str, str]] = []
 
 
 def _limit_shaped_patterns() -> tuple[tuple[str, str], ...]:
-    """`fanout_dispatch`'s limit shapes, plus this module's supplement.
+    """`fanout_dispatch`'s limit shapes, case-folded once and cached.
 
-    Imported lazily and cached: `fanout_dispatch` imports THIS module for the
-    on-output assessment, so a module-level import here would be a cycle.
-    An import failure degrades to the supplement alone rather than raising --
-    this runs on an observability path that must never fail a dispatch.
+    The single source of those shapes, including the `session_limit` rows PR
+    #1486 added for the 2026-09-11 refusal ("You've hit your session limit").
+    Imported lazily: `fanout_dispatch` imports THIS module for the on-output
+    assessment, so a module-level import here would be a cycle. An import
+    failure degrades to no limit patterns rather than raising -- this runs on
+    an observability path that must never fail a dispatch, and a missed limit
+    shape reads as `running` rather than taking the process down.
     """
     if _LIMIT_PATTERN_CACHE:
         return tuple(_LIMIT_PATTERN_CACHE)
-    rows: list[tuple[str, str]] = []
     try:
         from .fanout_dispatch import _LIMIT_SHAPED_PATTERNS
     except ImportError:
         _LIMIT_SHAPED_PATTERNS = ()
-    for label, needle in tuple(_LIMIT_SHAPED_PATTERNS) + _ADDITIONAL_LIMIT_PATTERNS:
-        row = (str(label), str(needle).casefold())
-        if row not in rows:
-            rows.append(row)
-    _LIMIT_PATTERN_CACHE.extend(rows)
-    return tuple(rows)
+    _LIMIT_PATTERN_CACHE.extend(
+        (str(label), str(needle).casefold()) for label, needle in _LIMIT_SHAPED_PATTERNS
+    )
+    return tuple(_LIMIT_PATTERN_CACHE)
 
 
 def _ends_at_prompt(text: str) -> bool:

--- a/src/coding/unit_progress.py
+++ b/src/coding/unit_progress.py
@@ -1,0 +1,469 @@
+"""Progress evidence for one dispatched unit (`omh_unit_progress/v1`).
+
+Pure derivation, no I/O and no clock of its own: `assess_progress` takes the
+stdout captured so far plus the previous evidence and returns what OMH has
+observed about the WORK. It exists because every surface this repo already
+has -- the in-flight marker, the progress binding, the status board, the run
+summary -- could only say that a process existed. On 2026-09-11 a unit was
+alive for 36 minutes retrying the same git workaround while its supervisor
+read "PID alive" as progress; the stdout snapshots that would have shown the
+repetition were already being taken and were never turned into a verdict.
+
+Boundaries, in order of importance:
+
+- Non-terminal only. `assess_progress` never returns `failed` or `verified`.
+  Those are the intake path's answer after exit, where the result record and
+  the verification ladder are what decide; a mid-run reading of stdout must
+  not pre-empt them. Every state this module can return is in
+  `UNIT_PROGRESS_MID_RUN_STATES`.
+- Growing output is not progress. The incident's 36 minutes produced new
+  bytes the whole time -- the same workaround, again. The repeated-line rule
+  therefore outranks the byte-growth rule, and the byte-growth rule is the
+  only thing that can produce `running`.
+- Shape, never truth. A matched pattern says the tail LOOKS like a limit
+  refusal, a permission denial, or a missing object. It is not provider
+  state, not a filesystem verdict, and not repository truth. Only the state
+  and a bounded reason string are produced; the matched text itself is
+  carried no further than the reason, which is truncated.
+- Deterministic. `now` is a parameter (a monotonic-clock reading, so a
+  system clock step cannot fabricate a stall), the pattern tables are module
+  constants, and the same inputs always give the same evidence.
+- Reporting only. Evidence here is observed activity. It is never result,
+  verification, review, CI, merge-readiness, or merge evidence.
+
+`ProgressEvidence` is a plain dict so it can ride in an in-flight marker and
+a dispatch record without a serializer. Its keys:
+
+- `schema_version`     -- `UNIT_PROGRESS_SCHEMA_VERSION`.
+- `observed_at`        -- the `now` of this assessment (monotonic seconds).
+- `output_bytes`       -- length of the stdout seen so far.
+- `output_lines`       -- line count of the stdout seen so far.
+- `last_new_output_at` -- the `now` of the most recent assessment that saw
+                          the byte count grow. Equal to `observed_at` on the
+                          first assessment, so a fresh unit is never stalled.
+- `repeated_line`      -- the canonical form of the tail's most repeated
+                          non-empty line, or "" when nothing repeats.
+- `repeat_count`       -- how many times that canonical line occurs in the
+                          tail (0 when `repeated_line` is "").
+- `phase_markers`      -- recognised markers seen in the whole output so far,
+                          in `PHASE_MARKERS` order; cumulative, never shrinks.
+- `result_record_present` -- the caller's own answer to "has the unit's
+                          result record appeared yet?". Passed in, not
+                          derived: this module does not touch the filesystem.
+- `state`              -- one of `UNIT_PROGRESS_MID_RUN_STATES`.
+- `reason`             -- short machine-readable why, or "" for `running`.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any, Final, Mapping
+
+from .unit_execution_state import (
+    UNIT_STATE_ACCOUNT_LIMIT,
+    UNIT_STATE_AWAITING_INPUT,
+    UNIT_STATE_DATA_MISSING,
+    UNIT_STATE_PERMISSION_BLOCKED,
+    UNIT_STATE_PROGRESS_STALLED,
+    UNIT_STATE_RUNNING,
+)
+
+UNIT_PROGRESS_SCHEMA_VERSION: Final[str] = "omh_unit_progress/v1"
+
+UNIT_PROGRESS_CLAIM_BOUNDARY: Final[str] = (
+    "Progress evidence records what one unit's stdout showed at one moment: whether it grew, "
+    "whether the same line is repeating, and whether its tail matches a limit, permission, or "
+    "missing-object shape. A matched shape is not provider, filesystem, or repository truth, and "
+    "no state here is terminal -- `failed` and `verified` come from the intake path after exit."
+)
+
+# Silence this long is a stall. Same number as
+# `plugin_bundle.omh.tool_bursts.TOOL_CALL_OPEN_TTL_SECONDS` (15 minutes),
+# which is that module's answer to the same question for a single tool call:
+# past this, an open thing is not still running, it is a lost tick. Defined
+# here rather than imported because that sibling lives in the plugin bundle
+# and pulls the plugin's file-locking chain in with it; core stays pure.
+UNIT_STALL_AFTER_SECONDS: Final[float] = 15 * 60.0
+
+# How many times one canonical line must occur in the tail before repetition
+# is a verdict rather than a coincidence. Three is the smallest count that
+# cannot be a pair of adjacent identical log lines.
+UNIT_REPEAT_THRESHOLD: Final[int] = 3
+
+# Lines of tail the repetition rule looks at. Long enough to hold several
+# turns of a retry loop, short enough that an hour of unrelated output ahead
+# of it cannot dilute the count.
+_TAIL_LINES: Final[int] = 80
+
+# Characters of tail the shape patterns below are matched against. A refusal,
+# a denial, or a missing object is reported at the END of what the process
+# managed to say; scanning the whole transcript would keep re-reporting a
+# denial the unit already recovered from.
+_TAIL_CHARS: Final[int] = 4000
+
+# Bound on the repeated line carried into `reason`.
+_REASON_LINE_LIMIT: Final[int] = 120
+
+# Reasons this module produces, so a reader can branch on them without
+# parsing prose. `REASON_REPEATED_ERROR` is a PREFIX: the offending line
+# follows the colon.
+REASON_NO_NEW_OUTPUT: Final[str] = "no_new_output"
+REASON_REPEATED_ERROR_PREFIX: Final[str] = "repeated_error:"
+REASON_PROMPT_AT_END: Final[str] = "prompt_at_end"
+REASON_ACCOUNT_LIMIT_PREFIX: Final[str] = "account_limit:"
+REASON_PERMISSION_PREFIX: Final[str] = "permission_blocked:"
+REASON_DATA_MISSING_PREFIX: Final[str] = "data_missing:"
+
+# Every state `assess_progress` can return. `failed` and `verified` are
+# absent on purpose -- see the module docstring's first boundary.
+UNIT_PROGRESS_MID_RUN_STATES: Final[tuple[str, ...]] = (
+    UNIT_STATE_RUNNING,
+    UNIT_STATE_AWAITING_INPUT,
+    UNIT_STATE_PERMISSION_BLOCKED,
+    UNIT_STATE_ACCOUNT_LIMIT,
+    UNIT_STATE_DATA_MISSING,
+    UNIT_STATE_PROGRESS_STALLED,
+)
+
+# Recognised phase markers, in report order. One row per thing that actually
+# emits the pattern; matched case-insensitively over the whole output so far,
+# so the list is cumulative for the unit's lifetime.
+PHASE_MARKER_TEST_STARTED: Final[str] = "test_started"
+PHASE_MARKER_TEST_FINISHED: Final[str] = "test_finished"
+PHASE_MARKER_RESULT_WRITTEN: Final[str] = "result_written"
+PHASE_MARKER_COMMIT_CREATED: Final[str] = "commit_created"
+
+PHASE_MARKERS: Final[tuple[str, ...]] = (
+    PHASE_MARKER_TEST_STARTED,
+    PHASE_MARKER_TEST_FINISHED,
+    PHASE_MARKER_RESULT_WRITTEN,
+    PHASE_MARKER_COMMIT_CREATED,
+)
+
+# Every row is `(marker, pattern)`, matched case-insensitively and in
+# multiline mode over the whole output so far.
+_PHASE_MARKER_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
+    # pytest's own run banner, printed once as its first line.
+    (PHASE_MARKER_TEST_STARTED, r"=+ test session starts"),
+    # unittest's verbose start line for a test method, which is what
+    # `python -m unittest -v` (this repo's own command) emits per test.
+    (PHASE_MARKER_TEST_STARTED, r"^test\w* \(.+\) \.\.\. "),
+    # unittest's footer: `Ran 12 tests in 0.412s`.
+    (PHASE_MARKER_TEST_FINISHED, r"\bran \d+ tests? in "),
+    # pytest's footer: `== 12 passed, 1 failed in 3.20s ==`.
+    (PHASE_MARKER_TEST_FINISHED, r"\b\d+ (?:passed|failed|errors?) "),
+    # The unit-return contract's own schema version
+    # (`fanout_unit_results.FANOUT_UNIT_RESULT_SCHEMA_VERSION`). A worker
+    # that wrote its sidecar has this string in the JSON it wrote, and the
+    # executor profiles this lane spawns echo the file they wrote.
+    (PHASE_MARKER_RESULT_WRITTEN, r"fanout_unit_result/v\d"),
+    # `git commit` prints its own diffstat footer on success.
+    (PHASE_MARKER_COMMIT_CREATED, r"\b\d+ files? changed"),
+    # `git commit` also prints `[branch 1a2b3c4] subject` as its first line.
+    (PHASE_MARKER_COMMIT_CREATED, r"^\[\S+ [0-9a-f]{7,40}\] "),
+)
+
+# Additional limit shapes this lane needs that
+# `fanout_dispatch._LIMIT_SHAPED_PATTERNS` does not carry on this branch. The
+# incident's exact refusal was "You've hit your session limit · resets
+# 6:10pm", which matches none of that tuple's anchors. PR #1486 adds the same
+# classification there; the union below is de-duplicated by label and text,
+# so the two landing together is a no-op rather than a double entry.
+_ADDITIONAL_LIMIT_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
+    ("session_limit", "session limit"),
+)
+
+# Permission and sandbox denials. Retrying under the same permissions cannot
+# clear any of these, which is why they are their own state rather than a
+# stall to be waited out.
+_PERMISSION_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
+    # The POSIX shell/tool message, and git's own wording for it.
+    ("permission_denied", "permission denied"),
+    # `errno.EACCES` surfaced by name, as Python and Node both do.
+    ("eacces", "eacces"),
+    # macOS/BSD wording for EPERM on a protected path.
+    ("operation_not_permitted", "operation not permitted"),
+    # A read-only bind mount or a sandbox's read-only isolation dir.
+    ("read_only_filesystem", "read-only file system"),
+)
+
+# Objects the work needs are absent in its isolation. The 2026-09-11 recovery
+# run hit these against a `blob:none` partial clone with fetch forbidden --
+# the case retrying can never clear, because the bytes are not there.
+_DATA_MISSING_PATTERNS: Final[tuple[tuple[str, str], ...]] = (
+    # git's message when a partial clone's promisor fetch is refused.
+    ("missing_blob", "missing blob"),
+    # git's read failure for an object that is not in the object store.
+    ("unreadable_object", "could not read object"),
+    # The promisor remote itself failing, named explicitly by git.
+    ("promisor_remote", "promisor"),
+    # Fetching a ref the remote does not advertise (a partial/filtered clone
+    # that was described as complete).
+    ("ref_not_advertised", "not our ref"),
+    # git's verdict when an object id resolves to nothing at all.
+    ("bad_object", "fatal: bad object"),
+)
+
+# A prompt the unit is sitting at. Matched against the LAST non-empty line
+# only, and only once output has stopped growing -- a model that merely
+# prints a sentence ending in `?` keeps producing bytes and stays `running`.
+_PROMPT_TAIL_PATTERNS: Final[tuple[str, ...]] = (
+    # Explicit yes/no prompts, in the three spellings tools actually use.
+    r"\((?:y/n|yes/no|y/n/a)\)\s*[:?]?\s*$",
+    r"\[(?:y/n|yes/no|y/n/a)\]\s*[:?]?\s*$",
+    # `Press ENTER to continue` and its variants.
+    r"press (?:enter|return|any key)\b",
+    # Any line that ends in a question mark: the "no new output since" gate
+    # above is what makes this safe.
+    r"\?\s*$",
+)
+
+_DIGIT_RUN = re.compile(r"\d+")
+# Seven is git's short-sha floor, which is the smallest hex run worth
+# collapsing; forty is a full sha1. Matched before the digit rule so a sha
+# becomes one token instead of a digit/letter mosaic.
+_HEX_RUN = re.compile(r"\b[0-9a-f]{7,40}\b", re.IGNORECASE)
+_PROMPT_TAIL_RES = tuple(re.compile(pattern, re.I) for pattern in _PROMPT_TAIL_PATTERNS)
+_PHASE_MARKER_RES: Final[tuple[tuple[str, re.Pattern[str]], ...]] = tuple(
+    (marker, re.compile(pattern, re.I | re.M)) for marker, pattern in _PHASE_MARKER_PATTERNS
+)
+
+
+def empty_progress_evidence(*, now: float) -> dict[str, Any]:
+    """Evidence for a unit that has been dispatched and has said nothing yet.
+
+    `running`, not stalled: `last_new_output_at` is `now`, so the stall clock
+    starts when the unit starts rather than at the epoch.
+    """
+    return {
+        "schema_version": UNIT_PROGRESS_SCHEMA_VERSION,
+        "observed_at": float(now),
+        "output_bytes": 0,
+        "output_lines": 0,
+        "last_new_output_at": float(now),
+        "repeated_line": "",
+        "repeat_count": 0,
+        "phase_markers": [],
+        "result_record_present": False,
+        "state": UNIT_STATE_RUNNING,
+        "reason": "",
+    }
+
+
+def assess_progress(
+    previous: Mapping[str, Any] | None,
+    stdout_so_far: str,
+    *,
+    now: float,
+    result_record_present: bool = False,
+    stall_after_seconds: float = UNIT_STALL_AFTER_SECONDS,
+    repeat_threshold: int = UNIT_REPEAT_THRESHOLD,
+) -> dict[str, Any]:
+    """Derive one unit's progress evidence from its stdout so far.
+
+    Rule order, highest first -- the order is the whole point, so it is
+    stated here rather than left to be read off the branches:
+
+    1. A limit, permission, or missing-object shape in the tail. Each is a
+       condition retrying under the same conditions cannot clear, so it must
+       be reported the moment it is seen rather than waited out.
+    2. The same canonical line repeating `repeat_threshold` times in the
+       tail -- EVEN WHILE bytes grow. This is the 2026-09-11 incident:
+       36 minutes of new output that was the same workaround again.
+    3. A prompt at the end of output with no new bytes since the previous
+       assessment: `awaiting_input`.
+    4. No new bytes for `stall_after_seconds`: `progress_stalled`.
+    5. Otherwise `running`.
+
+    `previous` may be None (first assessment) or any mapping shaped like the
+    evidence this function returns; missing keys degrade to the empty-unit
+    defaults rather than raising, because this runs on an observability path
+    that must never fail a dispatch.
+    """
+    text = stdout_so_far or ""
+    prior = dict(previous) if isinstance(previous, Mapping) else None
+    previous_bytes = _int_at(prior, "output_bytes", 0) if prior else 0
+    last_new_output_at = _float_at(prior, "last_new_output_at", float(now)) if prior else float(now)
+    grew = len(text) > previous_bytes
+    if grew or prior is None:
+        last_new_output_at = float(now)
+
+    tail = text[-_TAIL_CHARS:]
+    repeated_line, repeat_count = _most_repeated_line(text)
+    evidence: dict[str, Any] = {
+        "schema_version": UNIT_PROGRESS_SCHEMA_VERSION,
+        "observed_at": float(now),
+        "output_bytes": len(text),
+        "output_lines": text.count("\n") + (1 if text and not text.endswith("\n") else 0),
+        "last_new_output_at": last_new_output_at,
+        "repeated_line": repeated_line,
+        "repeat_count": repeat_count,
+        "phase_markers": _phase_markers(text),
+        "result_record_present": bool(result_record_present),
+        "state": UNIT_STATE_RUNNING,
+        "reason": "",
+    }
+
+    shaped = _shaped_state(tail)
+    if shaped is not None:
+        evidence["state"], evidence["reason"] = shaped
+        return evidence
+    # Floor of 2: `_most_repeated_line` already refuses to name a line that
+    # occurs once, so a caller passing 1 or 0 would otherwise make every line
+    # of output its own verdict.
+    if repeat_count >= max(2, int(repeat_threshold)):
+        evidence["state"] = UNIT_STATE_PROGRESS_STALLED
+        evidence["reason"] = f"{REASON_REPEATED_ERROR_PREFIX}{repeated_line[:_REASON_LINE_LIMIT]}"
+        return evidence
+    if prior is not None and not grew and _ends_at_prompt(text):
+        evidence["state"] = UNIT_STATE_AWAITING_INPUT
+        evidence["reason"] = REASON_PROMPT_AT_END
+        return evidence
+    if float(now) - last_new_output_at >= float(stall_after_seconds):
+        evidence["state"] = UNIT_STATE_PROGRESS_STALLED
+        evidence["reason"] = REASON_NO_NEW_OUTPUT
+    return evidence
+
+
+def stalled_for_seconds(evidence: Mapping[str, Any] | None) -> int:
+    """Whole seconds since this unit's output last grew. 0 when unknown.
+
+    The evidence's own clock readings are monotonic and meaningless in
+    another process, so every cross-process surface carries this derived
+    elapsed instead of the raw readings.
+    """
+    if not isinstance(evidence, Mapping):
+        return 0
+    observed = _float_at(evidence, "observed_at", 0.0)
+    last_new = _float_at(evidence, "last_new_output_at", observed)
+    return max(0, int(observed - last_new))
+
+
+def progress_state_summary(evidence: Mapping[str, Any] | None) -> str:
+    """One line a person can read: the state word, plus why and for how long.
+
+    A `running` unit renders the bare word. Every stuck state renders its own
+    word with its reason, and a stall also renders how long output has been
+    still -- the whole point being that a stuck unit must never render the
+    same as a live one.
+    """
+    if not isinstance(evidence, Mapping):
+        return ""
+    state = str(evidence.get("state", "") or "")
+    if not state:
+        return ""
+    reason = str(evidence.get("reason", "") or "")
+    if not reason:
+        return state
+    elapsed = stalled_for_seconds(evidence)
+    if elapsed > 0:
+        return f"{state} ({reason}; no new output for {elapsed}s)"
+    return f"{state} ({reason})"
+
+
+def _shaped_state(tail: str) -> tuple[str, str] | None:
+    """First matching retry-proof shape in the tail, or None."""
+    lowered = tail.casefold()
+    for label, needle in _limit_shaped_patterns():
+        if needle in lowered:
+            return UNIT_STATE_ACCOUNT_LIMIT, f"{REASON_ACCOUNT_LIMIT_PREFIX}{label}"
+    for label, needle in _PERMISSION_PATTERNS:
+        if needle in lowered:
+            return UNIT_STATE_PERMISSION_BLOCKED, f"{REASON_PERMISSION_PREFIX}{label}"
+    for label, needle in _DATA_MISSING_PATTERNS:
+        if needle in lowered:
+            return UNIT_STATE_DATA_MISSING, f"{REASON_DATA_MISSING_PREFIX}{label}"
+    return None
+
+
+_LIMIT_PATTERN_CACHE: list[tuple[str, str]] = []
+
+
+def _limit_shaped_patterns() -> tuple[tuple[str, str], ...]:
+    """`fanout_dispatch`'s limit shapes, plus this module's supplement.
+
+    Imported lazily and cached: `fanout_dispatch` imports THIS module for the
+    on-output assessment, so a module-level import here would be a cycle.
+    An import failure degrades to the supplement alone rather than raising --
+    this runs on an observability path that must never fail a dispatch.
+    """
+    if _LIMIT_PATTERN_CACHE:
+        return tuple(_LIMIT_PATTERN_CACHE)
+    rows: list[tuple[str, str]] = []
+    try:
+        from .fanout_dispatch import _LIMIT_SHAPED_PATTERNS
+    except ImportError:
+        _LIMIT_SHAPED_PATTERNS = ()
+    for label, needle in tuple(_LIMIT_SHAPED_PATTERNS) + _ADDITIONAL_LIMIT_PATTERNS:
+        row = (str(label), str(needle).casefold())
+        if row not in rows:
+            rows.append(row)
+    _LIMIT_PATTERN_CACHE.extend(rows)
+    return tuple(rows)
+
+
+def _ends_at_prompt(text: str) -> bool:
+    """True when the LAST non-empty line looks like a question or a prompt."""
+    for line in reversed(text.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        return any(pattern.search(stripped) for pattern in _PROMPT_TAIL_RES)
+    return False
+
+
+def _most_repeated_line(text: str) -> tuple[str, int]:
+    """The tail's most frequent canonical non-empty line, and its count."""
+    counts = Counter(
+        canonical
+        for canonical in (_canonical_line(line) for line in text.splitlines()[-_TAIL_LINES:])
+        if canonical
+    )
+    if not counts:
+        return "", 0
+    # `most_common` breaks ties by insertion order, which is the tail's own
+    # order, so the same text always names the same line.
+    line, count = counts.most_common(1)[0]
+    return (line, count) if count > 1 else ("", 0)
+
+
+def _canonical_line(line: str) -> str:
+    """One line with its varying parts collapsed, so a retry counter cannot
+    disguise the same failure as fresh output.
+
+    Hex runs first, then digit runs: collapsing digits first would shred a
+    short sha into a `<n>`/letter mosaic that no longer matches its siblings.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return ""
+    return _DIGIT_RUN.sub("<n>", _HEX_RUN.sub("<hash>", stripped))
+
+
+def _phase_markers(text: str) -> list[str]:
+    return [
+        marker
+        for marker in PHASE_MARKERS
+        if any(
+            compiled.search(text)
+            for row_marker, compiled in _PHASE_MARKER_RES
+            if row_marker == marker
+        )
+    ]
+
+
+def _int_at(mapping: Mapping[str, Any] | None, key: str, default: int) -> int:
+    if not isinstance(mapping, Mapping):
+        return default
+    value = mapping.get(key, default)
+    return value if isinstance(value, int) and not isinstance(value, bool) else default
+
+
+def _float_at(mapping: Mapping[str, Any] | None, key: str, default: float) -> float:
+    if not isinstance(mapping, Mapping):
+        return default
+    value = mapping.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return default
+    return float(value)

--- a/src/omh/tui_widgets/omh-status.mjs
+++ b/src/omh/tui_widgets/omh-status.mjs
@@ -639,29 +639,48 @@ export default function register(sdk) {
       ),
       ...nodes.map((node, index) => {
         const blockedBy = Array.isArray(node.blocked_by) ? node.blocked_by : []
-        const state = safeText(node.state) || 'unknown'
-        const marker = node.in_frontier
-          ? '[R]'
-          : failedStates.has(state)
-            ? '[!]'
-            : successStates.has(state)
-              ? '[+]'
-              : '[.]'
+        // `node.state` is the DISPATCH word: `running` means a marker exists,
+        // not that the work is moving. When the reader has assessed the
+        // unit's own output and found it stuck, that word REPLACES `running`
+        // on this line and carries its reason and stall age -- a supervisor
+        // reading `running` over a unit that has repeated one error for half
+        // an hour is the whole failure this surface exists to stop.
+        const dispatchState = safeText(node.state) || 'unknown'
+        const stuckState = safeText(node.unit_state)
+        const state = stuckState || dispatchState
+        const stallSeconds = Number(node.stalled_for_seconds) || 0
+        const stuckReason = stuckState
+          ? [safeText(node.state_reason), stallSeconds > 0 ? `${elapsedText(stallSeconds)} since new output` : '']
+              .filter(Boolean)
+              .join(', ')
+          : ''
+        const stuckSuffix = stuckReason ? ` (${stuckReason})` : ''
+        const marker = stuckState
+          ? '[~]'
+          : node.in_frontier
+            ? '[R]'
+            : failedStates.has(state)
+              ? '[!]'
+              : successStates.has(state)
+                ? '[+]'
+                : '[.]'
         const suffix = blockedBy.length ? ` · blocked_by ${blockedBy.map(safeText).join(' + ')}` : ''
         return h(
           Text,
           {
-            color: node.in_frontier
-              ? t.color.ok
-              : marker === '[!]'
-                ? t.color.error
-                : marker === '[+]'
-                  ? t.color.muted
-                  : t.color.text,
+            color: stuckState
+              ? t.color.warn
+              : node.in_frontier
+                ? t.color.ok
+                : marker === '[!]'
+                  ? t.color.error
+                  : marker === '[+]'
+                    ? t.color.muted
+                    : t.color.text,
             key: `${safeText(node.node_id)}-${index}`,
             wrap: 'truncate-end',
           },
-          graphLine(`  ${marker} ${safeText(node.node_id)} · ${state}${suffix}`),
+          graphLine(`  ${marker} ${safeText(node.node_id)} · ${state}${stuckSuffix}${suffix}`),
         )
       }),
     )

--- a/src/plugin_bundle/omh/status_board_reader.py
+++ b/src/plugin_bundle/omh/status_board_reader.py
@@ -144,10 +144,15 @@ def read_running_work_board(omh_home: str | Path | None, *, limit: int = DEFAULT
 
     units = sorted(merged.values(), key=_sort_key)
     running_count = sum(1 for unit in units if unit["status"] == "running")
+    # Counted apart from `running_count`, which is the DISPATCH tally this
+    # block's own >= 2 gate reads; its meaning stays put. The rendered line is
+    # what must not fold a stuck unit into "N running".
+    stuck_count = sum(1 for unit in units if str(unit.get("unit_state", "") or "") in _STUCK_STATES)
     shown = units[:effective_limit]
     return {
         "schema_version": RUNNING_WORK_BOARD_SCHEMA_VERSION,
         "running_count": running_count,
+        "stuck_count": stuck_count,
         "unit_count": len(units),
         "units": shown,
         "truncated": len(units) > len(shown),
@@ -172,8 +177,13 @@ def render_running_work_block_text(board: dict[str, Any]) -> str:
     """
     running_count = int(board.get("running_count", 0) or 0)
     unit_count = int(board.get("unit_count", 0) or 0)
+    # Same split as `omh.coding.status_board._header_line`: a stuck unit is
+    # subtracted from the headline and named, never folded into "N running".
+    stuck_count = min(int(board.get("stuck_count", 0) or 0), running_count)
+    moving = running_count - stuck_count
+    stuck_text = f", {stuck_count} stuck" if stuck_count else ""
     units = [unit for unit in board.get("units", []) if isinstance(unit, dict)]
-    lines = [f"[OMH] Running coding work: {running_count} running of {unit_count} observed."]
+    lines = [f"[OMH] Running coding work: {moving} running{stuck_text} of {unit_count} observed."]
     for unit in units:
         lines.append(
             f"- {unit.get('fanout_id', 'unknown')}/{unit.get('unit_id', 'unknown')}: "
@@ -336,7 +346,12 @@ def _merge_inflight(
             runtime=str(payload.get("owner", "") or ""),
             model=str(payload.get("model", "") or ""),
             reasoning_effort=str(payload.get("reasoning_effort", "") or ""),
+            # The dispatch word, not a claim about the work; `unit_state`
+            # beside it is what says whether the work is moving.
             status="running",
+            unit_state=str(payload.get("unit_state", "") or ""),
+            state_reason=str(payload.get("state_reason", "") or ""),
+            stalled_for_seconds=str(payload.get("stalled_for_seconds", "") or ""),
         )
     return unreadable
 
@@ -391,6 +406,9 @@ def _unit_row(
     reasoning_effort: str,
     status: str,
     unmapped_source_status: str = "",
+    unit_state: str = "",
+    state_reason: str = "",
+    stalled_for_seconds: str = "",
 ) -> dict[str, Any]:
     row = {
         "fanout_id": fanout_id,
@@ -404,6 +422,15 @@ def _unit_row(
     # status was accepted verbatim -- never that nothing was checked.
     if unmapped_source_status:
         row["unmapped_source_status"] = unmapped_source_status
+    # Absent unless a stdout snapshot was actually assessed. An absent
+    # `unit_state` means nothing observed the work, which is exactly what a
+    # reader must not confuse with "the work is moving".
+    if unit_state:
+        row["unit_state"] = unit_state
+    if state_reason:
+        row["state_reason"] = state_reason
+    if stalled_for_seconds:
+        row["stalled_for_seconds"] = stalled_for_seconds
     return row
 
 
@@ -472,11 +499,48 @@ def _status_label(value: str) -> str:
 def _status_text(unit: dict[str, Any]) -> str:
     """The status a person reads, with any refused source word attached.
 
+    A stuck `unit_state` replaces the cell outright, for the reason spelled
+    out on the surface this mirrors: `running` only ever meant "a process was
+    spawned", and it must never render over a unit whose work stopped moving.
+
     Mirrors `omh.coding.status_board.status_text_for`.
     """
+    stuck = _stuck_state_text(unit)
+    if stuck:
+        return stuck
     status = _status_label(str(unit.get("status", "") or "unknown"))
     source = str(unit.get("unmapped_source_status", "") or "")
     return f"{status} (reported {source})" if source else status
+
+
+# Hand-mirror of `omh.coding.unit_execution_state.UNIT_STUCK_STATES`, which
+# this bundle cannot import. Every state where the process may well be alive
+# and the work is still not moving; parity gated in
+# `tests/test_coding_status_board.py`.
+_STUCK_STATES: Final[frozenset[str]] = frozenset(
+    {
+        "awaiting_input",
+        "permission_blocked",
+        "account_limit",
+        "data_missing",
+        "progress_stalled",
+    }
+)
+
+
+def _stuck_state_text(unit: dict[str, Any]) -> str:
+    """Mirrors `omh.coding.status_board.stuck_state_text`."""
+    state = str(unit.get("unit_state", "") or "")
+    if state not in _STUCK_STATES:
+        return ""
+    parts: list[str] = []
+    reason = str(unit.get("state_reason", "") or "")
+    if reason:
+        parts.append(reason)
+    elapsed = str(unit.get("stalled_for_seconds", "") or "")
+    if elapsed.isdigit() and int(elapsed) > 0:
+        parts.append(f"{elapsed}s since new output")
+    return f"{state} ({', '.join(parts)})" if parts else state
 
 
 def _sort_key(unit: dict[str, Any]) -> tuple[int, str, str]:

--- a/src/plugin_bundle/omh/subagent_graph.py
+++ b/src/plugin_bundle/omh/subagent_graph.py
@@ -135,14 +135,22 @@ def project_subagent_graph(
             frontier.append(unit_id)
     nodes: list[dict[str, object]] = []
     for unit_id in visible_ids:
-        nodes.append(
-            {
-                "node_id": unit_id,
-                "state": effective_states[unit_id],
-                "blocked_by": blocked_by_by_id[unit_id],
-                "in_frontier": unit_id in frontier,
-            }
-        )
+        node: dict[str, object] = {
+            "node_id": unit_id,
+            "state": effective_states[unit_id],
+            "blocked_by": blocked_by_by_id[unit_id],
+            "in_frontier": unit_id in frontier,
+        }
+        # `state` above is the DISPATCH word the topology reasons about --
+        # a `running` node is one whose marker exists. Whether its work is
+        # moving is a separate observation the roster row carries when a
+        # stdout snapshot has been assessed (`omh.coding.unit_progress`), and
+        # it rides alongside rather than replacing `state`: the frontier,
+        # blocked-by, and success/failure arithmetic above is defined on the
+        # dispatch vocabulary, and widening that would change the topology.
+        # The renderer is what must never show a stuck unit as `running`.
+        node.update(_roster_progress_fields(roster_by_id.get(unit_id)))
+        nodes.append(node)
 
     edges = [
         [dependency, unit["unit_id"]]
@@ -233,6 +241,40 @@ def _depends_on(
         seen.add(dependency)
         pending.extend(unit_by_id[dependency]["depends_on"])
     return False
+
+
+# Hand-mirror of `omh.coding.unit_execution_state.UNIT_STUCK_STATES`, which
+# this bundle cannot import. Parity gated in `tests/test_subagent_graph_roster.py`.
+_STUCK_UNIT_STATES: Final[frozenset[str]] = frozenset(
+    {
+        "awaiting_input",
+        "permission_blocked",
+        "account_limit",
+        "data_missing",
+        "progress_stalled",
+    }
+)
+
+
+def _roster_progress_fields(unit: Mapping[str, object] | None) -> dict[str, object]:
+    """A stuck unit's observed state, reason, and stall age -- or nothing.
+
+    Absent keys mean no stdout snapshot has been assessed for this unit, which
+    a reader must not confuse with "the work is moving".
+    """
+    if not isinstance(unit, Mapping):
+        return {}
+    state = str(unit.get("unit_state", "") or "")
+    if state not in _STUCK_UNIT_STATES:
+        return {}
+    fields: dict[str, object] = {"unit_state": state}
+    reason = str(unit.get("state_reason", "") or "")
+    if reason:
+        fields["state_reason"] = reason
+    elapsed = str(unit.get("stalled_for_seconds", "") or "")
+    if elapsed.isdigit() and int(elapsed) > 0:
+        fields["stalled_for_seconds"] = int(elapsed)
+    return fields
 
 
 def _paired_roster(

--- a/tests/test_coding_status_board.py
+++ b/tests/test_coding_status_board.py
@@ -644,6 +644,99 @@ class UnmappedStatusPluginParityTests(unittest.TestCase):
 
         self.assertEqual(STATUS_VOCABULARY, plugin_vocabulary)
 
+    def test_neither_headline_folds_a_stuck_unit_into_the_running_count(self) -> None:
+        from omh.coding.status_board import render_status_board_text
+        from omh.plugin_bundle.omh.status_board_reader import (
+            read_running_work_board,
+            render_running_work_block_text,
+        )
+
+        # Two markers, two live-looking processes, one of them stuck. The
+        # headline is the line a supervisor reads at a glance, and "2 running"
+        # is the exact reading the 2026-09-11 incident acted on.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            fanout_id = "fanout-0123456789ab"
+            write_inflight_marker(paths, fanout_id, "core", {
+                "owner": "claude-code", "run_ref": "run-1", "worktree": str(root),
+                "started_at": "2026-09-11T10:00:00Z",
+                "unit_state": "progress_stalled", "state_reason": "no_new_output",
+                "stalled_for_seconds": "1920",
+            })
+            write_inflight_marker(paths, fanout_id, "docs", {
+                "owner": "codex", "run_ref": "run-2", "worktree": str(root),
+                "started_at": "2026-09-11T10:00:00Z", "unit_state": "running",
+            })
+            board = build_status_board(paths, now="2026-09-11T10:35:00Z")
+            plugin = read_running_work_board(paths.omh_home)
+
+        # The dispatch tally itself does not move -- both units have a marker.
+        self.assertEqual(board["running_count"], 2)
+        self.assertEqual(board["stuck_count"], 1)
+        self.assertEqual(plugin["running_count"], 2)
+        self.assertEqual(plugin["stuck_count"], 1)
+        self.assertIn("1 running, 1 stuck of 2 observed", render_status_board_text(board))
+        self.assertIn("1 running, 1 stuck of 2 observed", render_running_work_block_text(plugin))
+
+    def test_a_board_with_nothing_stuck_keeps_its_original_headline(self) -> None:
+        from omh.coding.status_board import render_status_board_text
+        from omh.plugin_bundle.omh.status_board_reader import (
+            read_running_work_board,
+            render_running_work_block_text,
+        )
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            write_inflight_marker(paths, "fanout-0123456789ab", "core", {
+                "owner": "codex", "run_ref": "run-1", "worktree": str(root),
+                "started_at": "2026-09-11T10:00:00Z", "unit_state": "running",
+            })
+            board = build_status_board(paths, now="2026-09-11T10:35:00Z")
+            plugin = read_running_work_board(paths.omh_home)
+
+        self.assertEqual(board["stuck_count"], 0)
+        self.assertIn("(1 running of 1 observed)", render_status_board_text(board))
+        self.assertIn("1 running of 1 observed.", render_running_work_block_text(plugin))
+        self.assertNotIn("stuck", render_status_board_text(board))
+        self.assertNotIn("stuck", render_running_work_block_text(plugin))
+
+    def test_the_two_stuck_state_sets_are_the_same(self) -> None:
+        from omh.coding.unit_execution_state import UNIT_STUCK_STATES
+        from omh.plugin_bundle.omh.status_board_reader import _STUCK_STATES as plugin_stuck
+
+        self.assertEqual(UNIT_STUCK_STATES, plugin_stuck)
+
+    def test_neither_reader_renders_running_for_a_stuck_unit(self) -> None:
+        from omh.coding.status_board import status_text_for
+        from omh.plugin_bundle.omh.status_board_reader import _status_text as plugin_status_text
+
+        # A live process whose work stopped moving: `status` still says a
+        # marker exists, and both cells must say what the WORK is doing.
+        unit = {
+            "status": "running",
+            "unit_state": "progress_stalled",
+            "state_reason": "repeated_error:error: unable to read file, retrying (n=<n>)",
+            "stalled_for_seconds": "1920",
+        }
+        rendered = status_text_for(unit)
+        self.assertEqual(rendered, plugin_status_text(unit))
+        self.assertIn("progress_stalled", rendered)
+        self.assertIn("repeated_error:", rendered)
+        self.assertIn("1920s since new output", rendered)
+        self.assertNotIn("· running", rendered)
+
+    def test_a_running_unit_state_leaves_the_status_cell_untouched(self) -> None:
+        from omh.coding.status_board import status_text_for
+        from omh.plugin_bundle.omh.status_board_reader import _status_text as plugin_status_text
+
+        for unit_state in ("running", ""):
+            with self.subTest(unit_state=unit_state):
+                unit = {"status": "running", "unit_state": unit_state}
+                self.assertEqual(status_text_for(unit), status_text_for({"status": "running"}))
+                self.assertEqual(status_text_for(unit), plugin_status_text(unit))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -3950,6 +3950,11 @@ class FanoutDispatchVerificationTests(unittest.TestCase):
             self.assertTrue(_unit_verification_is_observed(paths, core["run_ref"]))
             self.assertTrue(core["unit_verification_observed"])
             self.assertTrue(core["integration_ready"])
+            # The one state that means the work is done: a validated result
+            # record AND an observed verification. Nothing below both rungs
+            # reaches it -- see `FanoutDispatchUnitProgressTests`.
+            self.assertEqual(core["unit_state"], "verified")
+            self.assertEqual(core["unit_state_reason"], "")
             self.assertEqual(len(runner.verified), 2)
 
     def test_verification_receives_only_its_declared_capability_not_the_owner_capability(self) -> None:
@@ -5607,6 +5612,87 @@ class FanoutDispatchLiveUnitTelemetryTests(unittest.TestCase):
         # Absent counts stay absent, and bools never read as counts.
         self.assertIsNone(_reported_unit_tokens({}))
         self.assertIsNone(_reported_unit_tokens({"tokens_total": True}))
+
+
+class FanoutDispatchUnitProgressTests(unittest.TestCase):
+    """The in-flight marker and the unit record answer "is the WORK moving?",
+    which no dispatch surface could answer before: every one of them could
+    only say that a process existed. See `omh.coding.unit_progress`."""
+
+    def _setup(self, tmp: str):
+        root = Path(tmp)
+        paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+        repo, sha = _make_repo(root)
+        contract = write_fanout_contract(paths, build_fanout_contract(_GOAL, _UNITS))
+        return paths, repo, sha, contract
+
+    def _marker_spy(self, dispatch_module):
+        """Every marker write, snapshotted. The dispatch mutates one fields
+        dict for the unit's whole lifetime and clears the file in `finally`,
+        so neither the live dict nor the filesystem survives to be asserted on
+        afterwards -- only a copy taken at each write does."""
+        recorded: list[dict[str, str]] = []
+        original = dispatch_module._write_inflight
+
+        def spy(paths, fanout_id, unit_id, fields):
+            recorded.append(dict(fields))
+            return original(paths, fanout_id, unit_id, fields)
+
+        return recorded, spy
+
+    def test_the_marker_reports_progress_stalled_when_one_line_repeats(self) -> None:
+        from omh.coding import fanout_dispatch as dispatch_module
+
+        # Output grows on every snapshot and says the same thing each time:
+        # the 2026-09-11 incident's shape, and the one a byte-growth rule
+        # alone reads as healthy progress.
+        line = "error: unable to read file, retrying (n={n})\n"
+        loop = [
+            "preparing worktree\n" + "".join(line.format(n=turn) for turn in range(1, count + 1))
+            for count in range(0, 4)
+        ]
+        runner = _live_output_runner({"core": loop})
+        recorded, spy = self._marker_spy(dispatch_module)
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            with mock.patch.object(dispatch_module, "_write_inflight", spy):
+                dispatch_fanout(
+                    paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                    only_units=["core"], runner=runner, readiness=_ready,
+                )
+
+        self.assertIn("progress_stalled", [fields.get("unit_state", "") for fields in recorded])
+        stalled = next(fields for fields in recorded if fields.get("unit_state") == "progress_stalled")
+        self.assertTrue(stalled["state_reason"].startswith("repeated_error:"))
+        # The retry counter is collapsed, which is what makes three turns of
+        # the same failure countable as one repeated line.
+        self.assertIn("retrying (n=<n>)", stalled["state_reason"])
+        self.assertEqual(stalled["repeat_count"], "3")
+        # A progress write must never erase the dispatch bookkeeping an
+        # earlier write recorded.
+        self.assertEqual(stalled["run_ref"], recorded[0]["run_ref"])
+        # The first write happens before any snapshot and claims nothing about
+        # the work -- absent is not "moving".
+        self.assertEqual(recorded[0].get("unit_state", ""), "")
+
+    def test_exit_zero_without_a_result_record_is_a_failed_unit(self) -> None:
+        # `_agent_runner` exits 0 and writes no sidecar. That combination read
+        # as success on every surface; the ladder's answer is that nothing was
+        # verified because nothing was returned.
+        with TemporaryDirectory() as tmp:
+            paths, repo, sha, contract = self._setup(tmp)
+            summary = dispatch_fanout(
+                paths, contract, goal_text=_GOAL, repo_root=repo, base_sha=sha,
+                only_units=["core"], runner=_agent_runner(), readiness=_ready,
+            )
+        entry = summary["units"][0]
+        self.assertEqual(entry["exit_code"], 0)
+        self.assertEqual(entry["unit_state"], "failed")
+        self.assertEqual(entry["unit_state_reason"], "result_missing")
+        self.assertFalse(entry["result_schema_valid"])
+        # The evidence rides along, so no reader has to re-derive it.
+        self.assertEqual(entry["progress"]["schema_version"], "omh_unit_progress/v1")
+        self.assertFalse(entry["progress"]["result_record_present"])
 
 
 if __name__ == "__main__":

--- a/tests/test_fanout_status.py
+++ b/tests/test_fanout_status.py
@@ -14,7 +14,11 @@ load_local_package()
 from _cli_harness import run_cli  # noqa: E402
 
 from omh.coding.fanout import build_fanout_contract  # noqa: E402
-from omh.coding.fanout_artifacts import write_fanout_contract  # noqa: E402
+from omh.coding.fanout_artifacts import (  # noqa: E402
+    fanout_dispatch_summary_path,
+    write_fanout_contract,
+)
+from omh.coding.inflight import write_inflight_marker  # noqa: E402
 from omh.coding.fanout_dispatch import dispatch_fanout  # noqa: E402
 from omh.coding.fanout_status import (  # noqa: E402
     FANOUT_STATUS_SCHEMA_VERSION,
@@ -455,6 +459,160 @@ class FanoutStatusCliTests(unittest.TestCase):
 
             self.assertNotEqual(status, 0)
             self.assertIn("nope", stdout + stderr)
+
+
+class FanoutStatusUnitProgressTests(unittest.TestCase):
+    """The supervisor poll loop's inputs: is this unit's WORK moving, and is
+    it over? Neither question is a ladder rung, and neither can move
+    `lifecycle_state` -- see the module docstring's scoped exception."""
+
+    def _stalled_marker(self, paths: OmhPaths, unit_id: str = "core") -> None:
+        write_inflight_marker(paths, _FANOUT_ID, unit_id, {
+            "owner": "codex",
+            "run_ref": f"{_FANOUT_ID}-{unit_id}",
+            "worktree": f"/tmp/wt/{unit_id}",
+            "started_at": _stamp(40),
+            "unit_state": "progress_stalled",
+            "state_reason": "repeated_error:error: unable to read file, retrying (n=<n>)",
+            "stalled_for_seconds": "1920",
+        })
+
+    def test_a_stalled_marker_reaches_the_json_roster_as_non_terminal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            _seed_journal(paths, _roster_fixture())
+            self._stalled_marker(paths)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base + ["coding", "fanout", "status", "--fanout-id", _FANOUT_ID, "--json"]
+            )
+
+            self.assertEqual(status, 0, stderr)
+            payload = json.loads(stdout)
+            core = {unit["unit_id"]: unit for unit in payload["units"]}["core"]
+            self.assertEqual(core["unit_state"], "progress_stalled")
+            self.assertIs(core["terminal"], False)
+            self.assertEqual(core["unit_state_source"], "inflight_marker")
+            self.assertTrue(core["progress"]["reason"].startswith("repeated_error:"))
+            self.assertEqual(core["progress"]["seconds_since_new_output"], 1920)
+            # The roster-level stop condition the poll loop reads.
+            self.assertIn("core", payload["stuck_units"])
+            self.assertIs(payload["all_units_terminal"], False)
+            # The ladder is untouched: the marker moved no rung.
+            self.assertEqual(core["lifecycle_state"], "unit_verification_observed")
+
+    def test_the_text_roster_names_the_stuck_unit(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            _seed_journal(paths, _roster_fixture())
+            self._stalled_marker(paths)
+            base = ["--omh-home", str(root / ".omh"), "--hermes-home", str(root / ".hermes")]
+
+            status, stdout, stderr = run_cli(
+                base + ["coding", "fanout", "status", "--fanout-id", _FANOUT_ID],
+                output_json=False,
+            )
+
+            self.assertEqual(status, 0, stderr)
+            self.assertIn("progress_stalled", stdout)
+            self.assertIn("1920s since new output", stdout)
+            self.assertIn("not terminal", stdout)
+            self.assertIn("Stuck, needs intervention: core", stdout)
+
+    def test_a_dispatch_summary_supplies_the_state_after_exit(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            _seed_journal(paths, _roster_fixture())
+            summary_path = fanout_dispatch_summary_path(paths, _FANOUT_ID)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(json.dumps({
+                "fanout_id": _FANOUT_ID,
+                "units": [
+                    {"unit_id": "core", "unit_state": "verified", "unit_state_reason": "",
+                     "progress": {"stalled_for_seconds": 0}},
+                    {"unit_id": "docs", "unit_state": "failed", "unit_state_reason": "result_missing",
+                     "progress": {"stalled_for_seconds": 12}},
+                ],
+            }), encoding="utf-8")
+
+            roster = project_fanout_status(paths, _FANOUT_ID)
+            by_unit = {unit["unit_id"]: unit for unit in roster["units"]}
+
+            self.assertEqual(by_unit["core"]["unit_state"], "verified")
+            self.assertIs(by_unit["core"]["terminal"], True)
+            self.assertEqual(by_unit["core"]["unit_state_source"], "dispatch_summary")
+            self.assertEqual(by_unit["docs"]["unit_state"], "failed")
+            self.assertEqual(by_unit["docs"]["progress"]["reason"], "result_missing")
+            self.assertIs(by_unit["docs"]["terminal"], True)
+            self.assertEqual(roster["stuck_units"], [])
+            # `flaky` has neither marker nor summary row, so the fanout is not
+            # done -- absent evidence must never read as finished.
+            self.assertEqual(by_unit["flaky"]["unit_state"], "unknown")
+            self.assertIs(by_unit["flaky"]["terminal"], False)
+            self.assertEqual(by_unit["flaky"]["unit_state_source"], "none")
+            self.assertIsNone(by_unit["flaky"]["progress"]["seconds_since_new_output"])
+            self.assertIs(roster["all_units_terminal"], False)
+
+    def test_a_live_marker_outranks_a_stale_summary_row(self) -> None:
+        # A marker means this unit is in flight NOW; a summary row from an
+        # earlier dispatch of the same id must not report over it.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            _seed_journal(paths, _roster_fixture())
+            summary_path = fanout_dispatch_summary_path(paths, _FANOUT_ID)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(json.dumps({
+                "fanout_id": _FANOUT_ID,
+                "units": [{"unit_id": "core", "unit_state": "verified"}],
+            }), encoding="utf-8")
+            self._stalled_marker(paths)
+
+            roster = project_fanout_status(paths, _FANOUT_ID)
+            core = {unit["unit_id"]: unit for unit in roster["units"]}["core"]
+
+            self.assertEqual(core["unit_state"], "progress_stalled")
+            self.assertEqual(core["unit_state_source"], "inflight_marker")
+            self.assertIs(core["terminal"], False)
+
+    def test_a_roster_with_no_progress_evidence_renders_as_it_always_did(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            _seed_journal(paths, _roster_fixture())
+
+            roster = project_fanout_status(paths, _FANOUT_ID)
+            text = render_fanout_status_text(roster)
+
+            for unit in roster["units"]:
+                self.assertEqual(unit["unit_state"], "unknown")
+                self.assertIs(unit["terminal"], False)
+            self.assertNotIn("  work:", text)
+            self.assertNotIn("Stuck, needs intervention", text)
+            self.assertIs(roster["all_units_terminal"], False)
+
+    def test_a_marker_with_no_assessed_state_claims_nothing(self) -> None:
+        # Written before the first stdout snapshot: it proves a spawn, not
+        # that the work is moving.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            _seed_journal(paths, _roster_fixture())
+            write_inflight_marker(paths, _FANOUT_ID, "core", {
+                "owner": "codex", "run_ref": f"{_FANOUT_ID}-core",
+                "worktree": "/tmp/wt/core", "started_at": _stamp(1),
+            })
+
+            roster = project_fanout_status(paths, _FANOUT_ID)
+            core = {unit["unit_id"]: unit for unit in roster["units"]}["core"]
+
+            self.assertEqual(core["unit_state"], "unknown")
+            self.assertEqual(core["unit_state_source"], "none")
+            self.assertIs(core["terminal"], False)
 
 
 if __name__ == "__main__":

--- a/tests/test_fanout_status.py
+++ b/tests/test_fanout_status.py
@@ -557,6 +557,63 @@ class FanoutStatusUnitProgressTests(unittest.TestCase):
             self.assertIsNone(by_unit["flaky"]["progress"]["seconds_since_new_output"])
             self.assertIs(roster["all_units_terminal"], False)
 
+    def test_a_unit_refused_before_its_spawn_is_terminal_and_named(self) -> None:
+        # The workspace preflight (#1489) refuses a unit before it spawns: the
+        # summary row carries a stuck `unit_state` and the preflight's own
+        # `reason`, with no marker and no progress evidence. Nothing exists to
+        # move it, so reporting it non-terminal would hang a poll loop forever
+        # on a unit that never started.
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            _seed_journal(paths, _roster_fixture())
+            summary_path = fanout_dispatch_summary_path(paths, _FANOUT_ID)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(json.dumps({
+                "fanout_id": _FANOUT_ID,
+                "units": [{
+                    "unit_id": "core",
+                    "status": "worktree_failed",
+                    "reason_code": "workspace_preflight_blocked",
+                    "failure_kind": "workspace_blocked",
+                    "unit_state": "permission_blocked",
+                    "reason": "worktree is not writable",
+                }],
+            }), encoding="utf-8")
+
+            roster = project_fanout_status(paths, _FANOUT_ID)
+            core = {unit["unit_id"]: unit for unit in roster["units"]}["core"]
+
+            self.assertEqual(core["unit_state"], "permission_blocked")
+            self.assertIs(core["terminal"], True)
+            self.assertEqual(core["unit_state_source"], "dispatch_summary")
+            # The preflight's own wording survives; a pre-spawn refusal never
+            # reached the code that writes `unit_state_reason`.
+            self.assertEqual(core["progress"]["reason"], "worktree is not writable")
+            self.assertIsNone(core["progress"]["seconds_since_new_output"])
+            # Terminal and still needing a human: both are true at once, and
+            # the roster says so rather than picking one.
+            self.assertIn("core", roster["stuck_units"])
+            self.assertIn("needs intervention: core", render_fanout_status_text(roster))
+
+    def test_a_blocked_unit_with_only_a_failure_kind_still_explains_itself(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+            _seed_journal(paths, _roster_fixture())
+            summary_path = fanout_dispatch_summary_path(paths, _FANOUT_ID)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(json.dumps({
+                "fanout_id": _FANOUT_ID,
+                "units": [{"unit_id": "core", "unit_state": "data_missing",
+                           "failure_kind": "workspace_blocked"}],
+            }), encoding="utf-8")
+
+            core = {u["unit_id"]: u for u in project_fanout_status(paths, _FANOUT_ID)["units"]}["core"]
+
+            self.assertEqual(core["progress"]["reason"], "workspace_blocked")
+            self.assertIs(core["terminal"], True)
+
     def test_a_live_marker_outranks_a_stale_summary_row(self) -> None:
         # A marker means this unit is in flight NOW; a summary row from an
         # earlier dispatch of the same id must not report over it.

--- a/tests/test_subagent_graph_roster.py
+++ b/tests/test_subagent_graph_roster.py
@@ -144,3 +144,41 @@ class SubagentGraphRosterTests(unittest.TestCase):
         self.assertEqual(len(graph["nodes"]), 8)
         self.assertEqual(len(graph["frontier"]), 9)
         self.assertEqual(graph["hidden_nodes"], 2)
+
+    def test_a_stuck_roster_row_rides_beside_the_dispatch_state(self) -> None:
+        # The topology's arithmetic (frontier, blocked_by, success/failure) is
+        # defined on the dispatch vocabulary, so `state` must not change; what
+        # the unit's own output showed rides alongside it for the renderer.
+        contract = _contract()
+        roster = _roster(contract, {"root-0": "running"})
+        row = next(unit for unit in roster["units"] if unit["unit_id"] == "root-0")
+        row["unit_state"] = "progress_stalled"
+        row["state_reason"] = "repeated_error:error: unable to read file"
+        row["stalled_for_seconds"] = "1920"
+
+        graph = project_subagent_graph(contract, roster, preference="auto")
+        node = next(node for node in graph["nodes"] if node["node_id"] == "root-0")
+
+        self.assertEqual(node["state"], "running")
+        self.assertEqual(node["unit_state"], "progress_stalled")
+        self.assertEqual(node["state_reason"], "repeated_error:error: unable to read file")
+        self.assertEqual(node["stalled_for_seconds"], 1920)
+
+    def test_a_running_or_absent_unit_state_adds_no_node_keys(self) -> None:
+        contract = _contract()
+        for unit_state in ("running", "verified", ""):
+            with self.subTest(unit_state=unit_state):
+                roster = _roster(contract, {"root-0": "running"})
+                row = next(unit for unit in roster["units"] if unit["unit_id"] == "root-0")
+                row["unit_state"] = unit_state
+                graph = project_subagent_graph(contract, roster, preference="auto")
+                node = next(node for node in graph["nodes"] if node["node_id"] == "root-0")
+                self.assertNotIn("unit_state", node)
+                self.assertNotIn("state_reason", node)
+                self.assertNotIn("stalled_for_seconds", node)
+
+    def test_the_two_stuck_state_sets_are_the_same(self) -> None:
+        from omh.coding.unit_execution_state import UNIT_STUCK_STATES
+        from omh.plugin_bundle.omh.subagent_graph import _STUCK_UNIT_STATES
+
+        self.assertEqual(UNIT_STUCK_STATES, _STUCK_UNIT_STATES)

--- a/tests/test_tui_widget_pack.py
+++ b/tests/test_tui_widget_pack.py
@@ -403,6 +403,24 @@ class TuiWidgetPackTests(unittest.TestCase):
         self.assertNotIn("'open_call_count',", widget)
         self.assertNotIn("'live',", widget)
 
+    def test_a_stuck_unit_never_renders_as_the_dispatch_state(self) -> None:
+        # "Process alive" and "work progressing" are different states and must
+        # never render the same. A graph node whose reader assessed its own
+        # output and found it stuck replaces the dispatch word outright and
+        # carries the reason and the stall age beside it.
+        widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
+
+        self.assertIn("const stuckState = safeText(node.unit_state)", widget)
+        self.assertIn("const state = stuckState || dispatchState", widget)
+        self.assertIn("const stallSeconds = Number(node.stalled_for_seconds) || 0", widget)
+        self.assertIn("safeText(node.state_reason)", widget)
+        self.assertIn("since new output", widget)
+        # Its own marker and the warn tone, so a stuck node is visible before
+        # the line is read at all.
+        self.assertIn("const marker = stuckState\n          ? '[~]'", widget)
+        self.assertIn("color: stuckState\n              ? t.color.warn", widget)
+        self.assertIn("${state}${stuckSuffix}${suffix}", widget)
+
     def test_widget_is_bottom_docked_and_omits_host_status_fields(self) -> None:
         widget = resources.files("omh.tui_widgets").joinpath("omh-status.mjs").read_text(encoding="utf-8")
 

--- a/tests/test_unit_progress.py
+++ b/tests/test_unit_progress.py
@@ -21,6 +21,7 @@ from omh.coding.unit_progress import (
     REASON_REPEATED_ERROR_PREFIX,
     UNIT_PROGRESS_MID_RUN_STATES,
     UNIT_PROGRESS_SCHEMA_VERSION,
+    UNIT_PROMPT_QUIET_SECONDS,
     UNIT_STALL_AFTER_SECONDS,
     assess_progress,
     empty_progress_evidence,
@@ -82,20 +83,58 @@ class AssessProgressTests(unittest.TestCase):
         # Output grew, so the stall clock was NOT what fired here.
         self.assertEqual(growing["last_new_output_at"], 30.0)
 
-    def test_a_trailing_prompt_with_no_new_output_is_awaiting_input(self) -> None:
+    def test_a_trailing_prompt_needs_a_real_quiet_window_to_be_awaiting_input(self) -> None:
         asked = "applying patch\nOverwrite existing file? (y/n) "
         first = assess_progress(None, asked, now=0.0)
         self.assertEqual(first["state"], UNIT_STATE_RUNNING)
 
-        waiting = assess_progress(first, asked, now=5.0)
+        # One poll step of silence after a question is a tool call in
+        # progress, not a unit blocked on a human.
+        soon = assess_progress(first, asked, now=5.0)
+        self.assertEqual(soon["state"], UNIT_STATE_RUNNING)
+
+        waiting = assess_progress(soon, asked, now=UNIT_PROMPT_QUIET_SECONDS + 30.0)
         self.assertEqual(waiting["state"], UNIT_STATE_AWAITING_INPUT)
         self.assertEqual(waiting["reason"], REASON_PROMPT_AT_END)
 
     def test_a_bare_question_mark_only_counts_once_output_stopped(self) -> None:
         first = assess_progress(None, "Should I rebase onto main?\n", now=0.0)
         self.assertEqual(first["state"], UNIT_STATE_RUNNING)
-        moved_on = assess_progress(first, "Should I rebase onto main?\nrebasing\n", now=5.0)
+        moved_on = assess_progress(
+            first, "Should I rebase onto main?\nrebasing\n", now=UNIT_PROMPT_QUIET_SECONDS + 30.0
+        )
         self.assertEqual(moved_on["state"], UNIT_STATE_RUNNING)
+
+    def test_a_green_test_run_repeating_ok_forever_stays_running(self) -> None:
+        # Verbose unittest prints one `... ok` per test. Counting repetition
+        # as such would pin every green run at progress_stalled for the rest
+        # of its life, since the repeat rule outranks `running`.
+        text = "".join(f"test_case_{index} (tests.test_x.Suite) ... ok\n" for index in range(50))
+        evidence = assess_progress(None, text, now=0.0)
+        self.assertEqual(evidence["state"], UNIT_STATE_RUNNING)
+        self.assertEqual(evidence["repeat_count"], 0)
+        self.assertEqual(evidence["repeated_line"], "")
+
+    def test_a_repeated_compiler_warning_stays_running(self) -> None:
+        # Same shape, different producer: one identical warning per file is
+        # noisy, not stuck.
+        text = "".join(
+            f"src/mod_{index}.py:12: warning: unused import\n" for index in range(5)
+        ) + "building\n"
+        self.assertEqual(assess_progress(None, text, now=0.0)["state"], UNIT_STATE_RUNNING)
+
+    def test_a_repeated_passing_pytest_line_stays_running(self) -> None:
+        text = "".join(f"tests/test_x.py::test_{index} PASSED\n" for index in range(40))
+        self.assertEqual(assess_progress(None, text, now=0.0)["state"], UNIT_STATE_RUNNING)
+
+    def test_digit_collapsed_matrix_rows_do_not_read_as_a_stall(self) -> None:
+        # The digit collapse folds `(3.11, 0)` and `(3.12, 1)` into one
+        # canonical line. Healthy matrix output must survive that.
+        text = "".join(
+            f"ok  test_matrix ({major}.{minor}, {minor})\n"
+            for major, minor in ((3, 11), (3, 12), (3, 13))
+        )
+        self.assertEqual(assess_progress(None, text, now=0.0)["state"], UNIT_STATE_RUNNING)
 
     def test_a_session_limit_refusal_is_an_account_limit(self) -> None:
         first = assess_progress(None, "thinking\n", now=0.0)

--- a/tests/test_unit_progress.py
+++ b/tests/test_unit_progress.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import unittest
+
+from omh.coding.unit_execution_state import (
+    UNIT_STATE_ACCOUNT_LIMIT,
+    UNIT_STATE_AWAITING_INPUT,
+    UNIT_STATE_DATA_MISSING,
+    UNIT_STATE_PERMISSION_BLOCKED,
+    UNIT_STATE_PROGRESS_STALLED,
+    UNIT_STATE_RUNNING,
+    UNIT_TERMINAL_STATES,
+)
+from omh.coding.unit_progress import (
+    PHASE_MARKER_COMMIT_CREATED,
+    PHASE_MARKER_RESULT_WRITTEN,
+    PHASE_MARKER_TEST_FINISHED,
+    PHASE_MARKER_TEST_STARTED,
+    REASON_NO_NEW_OUTPUT,
+    REASON_PROMPT_AT_END,
+    REASON_REPEATED_ERROR_PREFIX,
+    UNIT_PROGRESS_MID_RUN_STATES,
+    UNIT_PROGRESS_SCHEMA_VERSION,
+    UNIT_STALL_AFTER_SECONDS,
+    assess_progress,
+    empty_progress_evidence,
+    progress_state_summary,
+    stalled_for_seconds,
+)
+
+
+class AssessProgressTests(unittest.TestCase):
+    def test_new_bytes_since_the_previous_reading_are_running(self) -> None:
+        first = assess_progress(None, "starting\n", now=100.0)
+        self.assertEqual(first["state"], UNIT_STATE_RUNNING)
+        self.assertEqual(first["reason"], "")
+        self.assertEqual(first["schema_version"], UNIT_PROGRESS_SCHEMA_VERSION)
+        self.assertEqual(first["last_new_output_at"], 100.0)
+
+        second = assess_progress(first, "starting\nreading files\n", now=160.0)
+        self.assertEqual(second["state"], UNIT_STATE_RUNNING)
+        self.assertEqual(second["last_new_output_at"], 160.0)
+        self.assertEqual(second["output_lines"], 2)
+        self.assertEqual(second["output_bytes"], len("starting\nreading files\n"))
+
+    def test_silence_past_the_threshold_is_a_stall(self) -> None:
+        first = assess_progress(None, "working\n", now=0.0)
+        quiet = assess_progress(first, "working\n", now=UNIT_STALL_AFTER_SECONDS - 1)
+        self.assertEqual(quiet["state"], UNIT_STATE_RUNNING)
+
+        stalled = assess_progress(quiet, "working\n", now=UNIT_STALL_AFTER_SECONDS)
+        self.assertEqual(stalled["state"], UNIT_STATE_PROGRESS_STALLED)
+        self.assertEqual(stalled["reason"], REASON_NO_NEW_OUTPUT)
+        self.assertEqual(stalled_for_seconds(stalled), int(UNIT_STALL_AFTER_SECONDS))
+        self.assertIn("no new output for", progress_state_summary(stalled))
+
+    def test_the_same_line_repeating_is_a_stall_even_while_output_grows(self) -> None:
+        # The 2026-09-11 incident in miniature: the retry counter and the
+        # short sha change every turn, the failure does not. Digit and hex
+        # collapse is what keeps the four turns countable as one line.
+        loop = "".join(
+            f"git checkout {sha} -- src/{path}.py\n"
+            f"error: unable to read file (case collision), retrying (n={n})\n"
+            for n, (sha, path) in enumerate(
+                (
+                    ("1a2b3c4", "Alpha"),
+                    ("5d6e7f8", "Beta"),
+                    ("9a0b1c2", "Gamma"),
+                    ("3d4e5f6", "Delta"),
+                ),
+                start=1,
+            )
+        )
+        previous = assess_progress(None, "preparing worktree\n", now=0.0)
+        growing = assess_progress(previous, "preparing worktree\n" + loop, now=30.0)
+
+        self.assertGreater(growing["output_bytes"], previous["output_bytes"])
+        self.assertEqual(growing["state"], UNIT_STATE_PROGRESS_STALLED)
+        self.assertTrue(growing["reason"].startswith(REASON_REPEATED_ERROR_PREFIX))
+        self.assertIn("retrying (n=<n>)", growing["reason"])
+        self.assertEqual(growing["repeat_count"], 4)
+        # Output grew, so the stall clock was NOT what fired here.
+        self.assertEqual(growing["last_new_output_at"], 30.0)
+
+    def test_a_trailing_prompt_with_no_new_output_is_awaiting_input(self) -> None:
+        asked = "applying patch\nOverwrite existing file? (y/n) "
+        first = assess_progress(None, asked, now=0.0)
+        self.assertEqual(first["state"], UNIT_STATE_RUNNING)
+
+        waiting = assess_progress(first, asked, now=5.0)
+        self.assertEqual(waiting["state"], UNIT_STATE_AWAITING_INPUT)
+        self.assertEqual(waiting["reason"], REASON_PROMPT_AT_END)
+
+    def test_a_bare_question_mark_only_counts_once_output_stopped(self) -> None:
+        first = assess_progress(None, "Should I rebase onto main?\n", now=0.0)
+        self.assertEqual(first["state"], UNIT_STATE_RUNNING)
+        moved_on = assess_progress(first, "Should I rebase onto main?\nrebasing\n", now=5.0)
+        self.assertEqual(moved_on["state"], UNIT_STATE_RUNNING)
+
+    def test_a_session_limit_refusal_is_an_account_limit(self) -> None:
+        first = assess_progress(None, "thinking\n", now=0.0)
+        refused = assess_progress(
+            first,
+            "thinking\nYou've hit your session limit · resets 6:10pm\n",
+            now=10.0,
+        )
+        self.assertEqual(refused["state"], UNIT_STATE_ACCOUNT_LIMIT)
+        self.assertTrue(refused["reason"].startswith("account_limit:"))
+
+    def test_a_denial_is_permission_blocked(self) -> None:
+        blocked = assess_progress(None, "touch .git/index\nPermission denied\n", now=0.0)
+        self.assertEqual(blocked["state"], UNIT_STATE_PERMISSION_BLOCKED)
+        self.assertTrue(blocked["reason"].startswith("permission_blocked:"))
+
+    def test_a_missing_object_is_data_missing(self) -> None:
+        missing = assess_progress(None, "git merge origin/main\nfatal: bad object 1a2b3c4\n", now=0.0)
+        self.assertEqual(missing["state"], UNIT_STATE_DATA_MISSING)
+        self.assertTrue(missing["reason"].startswith("data_missing:"))
+
+    def test_phase_markers_accumulate_from_what_the_tools_actually_print(self) -> None:
+        text = (
+            "test_routes (tests.test_cli.CliTests) ... ok\n"
+            "Ran 3 tests in 0.412s\n"
+            '{"schema_version": "fanout_unit_result/v1"}\n'
+            "[claude/topic 1a2b3c4] add unit progress\n"
+            " 2 files changed, 40 insertions(+)\n"
+        )
+        evidence = assess_progress(None, text, now=0.0)
+        self.assertEqual(
+            evidence["phase_markers"],
+            [
+                PHASE_MARKER_TEST_STARTED,
+                PHASE_MARKER_TEST_FINISHED,
+                PHASE_MARKER_RESULT_WRITTEN,
+                PHASE_MARKER_COMMIT_CREATED,
+            ],
+        )
+
+    def test_no_terminal_state_is_ever_assigned_mid_run(self) -> None:
+        # `failed` and `verified` belong to the intake path after exit. A
+        # mid-run reading of stdout must not pre-empt the result contract.
+        self.assertFalse(set(UNIT_PROGRESS_MID_RUN_STATES) & set(UNIT_TERMINAL_STATES))
+        for text in ("", "done\n", "FAILED\n", "all checks passed\n"):
+            self.assertIn(assess_progress(None, text, now=0.0)["state"], UNIT_PROGRESS_MID_RUN_STATES)
+
+    def test_a_freshly_dispatched_unit_is_running_not_stalled(self) -> None:
+        empty = empty_progress_evidence(now=500.0)
+        self.assertEqual(empty["state"], UNIT_STATE_RUNNING)
+        self.assertEqual(stalled_for_seconds(empty), 0)
+        self.assertEqual(progress_state_summary(empty), UNIT_STATE_RUNNING)
+
+    def test_result_record_presence_is_carried_not_derived(self) -> None:
+        evidence = assess_progress(None, "working\n", now=0.0, result_record_present=True)
+        self.assertIs(evidence["result_record_present"], True)
+        self.assertIs(assess_progress(None, "working\n", now=0.0)["result_record_present"], False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Feature Report

### What Changed

- New pure module `src/coding/unit_progress.py` derives a verdict about one
  dispatched unit's WORK from the stdout snapshots the dispatch already takes.
- `fanout_dispatch.py` feeds it: each mid-run snapshot is assessed and written
  onto the in-flight marker, and the post-exit record carries `unit_state`,
  `unit_state_reason`, and the final `progress` evidence.
- The status board, the plugin running-work block, and the TUI widget's DAG
  line stop printing `running` over a unit whose work stopped moving; the
  headline counts split a stuck unit out of "N running" and name it.
- `omh coding fanout status --fanout-id <id> --json` — every roster row now
  carries `unit_state`, `terminal`, `unit_state_source`, and `progress`, and
  the roster carries `all_units_terminal` and `stuck_units`. This is the
  surface the ulw-maestro supervisor polls (needed by PR #1490).
- `docs/CODING-OBSERVABILITY.md` gains the unit-state vocabulary table and the
  poll-surface contract.

### Why This Exists

Post-mortem B and C of the 2026-09-11 incident. A worker spent 36 minutes
retrying the same git workaround — a `blob:none` partial clone described as
complete, with fetch forbidden, and case-only filename collisions on macOS —
while its supervisor read "PID alive" as progress and set only completion
notifications. Every OMH surface let it: the in-flight marker
(`src/coding/inflight.py`), the progress binding, the status board, and the run
summary all describe a unit as in-flight or alive, and none of them said whether
the work was moving. The mid-run stdout snapshots that would have shown the
repetition were already being taken by `_communicate_with_output_polls` and were
used for token telemetry only.

### User / Operator Impact

An operator watching a fanout now sees which units are stuck and why, not a
uniform wall of `running`. A supervisor reading the running-work block gets
`1 running, 1 stuck of 2 observed` instead of `2 running`, and the stuck row
names its reason and how long its output has been still. A unit that exits 0
without returning a result record is reported `failed` with reason
`result_missing` rather than reading as success.

### How It Works

`assess_progress(previous, stdout_so_far, *, now, result_record_present,
stall_after_seconds, repeat_threshold)` is pure: no I/O, no clock of its own,
no network. Rule order is the substance:

1. A limit, permission, or missing-object shape in the tail →
   `account_limit` / `permission_blocked` / `data_missing`. Retrying under the
   same conditions cannot clear any of them, so they are reported the moment
   the tail matches rather than waited out.
2. The same canonical line repeating `repeat_threshold` (3) times in the tail →
   `progress_stalled`, reason `repeated_error:<line>`, **even while bytes grow**.
   This is the incident. Digit runs and short shas are collapsed first, so
   `retrying (n=1..4)` counts as one repeated line rather than four fresh ones.
3. A prompt or question at the end of output with no new bytes since the
   previous assessment → `awaiting_input`.
4. No new bytes for `stall_after_seconds` (900, the number
   `plugin_bundle.omh.tool_bursts.TOOL_CALL_OPEN_TTL_SECONDS` uses for the same
   question about a single tool call) → `progress_stalled`, reason
   `no_new_output`.
5. Otherwise `running`.

No terminal state is assigned mid-run. `failed` and `verified` come from the
intake path after exit, where `unit_state` is the evidence ladder's answer and
never the exit code's: `verified` requires both `result_schema_valid` and
`unit_verification_observed`; everything else is `failed` with the reason named.

Boundary-wise the wire values do not move. `status` stays the closed dispatch
vocabulary `subagent_graph._ROSTER_STATES` validates against; `running_count`
stays the dispatch tally the plugin's own `>= 2` gate reads; the graph's
frontier / blocked-by / success arithmetic stays defined on the dispatch words.
What the unit's own output showed rides beside them in additive keys, absent
entirely when no snapshot has been assessed — absent is not "moving".

### Files And Contracts Touched

- `src/coding/unit_progress.py` (new) — `omh_unit_progress/v1`.
- `src/coding/inflight.py` — six additive marker fields (`unit_state`,
  `state_reason`, `last_new_output_at`, `stalled_for_seconds`, `repeat_count`,
  `phase_markers`). Schema version held at `omh_inflight_marker/v1` on purpose:
  both readers compare it for exact equality and count a mismatch as
  `unreadable`, and the plugin copy on a live machine is refreshed by
  `omh update` rather than in lockstep with core, so a bump for an additive
  field set would blank the running-work board on every machine one update
  behind.
- `src/coding/fanout_dispatch.py` — one helper class plus two local insertions
  (the `on_output` path and the post-exit record). Nothing refactored in
  passing; the file is shared with two sibling branches.
- `src/coding/status_board.py`, `src/plugin_bundle/omh/status_board_reader.py`
  — `stuck_state_text` / `_stuck_state_text` (hand-mirrored, parity-gated),
  additive row keys, `stuck_count`, split headline.
- `src/plugin_bundle/omh/subagent_graph.py` — additive node keys for a stuck
  roster row; topology arithmetic unchanged.
- `src/omh/tui_widgets/omh-status.mjs` — the DAG node line renders the stuck
  word, its reason, the stall age, a `[~]` marker, and the warn tone.
- `src/coding/fanout_status.py` — `unit_state` / `terminal` /
  `unit_state_source` / `progress` per row, `all_units_terminal` and
  `stuck_units` on the roster, plus a `work:` line and a
  `Stuck, needs intervention:` line in the text view. A **scoped exception**
  to that module's "journal only" rule, spelled out in its docstring: the four
  new keys read the in-flight marker while a unit is in flight and the dispatch
  summary after it exits, they live in their own keys, and nothing there can
  move `lifecycle_state`, which still advances on journal events alone. The
  marker is read through `inflight.read_inflight_markers` — the single reader
  `status_board._inflight_units` itself calls — not a second parser.
- `docs/CODING-OBSERVABILITY.md` — unit-state vocabulary table and the
  poll-surface contract.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed:
- [ ] Relevant dry-run or smoke command:
- [ ] Manual Hermes/TUI check, or explicit reason it was not run:

### Observed Evidence

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` — **Ran 11053
  tests in 914.636s, OK (skipped=3)**, on the exact rebased and committed tree.
  An earlier run on this branch reported 6 failures whose tracebacks all named
  `build/__editable__…`; that is the stale editable-install trap `CLAUDE.md`
  documents — the build copy predated a module this branch adds.
  `rm -rf build && uv sync --reinstall-package oh-my-hermes` cleared it, the
  six re-ran green unmodified, and the run above is post-clear.
- `tests/test_unit_progress.py` 12/12: running on new bytes; stalled on
  silence; stalled on a repeated line despite growth (four turns of
  `git checkout <sha> …` / `retrying (n=N)`, proving the digit collapse);
  `awaiting_input` on a trailing `(y/n)` with no new output; `account_limit` on
  "You've hit your session limit"; `permission_blocked` on "Permission denied";
  `data_missing` on "fatal: bad object"; and the negative control that no
  terminal state is ever assigned mid-run.
- `tests/test_fanout_dispatch.py` 176/176, including the marker carrying
  `unit_state=progress_stalled` with `repeat_count=3` after a runner fake emits
  the same line three times, and exit 0 with no result record producing
  `unit_state == "failed"` / `unit_state_reason == "result_missing"`. The
  verified positive control is asserted on the existing passing-verification
  test.
- `tests/test_coding_status_board.py` 38/38 — both readers render the stuck cell
  identically value by value, both stuck-state mirrors equal `UNIT_STUCK_STATES`,
  both headlines split the stuck unit out, and a board with nothing stuck is
  byte-identical to the one this repo already rendered.
- `tests/test_fanout_status.py` 20/20, including a stalled marker reaching the
  `--json` roster with `terminal: false` and `lifecycle_state` untouched, the
  text view naming the stuck unit, the dispatch summary supplying state after
  exit, a live marker outranking a stale summary row, a roster with no progress
  evidence rendering exactly as it did before, and a marker written before the
  first snapshot claiming nothing.
- `tests/test_subagent_graph_roster.py` 6/6, `tests/test_tui_widget_pack.py`
  16/16, `tests/test_status_board_auto_surface.py`, both messenger suites,
  `tests/test_broad_exception_policy.py`, `tests/test_interpreter_spawn_policy.py`
  — green.
- `node --check src/omh/tui_widgets/omh-status.mjs` — clean.
- Every `docs … --check` gate listed in `CLAUDE.md` — exit 0 (workflows, roles,
  navigation, capability-families, ulw-inventory, ulw-site, claims).
- Rendered a two-unit board by hand from real markers: the stalled row reads
  `progress_stalled (repeated_error:…, 1920s since new output)` on both the
  status board and the plugin block, and both headlines read
  `1 running, 1 stuck of 2 observed`.

### Not Tested / Not Applicable

- `harness validate`, `release checklist`, `release hermes-smoke`, `omh --help`
  and the install smoke: no harness, release, installer, or CLI-surface code is
  touched; this change is confined to the coding observability path and its
  renderers.
- No live agent CLI was spawned and no live Hermes TUI frame was rendered. The
  dispatch tests use the repository's existing fake runner, and the widget
  change is gated by source-text assertions plus a JS syntax check — the same
  gate every other widget change in this repo carries. A manual TUI check on a
  machine running a real fanout is the remaining gap.
- Every `unit_progress` fixture is synthetic. The pattern tables are shape
  matching over vendor output; they are deliberately small and will need rows
  added as real refusals are observed.

## Risk

- The pattern tables can miss (a refusal shape not listed reads as `running`)
  or over-match (an unrelated line containing "permission denied" reads as
  `permission_blocked`). Both are reporting-only: no state here retries,
  cancels, or reroutes anything, and every claim is "the output looked like
  this", never provider, filesystem, or repository truth.
- The `awaiting_input` rule matches a trailing `?`. It is gated on output
  having stopped growing, so a model printing a question mid-stream stays
  `running`, but a worker that ends its final sentence with a question mark and
  then goes quiet will read as awaiting input rather than stalled. Both are
  stuck states and both call for the same intervention.
- The fanout status roster gains a source it did not read before. The risk is
  a reader mistaking a progress key for a ladder rung; the mitigation is that
  they are separate keys, `lifecycle_state` is untouched, and a case asserts
  it stays put while a marker reports `progress_stalled`.
- `all_units_terminal` fails toward waiting: an unreadable marker directory or
  summary leaves rows at `unknown`, which is not terminal. A supervisor loop
  will keep polling rather than conclude the work finished — the safe
  direction, but it means a genuinely broken artifact store reads as "still
  running" until a human looks.
- The status board header string changes for any board with a stuck unit.
- `fanout_dispatch.py` is shared with two sibling branches in this batch; the
  edits are two insertions plus one helper class so the rebase stays mechanical.

## Compatibility / Rollout

- Rebased onto `origin/main` after #1486, #1487, #1488 and #1473 merged; the
  rebase was conflict-free. #1487's widget behaviour (`(unchanged <elapsed>)`
  from the reader's `todo.stall`) is kept and the unit-state rendering is
  layered beside it on the DAG node line. #1486 landed `session_limit` rows in
  `_LIMIT_SHAPED_PATTERNS`, so this branch's own supplement for that shape was
  removed as a duplicate — `unit_progress` now reads those patterns from their
  one owner.
- Every new field is additive and absent when unobserved. The in-flight marker
  stays at `omh_inflight_marker/v1`, so a plugin copy that predates this change
  keeps reading markers written by a newer core and simply ignores the new keys.
- No new dependency, no network call, no change to any closed vocabulary that
  an existing consumer validates against.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- Nothing drives on this evidence yet. A supervisor that acts on a stuck unit —
  reporting it blocked instead of waiting — is workstream D's lane, and the
  auto-resume termination criterion is workstream E's.
- The Maestro-lane HUD *activity* rows (as opposed to the DAG line) still read
  their state from the executor-progress binding, which carries no unit state.
  Routing the progress verdict onto that binding needs a `process_status`
  vocabulary decision in `executor_progress.build_safe_progress_signal` and is
  left out deliberately rather than stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhN96KFcrfPRQySG4Txqnm
