### PR TITLE
test(coding): pin that a blocked workspace exits non-zero

### DIFF
--- a/src/commands/coding.py
+++ b/src/commands/coding.py
@@ -2318,10 +2318,12 @@ def _fanout_dispatch_exit_code(summary: dict) -> int:
     2026-09-11 it did not: a batch whose every unit failed exited 0, so a
     caller reading only the status was told the work succeeded. That is how a
     real limit-exhausted run came back "ok" to its wrapper while the inner
-    dispatch had exit 1 and no report. `failure_kind` is the closed enum
-    `classify_failure_kind` sets on a failed unit and leaves empty on a
-    successful one, so presence is the signal and no status vocabulary is
-    duplicated here.
+    dispatch had exit 1 and no report. `failure_kind` is the closed enum a
+    failed unit carries and a successful one leaves empty, so presence is the
+    signal and no status vocabulary is duplicated here. Most kinds come from
+    `classify_failure_kind` reading a finished process; `workspace_blocked` is
+    assigned before the spawn by the workspace preflight, and it reaches this
+    mapper by the same key for the same reason -- the work did not happen.
     """
     if summary.get("interrupted"):
         return 130

--- a/tests/test_fanout_dispatch.py
+++ b/tests/test_fanout_dispatch.py
@@ -57,6 +57,7 @@ from omh.coding.fanout_dispatch import (  # noqa: E402
     verify_goal_matches_contract,
 )
 from omh.coding.verification_execution import VerificationExecutionGate  # noqa: E402
+from omh.commands.coding import _fanout_dispatch_exit_code  # noqa: E402
 from omh.coding.parallelism_policy import (  # noqa: E402
     FANOUT_MAX_DEPTH_DEFAULT,
     FANOUT_RUN_SPAWN_CEILING_DEFAULT,
@@ -1750,6 +1751,11 @@ class FanoutWorkspacePreflightTests(unittest.TestCase):
             self.assertIn("is not a commit present in", core["reason"])
             # The point of the whole check: no agent CLI was started.
             self.assertEqual(root_runner.spawned, [])
+            # ...and the outer command must not call that success. The mapper
+            # keys on `failure_kind` being present, which is exactly what a
+            # pre-spawn blocker sets, so a blocked unit exits 1 like any other
+            # failed one rather than reporting work that never happened.
+            self.assertEqual(_fanout_dispatch_exit_code(summary), 1)
 
     def test_a_healthy_worktree_reports_a_passing_preflight_and_still_spawns(self) -> None:
         # The negative control for the test above: the same dispatch with git


### PR DESCRIPTION
## Capability

A workspace-blocked unit is pinned to make `omh coding fanout dispatch` exit non-zero, and the exit-code mapper's docstring describes where `failure_kind` actually comes from.

## Motivation

#1489 refuses a dispatch before spawn when the unit's worktree cannot take the work, and left one claim as "not tested": that the outer command then exits 1. #1486 (merged in between) made that verifiable — the mapper keys on `failure_kind` presence — so this closes the claim with a direct assertion. The mapper's docstring also said the enum comes from `classify_failure_kind`; after #1489 that is no longer the whole truth, since `workspace_blocked` is assigned before any process exists.

## Implementation

- `tests/test_fanout_dispatch.py`: the blocked-workspace test now also asserts `_fanout_dispatch_exit_code(summary) == 1`.
- `src/commands/coding.py`: docstring states the general rule (presence of `failure_kind` is the signal) and names the pre-spawn kind as the exception to "read from a finished process".

## Verification (observed)

- `tests/test_exit_code_truthfulness_policy.py` OK; `tests/test_fanout_dispatch.py` preflight + exit-code cases OK; ruff clean; `git diff --check` clean.

## Risks

None — one assertion and one docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhN96KFcrfPRQySG4Txqnm
