### PR TITLE
feat(coding): match dispatch recovery to the cause of the failure

### DIFF
--- a/docs/FANOUT.md
+++ b/docs/FANOUT.md
@@ -861,6 +861,110 @@ funnel into the same engine.
   retargeted or Hermes-lane unit that exits 0 is no more verified than any other
   unit that exits 0.
 
+## Cause-specific recovery
+
+The three actions above answer *where else could this run*. They do not answer
+*may it run again at all, and what has to be true first* — and those are
+different questions. Re-running a unit under the permissions that denied it, or
+inside the quota window that refused it, is not a recovery; it is the same
+attempt again. `src/coding/cause_recovery.py` is the table that answers the
+second question, one row per cause, attached to every candidate as its `plan`
+(`unit_recovery_plan/v1`).
+
+A plan carries `cause`, `action`, `allowed_rerun`, `requires`, `unmet`,
+`reason`, and `resume_unit_id`. A reader branches on `cause` and `action`, never
+on the prose.
+
+| Cause | Action | Rerun allowed only when |
+| --- | --- | --- |
+| any cause, while a marker for this scope is present | `wait_for_live_worker` | never — the marker is cleared first |
+| `permission_blocked`, `workspace_blocked` on a file or the index | `repair_permissions_then_reprobe` | `workspace_preflight_ok` |
+| `account_limit` / `limit_shaped` | `check_account_then_switch_if_allowed` | `account_changed_or_reset_elapsed` |
+| `data_missing`, `workspace_blocked` on objects | `supplement_objects_then_resume_unit` | `objects_present` |
+| `progress_stalled` | `rerun_with_changed_conditions_or_checkpoint` | `conditions_changed` |
+| `awaiting_input` | `answer_or_cancel` | never — a rerun only asks again |
+| `auth_shaped` | `reauthenticate_then_redispatch` | `credential_repaired` |
+| `binary_missing` | `install_binary_then_redispatch` | `binary_present` |
+| `timeout`, `crash` | `report_or_choose_recovery` | always (existing behaviour, unchanged) |
+| nothing recorded | `report_only` | always — no cause-specific repair is claimed |
+
+- **The live-worker row wins over every other row**, and is checked before the
+  cause is even resolved. Scope is the unit id **or** the worktree path: two
+  dispatchers racing one unit and two units pointed at one directory are the
+  same hazard. Marker presence is still not liveness, so the plan names the
+  marker and asks for it to be confirmed gone and cleared — it never claims the
+  process exists. This is the "never add a second worker to a scope whose worker
+  is still alive" rule, and it is the reason it cannot be talked past.
+- **A cause a new worker would inherit closes the two spawning lanes.** For
+  `live_worker_present`, `permission_blocked`, `data_missing`, and
+  `awaiting_input`, retarget and the Hermes lane are listed `available: false`
+  with the requirement named, because a fresh worker meets the same denied
+  permission, the same absent objects, or the same unanswered question. A quota
+  and a stall are **not** inherited — another owner has its own account, and
+  another owner is itself a changed condition — so both lanes stay open for
+  them. Waiting is always offered: it spawns nothing.
+- **`conditions_fingerprint` is what makes "identical conditions" false-able.**
+  It folds owner, model, `prompt_sha256`, worktree, and permissions into one
+  digest. A proposed attempt whose fingerprint equals the last attempt's is the
+  attempt that already stalled, and is refused. When no proposal is stated the
+  proposal is taken to BE the last attempt, because that is what re-running the
+  same command does — a stall with no stated change is refused rather than
+  waved through. A fingerprint over a mapping that names none of the five is
+  empty and never compares equal to anything, so "the conditions are identical"
+  cannot be claimed by accident.
+- **`data_missing` names one unit.** The plan's `resume_unit_id` is the single
+  unit to resume once the objects are supplemented and verified. Rebuilding the
+  fanout would destroy the work the failure left behind.
+- **`workspace_blocked` is two causes wearing one name**, and the preflight's own
+  verdict decides which. A blocked unit carries that verdict as `unit_state` and
+  the plan reads it first. Only a record that lost its state falls through to
+  deriving it from the `workspace_preflight/v1` report, and it derives it the way
+  the preflight itself does: the FIRST name in `blocking` is the repair, because
+  the checks run in dependency order — a worktree that refuses a file write also
+  fails the index write and the object reads, and that repair belongs at the
+  filesystem, not at the objects. That rule is not restated here: the plan calls
+  `workspace_preflight_unit_state`, the same function that stamped the state, so
+  the routing and the stamp cannot drift into two answers. An absent or
+  unreadable report is read as the permission row, the more conservative of the
+  two — it blocks a new worker where the objects row would have let one start. A
+  passing preflight is `ok: true` and nothing else; an `ok` arriving as `1` or
+  `"true"` came from something that is not the preflight and is not a pass.
+  `workspace_blocked` is deliberately **not** in `RECOVERABLE_FAILURE_KINDS` —
+  no other owner and no later attempt answers a denied write or an absent object
+  — so a blocked unit reaches the interview through its `unit_state` instead,
+  where every spawning option is closed and the requirement is named.
+- **The account a limit was hit under is recorded.** At spawn time the dispatch
+  reads the owner's own CLI config — `~/.claude.json` `oauthAccount`, falling
+  back to the single `claudeAiOauth` slot in `~/.claude/.credentials.json`; or
+  `~/.codex/auth.json` `tokens.account_id`, falling back to whether an API key
+  is configured — and records a redacted tag (`claude:kh...@gmail.com`,
+  `codex:<8 hex>`) on the unit envelope and in the limit signal, where the
+  readiness advisory already surfaces every stored key. **No token, key, or
+  secret value is read**: the only inputs are an email address, an account
+  uuid, and an account id. An unreadable or absent file is an empty tag, and an
+  empty tag means "nothing readable named an account" — never "nobody is logged
+  in", and never a tag that compares equal to another unknown, which is why an
+  account change it cannot show keeps the operator waiting for the reset.
+- **`reset_text` is a literal, not a time.** The phrase the provider wrote
+  (`6:10pm (Asia/Seoul)`) is taken as-is into the limit signal for display.
+  Nothing converts it to an instant; a timezone-aware reset computed from a
+  provider's prose would be a fabricated observation. The elapsed answer comes
+  from the cooldown window going stale, which omh does measure.
+- **The table is gated, not frozen.** `tests/test_cause_recovery.py` re-derives
+  every `FAILURE_KIND_*` constant from the classifier's source and every member
+  of `UNIT_STUCK_STATES`, and fails naming the member that has no row. Adding a
+  failure kind or a stuck state stays a one-line change plus its row; nothing
+  here forbids adding one.
+- **A stuck unit reaches the interview.** `recovery_candidates` admits a unit
+  whose `unit_state` is in `UNIT_STUCK_STATES` as well as one whose
+  `failure_kind` is recoverable. That is what carries a workspace-blocked unit
+  in, and what will carry a stalled or input-waiting one in as soon as a
+  producer stamps those states.
+- **Not evidence.** A plan states which repair the observed cause requires. It
+  is not a claim the repair will succeed, and `allowed_rerun: false` is a
+  refusal to re-run under conditions that already failed — never a verdict
+  about the work.
+
 ## Installed-skill discovery
 
 Before building unit prompts, dispatch probes fixed executor-specific

--- a/src/coding/cause_recovery.py
+++ b/src/coding/cause_recovery.py
@@ -1,0 +1,621 @@
+"""Match the recovery to the cause of one unit's failure.
+
+`dispatch_failure_recovery` answers "what kind of failure was that" and offers
+three ways out. It does not answer the question the 2026-09-11 incident turned
+into a post-mortem item: *which* way out this particular cause admits. A
+credential rejection and a permission denial both reach the operator as a
+failed unit, and re-running is the right move for neither. A worker that has
+been alive for thirty-six minutes retrying the same git workaround is not
+failed at all, and adding a second worker to its scope is the worst available
+move.
+
+This module is that missing answer, and it is a table rather than a chain of
+conditionals so that the answer for a cause can be read in one row.
+
+Five rules are encoded here and nowhere else:
+
+1. **A live worker wins over every other row.** If an in-flight marker still
+   names this unit id or this worktree, the plan is `wait_for_live_worker` and
+   no rerun is allowed, whatever the cause was. This is the "never add a second
+   worker to a scope whose worker is still alive" rule; it is checked first
+   precisely so no cause can talk its way past it. Marker presence is not
+   liveness (`inflight` says so itself), so the plan reports the marker and
+   asks for it to be cleared — it never claims the process exists.
+2. **Re-running under the same permissions is not a recovery.** A permission or
+   sandbox denial requires a fresh workspace preflight to pass before anything
+   is re-dispatched.
+3. **A limit is an account fact, not a clock fact.** A limit-shaped failure may
+   be re-run only when the account differs from the one that hit the limit, or
+   when the recorded reset has elapsed. `reset_text` is carried as the literal
+   string the provider wrote and is never parsed into a time — the elapsed
+   answer comes from the cooldown window going stale or from an explicitly
+   observed `reset_elapsed`, both of which OMH can actually measure.
+4. **Missing objects are supplemented, then ONE unit resumes.** The 36-minute
+   stall was a partial clone described as complete. Rebuilding the fanout would
+   destroy the work the failure left behind; the plan names the single unit.
+5. **A stall re-runs only under changed conditions.** `conditions_fingerprint`
+   folds the five things that decide whether an attempt is the same attempt
+   (owner, model, prompt digest, worktree, permissions). Identical fingerprint,
+   no rerun — that is "never re-run under identical failure conditions" made
+   false-able rather than asserted in prose.
+
+The table is deliberately keyed by BOTH vocabularies: the `failure_kind` enum
+in `dispatch_failure_recovery` (what the dispatcher observed of the process and
+its output) and the `unit_state` vocabulary in `unit_execution_state` (what was
+observed of the work). A unit carries whichever its producer recorded, and a
+unit that carries neither resolves to `unknown`, which offers nothing and
+forbids nothing. `tests/test_cause_recovery.py` re-derives both vocabularies
+from source and fails when one gains a member with no row, so the class is
+caught without the table freezing either vocabulary.
+
+The remaining `failure_kind` spellings are written as literals rather than
+imported: the closed enum lives with the classifier that produces it, and this
+module is imported BY that classifier, so only the one name the routing has to
+branch on (`FAILURE_KIND_WORKSPACE_BLOCKED`) is worth the import that forced
+the classifier's own import of this module to be deferred. The derived gate is
+what keeps every other spelling equal.
+
+Nothing here reads state, writes state, or spawns anything. `recovery_plan` is
+a pure function of the unit record, the in-flight markers it is handed, and the
+previous attempt's conditions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Mapping, NamedTuple, Sequence
+
+from .dispatch_failure_recovery import FAILURE_KIND_WORKSPACE_BLOCKED
+from .unit_execution_state import (
+    UNIT_STATE_ACCOUNT_LIMIT,
+    UNIT_STATE_AWAITING_INPUT,
+    UNIT_STATE_DATA_MISSING,
+    UNIT_STATE_PERMISSION_BLOCKED,
+    UNIT_STATE_PROGRESS_STALLED,
+)
+from .workspace_preflight import workspace_preflight_unit_state
+
+RECOVERY_PLAN_SCHEMA_VERSION = "unit_recovery_plan/v1"
+
+RECOVERY_PLAN_CLAIM_BOUNDARY = (
+    "A recovery plan states which repair the observed cause requires before this unit is "
+    "re-dispatched. It is not a claim that the repair will succeed, not evidence that the unit "
+    "can succeed, and `allowed_rerun` is a refusal to re-run under conditions that already "
+    "failed — never a verdict about the work itself."
+)
+
+# The conditions that decide whether a proposed attempt is the SAME attempt.
+# Changing any one of them is a changed condition; changing none of them is the
+# re-run the post-mortem forbids.
+CONDITION_FIELDS: tuple[str, ...] = (
+    "owner",
+    "model",
+    "prompt_sha256",
+    "worktree",
+    "permissions",
+)
+
+# Canonical causes. Every `failure_kind` and every `unit_state` resolves to one
+# of these through `resolve_cause`.
+CAUSE_LIVE_WORKER_PRESENT = "live_worker_present"
+CAUSE_PERMISSION_BLOCKED = "permission_blocked"
+CAUSE_ACCOUNT_LIMIT = "account_limit"
+CAUSE_DATA_MISSING = "data_missing"
+CAUSE_PROGRESS_STALLED = "progress_stalled"
+CAUSE_AWAITING_INPUT = "awaiting_input"
+CAUSE_AUTH_INVALID = "auth_invalid"
+CAUSE_BINARY_MISSING = "binary_missing"
+CAUSE_TIMEOUT = "timeout"
+CAUSE_CRASH = "crash"
+CAUSE_UNKNOWN = "unknown"
+
+# Actions. A reader branches on these, never on the reason prose.
+ACTION_WAIT_FOR_LIVE_WORKER = "wait_for_live_worker"
+ACTION_REPAIR_PERMISSIONS_THEN_REPROBE = "repair_permissions_then_reprobe"
+ACTION_CHECK_ACCOUNT_THEN_SWITCH_IF_ALLOWED = "check_account_then_switch_if_allowed"
+ACTION_SUPPLEMENT_OBJECTS_THEN_RESUME_UNIT = "supplement_objects_then_resume_unit"
+ACTION_RERUN_WITH_CHANGED_CONDITIONS_OR_CHECKPOINT = "rerun_with_changed_conditions_or_checkpoint"
+ACTION_ANSWER_OR_CANCEL = "answer_or_cancel"
+ACTION_REAUTHENTICATE_THEN_REDISPATCH = "reauthenticate_then_redispatch"
+ACTION_INSTALL_BINARY_THEN_REDISPATCH = "install_binary_then_redispatch"
+ACTION_REPORT_OR_CHOOSE_RECOVERY = "report_or_choose_recovery"
+ACTION_REPORT_ONLY = "report_only"
+
+# Requirement names. Each one is a condition a caller must be able to show was
+# met; an unmet requirement is why `allowed_rerun` is false.
+REQUIRE_WORKSPACE_PREFLIGHT_OK = "workspace_preflight_ok"
+REQUIRE_ACCOUNT_CHANGED_OR_RESET_ELAPSED = "account_changed_or_reset_elapsed"
+REQUIRE_OBJECTS_PRESENT = "objects_present"
+REQUIRE_CONDITIONS_CHANGED = "conditions_changed"
+REQUIRE_CREDENTIAL_REPAIRED = "credential_repaired"
+REQUIRE_BINARY_PRESENT = "binary_present"
+
+
+class RecoveryRow(NamedTuple):
+    """One cause, one action, and the conditions a rerun of it requires."""
+
+    cause: str
+    action: str
+    requires: tuple[str, ...]
+    # True when no rerun of this unit is a recovery at all, whatever is
+    # satisfied. Distinct from "requires something first": a question nobody
+    # answered is answered or cancelled, never re-run.
+    never_rerun: bool
+    # True when this cause would be inherited by ANY new worker on this scope,
+    # so retargeting or re-running through another lane is also refused until
+    # the requirement is met. A quota is an account fact and a stall is a
+    # conditions fact — neither is inherited, so neither blocks a new worker.
+    blocks_new_worker: bool
+    # True when the plan resumes exactly one unit rather than the fanout.
+    resumes_single_unit: bool
+    reason: str
+
+
+RECOVERY_ROWS: tuple[RecoveryRow, ...] = (
+    # A marker still names this unit id or this worktree. This row is checked
+    # before the cause is even resolved: a second worker on a live scope is the
+    # one recovery that can make things worse than doing nothing.
+    RecoveryRow(
+        cause=CAUSE_LIVE_WORKER_PRESENT,
+        action=ACTION_WAIT_FOR_LIVE_WORKER,
+        requires=(),
+        never_rerun=True,
+        blocks_new_worker=True,
+        resumes_single_unit=False,
+        reason="an in-flight marker still occupies this scope; a second worker must not be added to it",
+    ),
+    # A permission or sandbox denial (file write, git index, an isolation dir
+    # omh cannot write). The next attempt inherits the same permissions unless
+    # something changes them, so a fresh preflight has to pass first.
+    RecoveryRow(
+        cause=CAUSE_PERMISSION_BLOCKED,
+        action=ACTION_REPAIR_PERMISSIONS_THEN_REPROBE,
+        requires=(REQUIRE_WORKSPACE_PREFLIGHT_OK,),
+        never_rerun=False,
+        blocks_new_worker=True,
+        resumes_single_unit=True,
+        reason="re-running under the same permissions cannot clear a permission denial",
+    ),
+    # The provider refused for account reasons. Waiting clears it, and so does
+    # a different account; nothing else does, and a blind retry inside the
+    # cooldown is the behaviour the post-mortem named.
+    RecoveryRow(
+        cause=CAUSE_ACCOUNT_LIMIT,
+        action=ACTION_CHECK_ACCOUNT_THEN_SWITCH_IF_ALLOWED,
+        requires=(REQUIRE_ACCOUNT_CHANGED_OR_RESET_ELAPSED,),
+        never_rerun=False,
+        blocks_new_worker=False,
+        resumes_single_unit=True,
+        reason="a limit clears with a different account or with its reset, never with a retry inside the cooldown",
+    ),
+    # Objects the work needs are absent from its isolation: partial-clone
+    # blobs, a missing base commit, a ref described but never fetched. The
+    # parent supplements and verifies them, then exactly one unit resumes.
+    RecoveryRow(
+        cause=CAUSE_DATA_MISSING,
+        action=ACTION_SUPPLEMENT_OBJECTS_THEN_RESUME_UNIT,
+        requires=(REQUIRE_OBJECTS_PRESENT,),
+        never_rerun=False,
+        blocks_new_worker=True,
+        resumes_single_unit=True,
+        reason="the objects the work needs are absent; supplement and verify them, then resume this one unit",
+    ),
+    # Alive and not moving. The only honest rerun is one whose conditions
+    # differ, or one that starts from a checkpoint rather than from base.
+    RecoveryRow(
+        cause=CAUSE_PROGRESS_STALLED,
+        action=ACTION_RERUN_WITH_CHANGED_CONDITIONS_OR_CHECKPOINT,
+        requires=(REQUIRE_CONDITIONS_CHANGED,),
+        never_rerun=False,
+        blocks_new_worker=False,
+        resumes_single_unit=True,
+        reason="identical conditions produced the stall; re-running them reproduces it",
+    ),
+    # The worker asked a question. A rerun discards the work that reached the
+    # question and asks it again.
+    RecoveryRow(
+        cause=CAUSE_AWAITING_INPUT,
+        action=ACTION_ANSWER_OR_CANCEL,
+        requires=(),
+        never_rerun=True,
+        blocks_new_worker=True,
+        resumes_single_unit=False,
+        reason="the worker is waiting on an answer; answer it or cancel it, a rerun only asks again",
+    ),
+    # Credential rejection. Same shape as a permission denial — the next
+    # attempt on this owner inherits the rejected credential — but another
+    # owner carries its own, so a retarget is not blocked.
+    RecoveryRow(
+        cause=CAUSE_AUTH_INVALID,
+        action=ACTION_REAUTHENTICATE_THEN_REDISPATCH,
+        requires=(REQUIRE_CREDENTIAL_REPAIRED,),
+        never_rerun=False,
+        blocks_new_worker=False,
+        resumes_single_unit=True,
+        reason="the stored credential was rejected; re-running before it is repaired repeats the rejection",
+    ),
+    # The dispatcher's own exit 127. Re-running with the binary still absent
+    # from PATH is the same pointless attempt.
+    RecoveryRow(
+        cause=CAUSE_BINARY_MISSING,
+        action=ACTION_INSTALL_BINARY_THEN_REDISPATCH,
+        requires=(REQUIRE_BINARY_PRESENT,),
+        never_rerun=False,
+        blocks_new_worker=False,
+        resumes_single_unit=True,
+        reason="the owner's CLI was not on PATH; install or point at it before re-dispatching",
+    ),
+    # Existing behaviour, mapped through unchanged: a timeout and a crash are
+    # already offered report / retarget / hermes / wait, and neither carries a
+    # precondition omh can check.
+    RecoveryRow(
+        cause=CAUSE_TIMEOUT,
+        action=ACTION_REPORT_OR_CHOOSE_RECOVERY,
+        requires=(),
+        never_rerun=False,
+        blocks_new_worker=False,
+        resumes_single_unit=True,
+        reason="the unit burned its timeout; re-run it, give it a different owner or lane, or wait",
+    ),
+    RecoveryRow(
+        cause=CAUSE_CRASH,
+        action=ACTION_REPORT_OR_CHOOSE_RECOVERY,
+        requires=(),
+        never_rerun=False,
+        blocks_new_worker=False,
+        resumes_single_unit=True,
+        reason="the unit exited non-zero with no recognised shape; the tails are the only account of why",
+    ),
+    # Nothing was recorded. Offering a repair for a cause nobody observed would
+    # be the invention this repo's evidence rule forbids.
+    RecoveryRow(
+        cause=CAUSE_UNKNOWN,
+        action=ACTION_REPORT_ONLY,
+        requires=(),
+        never_rerun=False,
+        blocks_new_worker=False,
+        resumes_single_unit=True,
+        reason="no failure kind and no unit state were recorded, so no cause-specific repair is claimed",
+    ),
+)
+
+_ROWS_BY_CAUSE: dict[str, RecoveryRow] = {row.cause: row for row in RECOVERY_ROWS}
+
+# Vocabulary members that are the same cause under a different name. Both
+# vocabularies are aliased here rather than renamed at the producer, because
+# each one is right for its own surface: `limit_shaped` describes the output
+# shape the dispatcher matched, `account_limit` describes the state the work is
+# in, and the recovery is the same either way.
+RECOVERY_CAUSE_ALIASES: dict[str, str] = {
+    # `failure_kind` spellings (dispatch_failure_recovery).
+    "auth_shaped": CAUSE_AUTH_INVALID,
+    "limit_shaped": CAUSE_ACCOUNT_LIMIT,
+    # `unit_state` spellings (unit_execution_state).
+    UNIT_STATE_PERMISSION_BLOCKED: CAUSE_PERMISSION_BLOCKED,
+    UNIT_STATE_ACCOUNT_LIMIT: CAUSE_ACCOUNT_LIMIT,
+    UNIT_STATE_DATA_MISSING: CAUSE_DATA_MISSING,
+    UNIT_STATE_PROGRESS_STALLED: CAUSE_PROGRESS_STALLED,
+    UNIT_STATE_AWAITING_INPUT: CAUSE_AWAITING_INPUT,
+}
+
+# A workspace preflight refusal splits two ways, and `workspace_preflight` owns
+# which — `workspace_preflight_unit_state` is the same function that stamps the
+# unit's state, so the routing here and the state on the envelope cannot drift.
+# Absent or unreadable, the refusal is read as a file/index denial: that is what
+# a preflight refusal mostly is, and it is the more conservative of the two — it
+# blocks a new worker, where the objects row would have let one start.
+_WORKSPACE_BLOCKED_DEFAULT_CAUSE = CAUSE_PERMISSION_BLOCKED
+
+
+def recovery_row_for(cause: str) -> RecoveryRow | None:
+    """The row for one cause or vocabulary member, or None when it has none."""
+    name = str(cause or "").strip()
+    return _ROWS_BY_CAUSE.get(RECOVERY_CAUSE_ALIASES.get(name, name))
+
+
+def has_recovery_row(name: str) -> bool:
+    """Whether one vocabulary member resolves to a row. The derived gate's question.
+
+    `workspace_blocked` answers True through `resolve_cause` rather than through
+    a row of its own: it is two causes wearing one name, and which one it is
+    depends on the preflight payload, not on the name.
+    """
+    if str(name or "").strip() == FAILURE_KIND_WORKSPACE_BLOCKED:
+        return True
+    return recovery_row_for(name) is not None
+
+
+def resolve_cause(
+    *,
+    failure_kind: str = "",
+    unit_state: str = "",
+    workspace_preflight: Mapping[str, Any] | None = None,
+) -> str:
+    """The canonical cause of one failure, from whichever vocabulary recorded it.
+
+    `unit_state` is consulted first: it describes the WORK, which is the thing
+    a recovery acts on, and it is the vocabulary that can say `progress_stalled`
+    at all. `failure_kind` describes the process and its output tails and
+    answers for everything the state vocabulary has no member for. A unit that
+    carries neither — or carries a member nothing here knows — is `unknown`.
+    """
+    state = str(unit_state or "").strip()
+    if state:
+        row = recovery_row_for(state)
+        if row is not None:
+            return row.cause
+    kind = str(failure_kind or "").strip()
+    if kind == FAILURE_KIND_WORKSPACE_BLOCKED:
+        return _workspace_blocked_cause(workspace_preflight)
+    row = recovery_row_for(kind)
+    if row is not None:
+        return row.cause
+    return CAUSE_UNKNOWN
+
+
+def _workspace_blocked_cause(preflight: Mapping[str, Any] | None) -> str:
+    """Which repair a `workspace_preflight/v1` refusal admits.
+
+    This is the fallback path. A unit the preflight blocked already carries the
+    answer as `unit_state`, and `resolve_cause` reads that first, so this runs
+    only for a record that lost its state or never had one. It asks the
+    preflight's own `workspace_preflight_unit_state` rather than re-deriving the
+    rule, so the routing and the stamped state cannot disagree: a second copy of
+    "which blocking check decides" is how two answers start to drift.
+    """
+    if not isinstance(preflight, Mapping):
+        return _WORKSPACE_BLOCKED_DEFAULT_CAUSE
+    state = workspace_preflight_unit_state(dict(preflight))
+    row = recovery_row_for(state) if state else None
+    return row.cause if row is not None else _WORKSPACE_BLOCKED_DEFAULT_CAUSE
+
+
+def unit_worktree(unit: Mapping[str, Any]) -> str:
+    """The unit's worktree, under whichever of the two names its producer used.
+
+    An in-flight marker spells it `worktree`; a dispatch result envelope spells
+    it `worktree_path`. Both are read because scope matching is the rule that
+    must not miss, and neither producer is this module's to rename.
+    """
+    return str(unit.get("worktree", "") or unit.get("worktree_path", "") or "")
+
+
+def attempt_conditions(unit: Mapping[str, Any]) -> dict[str, str]:
+    """The five fingerprinted conditions plus the account tag, from a unit record.
+
+    A field the producer did not record stays empty rather than being guessed;
+    `conditions_fingerprint` folds empties, so a record carrying four of five
+    still compares against another record carrying the same four.
+    """
+    conditions = {field: str(unit.get(field, "") or "") for field in CONDITION_FIELDS}
+    conditions["worktree"] = unit_worktree(unit)
+    conditions["account_tag"] = str(unit.get("account_tag", "") or "")
+    return conditions
+
+
+def conditions_fingerprint(conditions: Mapping[str, Any] | None) -> str:
+    """A short stable digest of the five conditions that make an attempt itself.
+
+    Empty when the mapping names none of them: a fingerprint over nothing would
+    compare equal to every other fingerprint over nothing, and "the conditions
+    are identical" is exactly the claim that must never be made by accident.
+    Absent fields are folded as empty strings so a caller that records four of
+    the five still gets a comparable digest.
+    """
+    if not isinstance(conditions, Mapping):
+        return ""
+    values = [str(conditions.get(field, "") or "") for field in CONDITION_FIELDS]
+    if not any(values):
+        return ""
+    joined = "\n".join(f"{field}={value}" for field, value in zip(CONDITION_FIELDS, values))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+
+# `resets 6:10pm (Asia/Seoul)` and friends. The literal string the provider
+# wrote is taken and kept; nothing here converts it to a time. A timezone-aware
+# reset instant computed from a provider's prose would be a fabricated
+# observation, and the elapsed answer comes from the cooldown window instead.
+_RESET_TEXT_RE = re.compile(r"\bresets?\s+(?P<text>[^\n\r]{1,60})", re.IGNORECASE)
+_MAX_RESET_TEXT = 60
+
+
+def limit_reset_text(*tails: str) -> str:
+    """The literal reset phrase a limit message carried, or an empty string."""
+    for tail in tails:
+        match = _RESET_TEXT_RE.search(str(tail or ""))
+        if match is None:
+            continue
+        text = match.group("text").strip().rstrip(".,;")
+        if text:
+            return text[:_MAX_RESET_TEXT]
+    return ""
+
+
+def recovery_plan(
+    unit: Mapping[str, Any],
+    *,
+    inflight: Sequence[Mapping[str, Any]] = (),
+    last_attempt: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """The cause-specific recovery for one unit, and whether a rerun is allowed.
+
+    `unit` is the unit record (or result envelope): `unit_id`, `worktree`, and
+    whichever of `failure_kind` / `unit_state` its producer recorded, plus the
+    optional observations a requirement is checked against —
+    `workspace_preflight`, `objects_present`, `credential_repaired`,
+    `binary_present`, `limit_signal`, `reset_elapsed`, and `proposed_attempt`.
+
+    `proposed_attempt` is the conditions the caller intends to re-run under.
+    When it is absent the proposal is taken to BE `last_attempt`, because that
+    is what re-running the same command does — which is why a stall with no
+    stated change is refused rather than waved through.
+    """
+    unit_id = str(unit.get("unit_id", "") or "")
+    live = _live_marker(inflight, unit_id=unit_id, worktree=unit_worktree(unit))
+    if live is not None:
+        row = _ROWS_BY_CAUSE[CAUSE_LIVE_WORKER_PRESENT]
+        return _plan(
+            row=row,
+            unit_id=unit_id,
+            unmet=(),
+            reason=(
+                f"{row.reason}: marker for unit {live.get('unit_id') or 'unknown'} "
+                f"in fanout {live.get('fanout_id') or 'unknown'} started "
+                f"{live.get('started_at') or 'at an unrecorded time'}. Marker presence is not "
+                "liveness; confirm the worker is gone and clear the marker before re-dispatching."
+            ),
+        )
+    cause = resolve_cause(
+        failure_kind=str(unit.get("failure_kind", "") or ""),
+        unit_state=str(unit.get("unit_state", "") or ""),
+        workspace_preflight=unit.get("workspace_preflight")
+        if isinstance(unit.get("workspace_preflight"), Mapping)
+        else None,
+    )
+    row = _ROWS_BY_CAUSE[cause]
+    unmet = tuple(
+        requirement
+        for requirement in row.requires
+        if not _requirement_met(requirement, unit=unit, last_attempt=last_attempt)
+    )
+    reason = row.reason
+    if row.cause == CAUSE_DATA_MISSING:
+        reason = f"{reason} (resume unit {unit_id or 'unknown'} only, never the whole fanout)"
+    if unmet:
+        reason = f"{reason}; not yet shown: {', '.join(unmet)}"
+    return _plan(row=row, unit_id=unit_id, unmet=unmet, reason=reason)
+
+
+def _plan(*, row: RecoveryRow, unit_id: str, unmet: Sequence[str], reason: str) -> dict[str, Any]:
+    allowed = (not row.never_rerun) and not unmet
+    return {
+        "schema_version": RECOVERY_PLAN_SCHEMA_VERSION,
+        "cause": row.cause,
+        "action": row.action,
+        "allowed_rerun": bool(allowed),
+        "requires": list(row.requires),
+        "unmet": list(unmet),
+        "blocks_new_worker": bool(row.blocks_new_worker),
+        "unit_id": unit_id,
+        # The ONE unit to resume, and only once the rerun is actually allowed:
+        # a caller acting on this key must never be handed a unit id it may not
+        # start yet. Empty otherwise, and empty is never "the fanout" -- the
+        # unit this plan is about is always named in `unit_id`.
+        "resume_unit_id": unit_id if (row.resumes_single_unit and allowed) else "",
+        "reason": reason,
+        "claim_boundary": RECOVERY_PLAN_CLAIM_BOUNDARY,
+    }
+
+
+def _live_marker(
+    inflight: Sequence[Mapping[str, Any]], *, unit_id: str, worktree: str
+) -> Mapping[str, Any] | None:
+    """The first present marker occupying this unit's scope, or None.
+
+    Scope is the unit id or the worktree path: two dispatchers racing the same
+    unit and two units pointed at one directory are the same hazard.
+    """
+    for marker in inflight or ():
+        if not isinstance(marker, Mapping):
+            continue
+        if str(marker.get("marker_status", "")) != "present":
+            continue
+        marker_unit = str(marker.get("unit_id", "") or "")
+        marker_worktree = str(marker.get("worktree", "") or "")
+        if unit_id and marker_unit == unit_id:
+            return marker
+        if worktree and marker_worktree == worktree:
+            return marker
+    return None
+
+
+def _requirement_met(
+    requirement: str, *, unit: Mapping[str, Any], last_attempt: Mapping[str, Any] | None
+) -> bool:
+    if requirement == REQUIRE_WORKSPACE_PREFLIGHT_OK:
+        return _preflight_ok(unit.get("workspace_preflight"))
+    if requirement == REQUIRE_ACCOUNT_CHANGED_OR_RESET_ELAPSED:
+        return _account_changed(unit, last_attempt) or _reset_elapsed(unit)
+    if requirement == REQUIRE_OBJECTS_PRESENT:
+        return unit.get("objects_present") is True
+    if requirement == REQUIRE_CONDITIONS_CHANGED:
+        return _conditions_changed(unit, last_attempt)
+    if requirement == REQUIRE_CREDENTIAL_REPAIRED:
+        return unit.get("credential_repaired") is True
+    if requirement == REQUIRE_BINARY_PRESENT:
+        return unit.get("binary_present") is True
+    return False
+
+
+def _preflight_ok(preflight: Any) -> bool:
+    """A preflight counts only when it says so itself: `ok is True`, nothing else.
+
+    `workspace_preflight/v1` has exactly one pass field and it is a boolean, so
+    `is True` rather than a truthiness test — a report whose `ok` arrived as a
+    non-empty string or a 1 is a report this module did not understand, and an
+    unreadable answer must not read as a pass. Absent, unparsed, or a refusal is
+    likewise not one.
+    """
+    return isinstance(preflight, Mapping) and preflight.get("ok") is True
+
+
+def _account_changed(unit: Mapping[str, Any], last_attempt: Mapping[str, Any] | None) -> bool:
+    """Whether the proposed attempt runs under a different account than the limit did.
+
+    Both tags have to be known: an unreadable tag on either side means the
+    account cannot be SHOWN to have changed, and the conservative answer is the
+    one that keeps the operator out of the cooldown.
+    """
+    proposed = _proposed(unit, last_attempt)
+    before = str((last_attempt or {}).get("account_tag", "") or "")
+    after = str(proposed.get("account_tag", "") or "")
+    if not before or not after:
+        return False
+    return before != after
+
+
+def _reset_elapsed(unit: Mapping[str, Any]) -> bool:
+    """Whether the recorded limit window has passed.
+
+    Two sources, both measured rather than parsed: an explicitly observed
+    `reset_elapsed`, and the stored limit signal going stale — the cooldown
+    window `executor_auth_signals` already ages. `reset_text` is displayed
+    beside both and is never one of them.
+    """
+    if unit.get("reset_elapsed") is True:
+        return True
+    signal = unit.get("limit_signal")
+    return isinstance(signal, Mapping) and signal.get("stale") is True
+
+
+def _conditions_changed(unit: Mapping[str, Any], last_attempt: Mapping[str, Any] | None) -> bool:
+    before = conditions_fingerprint(last_attempt)
+    after = conditions_fingerprint(_proposed(unit, last_attempt))
+    if not before or not after:
+        return False
+    return before != after
+
+
+def _proposed(unit: Mapping[str, Any], last_attempt: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    proposed = unit.get("proposed_attempt")
+    if isinstance(proposed, Mapping):
+        return proposed
+    return last_attempt or {}
+
+
+def plan_summary_line(plan: Mapping[str, Any] | None) -> str:
+    """The one line an operator surface prints: the cause and what it requires.
+
+    Empty for an absent plan so a caller can print it unconditionally without
+    emitting a blank claim.
+    """
+    if not isinstance(plan, Mapping) or not plan.get("cause"):
+        return ""
+    requires = plan.get("requires") or []
+    required = ", ".join(str(name) for name in requires) if requires else "nothing further"
+    verdict = "rerun allowed" if plan.get("allowed_rerun") else "rerun not allowed yet"
+    return (
+        f"Cause {plan.get('cause')}: {plan.get('action')} ({verdict}; requires {required}). "
+        f"{plan.get('reason')}"
+    )

--- a/src/coding/dispatch_failure_recovery.py
+++ b/src/coding/dispatch_failure_recovery.py
@@ -39,6 +39,16 @@ Three pieces live here.
    picks one on the operator's behalf; the default mode prints the card and the
    options and changes nothing.
 
+4. **The cause-specific plan**, computed in `cause_recovery` and attached here.
+   The three actions above answer "where else could this run"; the plan answers
+   "may it run again at all, and what has to be true first". They are different
+   questions and the plan is allowed to close an option: a unit whose objects
+   are missing, whose permissions are denied, or whose worker is still alive
+   would hand any new worker the same condition, so retarget and the Hermes
+   lane are listed unavailable with the requirement named, instead of spending
+   a second worker to reproduce the first one's failure. A quota and a stall
+   are not inherited that way, so both lanes stay open for them.
+
 Nothing in this module spawns anything. It classifies, it persists metadata, and
 it renders choices. Acting on a choice is the dispatcher's job.
 """
@@ -52,6 +62,14 @@ from ..executors import executor_label
 from ..system.local_store import locked_json_update, read_json_object_result, utc_now
 from ..system.paths import OmhPaths
 from .executor_auth_signals import LIMIT_SIGNAL_STALE_AFTER_SECONDS, signal_age_seconds
+from .unit_execution_state import UNIT_STUCK_STATES
+
+# `cause_recovery` is imported inside the three functions that use it, never at
+# module level. It needs `FAILURE_KIND_WORKSPACE_BLOCKED` from here, and the
+# closed enum belongs with the classifier that produces it, so the cycle is
+# broken on this side: a module-level import in both directions fails outright
+# when `cause_recovery` is the one imported first. Same deferred-import pattern
+# `spawn_cooldown` already uses for `executor_auth_signals`.
 
 # The closed enum. Every failed unit envelope carries exactly one of these.
 FAILURE_KIND_AUTH_SHAPED = "auth_shaped"
@@ -275,11 +293,19 @@ def build_repair_card(
     failure_kind: str,
     detail: str = "",
     remaining_seconds: int | None = None,
+    plan: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """The deterministic repair card for one recoverable dispatch failure.
 
     Two kinds, two repair steps, one shape: a reader branches on `failure_kind`
     and `reason_code`, never on the prose.
+
+    `plan` is the cause-specific answer from `cause_recovery.recovery_plan`.
+    When it is supplied the card also carries the cause, the required condition,
+    and whether a rerun is allowed yet, so the operator surface that renders the
+    card states the precondition instead of leaving it to be inferred from the
+    two generic repair steps. An absent plan leaves the card byte-identical to
+    what it was before, which is what keeps every existing caller honest.
     """
     card: dict[str, Any] = {
         "schema_version": DISPATCH_REPAIR_CARD_SCHEMA_VERSION,
@@ -330,6 +356,11 @@ def build_repair_card(
         ]
     if remaining_seconds is not None:
         card["cooldown_remaining_seconds"] = int(remaining_seconds)
+    if isinstance(plan, Mapping) and plan.get("cause"):
+        from .cause_recovery import plan_summary_line
+
+        card["recovery_plan"] = dict(plan)
+        card["required_condition"] = plan_summary_line(plan)
     return card
 
 
@@ -387,11 +418,24 @@ def _cooldown(
         f"this machine observed {owner} fail as {failure_kind} "
         f"({signal.get('pattern_label') or 'unlabelled'}) at {signal.get(observed_key) or 'an unrecorded time'}"
     )
+    # Which account it happened under, and the provider's own reset phrase,
+    # when the signal recorded them. This is the line the operator reads on a
+    # refused spawn, and "wait for a window" is a different instruction
+    # depending on whose window it was — an operator who has since switched
+    # accounts is being told to wait for one that is no longer theirs.
+    account_tag = str(signal.get("account_tag", "") or "")
+    reset_text = str(signal.get("reset_text", "") or "")
+    if account_tag:
+        detail = f"{detail} under account {account_tag}"
+    if reset_text:
+        detail = f"{detail}, provider said it resets {reset_text}"
     return {
         "status": status,
         "failure_kind": failure_kind,
         "pattern_label": str(signal.get("pattern_label", "")),
         "observed_at": str(signal.get(observed_key, "")),
+        **({"account_tag": account_tag} if account_tag else {}),
+        **({"reset_text": reset_text} if reset_text else {}),
         "cooldown_remaining_seconds": remaining,
         "reason": (
             f"{detail}; the spawn is refused inside the staleness window. "
@@ -462,20 +506,53 @@ def parse_on_failure(value: str, *, known_owners: Sequence[str] = ()) -> tuple[s
     )
 
 
-def recovery_candidates(units: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
-    """The failed units a recovery choice is offered for, in summary order."""
-    return [
-        {
-            "unit_id": str(entry.get("unit_id", "")),
-            "owner": str(entry.get("owner", "")),
-            "failure_kind": str(entry.get("failure_kind", "")),
-            "status": str(entry.get("status", "")),
-        }
-        for entry in units
-        if isinstance(entry, Mapping)
-        and str(entry.get("failure_kind", "")) in RECOVERABLE_FAILURE_KINDS
-        and not entry.get("process_succeeded")
-    ]
+def recovery_candidates(
+    units: Sequence[Mapping[str, Any]],
+    *,
+    inflight: Sequence[Mapping[str, Any]] = (),
+) -> list[dict[str, Any]]:
+    """The failed units a recovery choice is offered for, in summary order.
+
+    Two admissions, not one. The original: a `failure_kind` the provider's
+    refusal produced, which another owner or a later attempt can answer. The
+    second: a `unit_state` in `UNIT_STUCK_STATES` — a unit whose process is
+    alive or gone but whose WORK is blocked, which is the state the 2026-09-11
+    incident spent thirty-six minutes in without ever being offered a choice.
+    That second admission is what carries a workspace-blocked unit here:
+    `workspace_blocked` is deliberately NOT in `RECOVERABLE_FAILURE_KINDS` — no
+    other owner and no later attempt answers a denied write or an absent object
+    — but the preflight stamps the unit's `unit_state`, and a stuck unit with a
+    cause-specific plan belongs in the interview even when every spawning option
+    in it is closed.
+
+    Each candidate carries its `plan` — the cause-specific answer that decides
+    which of the offered options is real. `inflight` is the marker listing the
+    live-worker rule is checked against; passing none means that rule cannot
+    fire, so a caller that can read markers should.
+    """
+    from .cause_recovery import attempt_conditions, recovery_plan
+
+    candidates: list[dict[str, Any]] = []
+    for entry in units:
+        if not isinstance(entry, Mapping) or entry.get("process_succeeded"):
+            continue
+        failure_kind = str(entry.get("failure_kind", ""))
+        unit_state = str(entry.get("unit_state", ""))
+        if failure_kind not in RECOVERABLE_FAILURE_KINDS and unit_state not in UNIT_STUCK_STATES:
+            continue
+        candidates.append(
+            {
+                "unit_id": str(entry.get("unit_id", "")),
+                "owner": str(entry.get("owner", "")),
+                "failure_kind": failure_kind,
+                "unit_state": unit_state,
+                "status": str(entry.get("status", "")),
+                "plan": recovery_plan(
+                    entry, inflight=inflight, last_attempt=attempt_conditions(entry)
+                ),
+            }
+        )
+    return candidates
 
 
 def retarget_candidates(
@@ -519,6 +596,7 @@ def recovery_options(
     candidate: Mapping[str, Any],
     retargets: Sequence[Mapping[str, Any]],
     hermes_available: bool,
+    plan: Mapping[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """The numbered choices offered for one failed unit, in a fixed order.
 
@@ -526,23 +604,44 @@ def recovery_options(
     `available: false` and the reason, rather than silently dropped: an operator
     who was told there were three ways out should be told which one is closed
     and why.
+
+    `plan` closes the two spawning options — retarget and Hermes — for a cause a
+    new worker would inherit (a live worker on this scope, a permission denial,
+    missing objects, an unanswered question). That is the one place this module
+    refuses something the operator asked for, and it refuses it by listing the
+    option with the requirement rather than by removing it. `plan` defaults to
+    the candidate's own, so a caller that built the candidate through
+    `recovery_candidates` gets the closure without passing anything.
     """
+    plan = plan if plan is not None else candidate.get("plan")
+    blocked_reason = ""
+    if isinstance(plan, Mapping) and plan.get("blocks_new_worker") and not plan.get("allowed_rerun"):
+        blocked_reason = (
+            f"cause {plan.get('cause')}: a new worker on this scope inherits the same condition "
+            f"({plan.get('reason')})"
+        )
     options: list[dict[str, Any]] = [
         {
             "key": "1",
             "choice": CHOICE_RETARGET,
             "title": "Retarget this unit to another coding owner and re-dispatch it now.",
-            "available": bool(retargets),
-            "unavailable_reason": "" if retargets else "no other locally-installed coding owner is offered",
+            "available": bool(retargets) and not blocked_reason,
+            "unavailable_reason": (
+                blocked_reason
+                if blocked_reason
+                else "" if retargets else "no other locally-installed coding owner is offered"
+            ),
             "candidates": [dict(row) for row in retargets],
         },
         {
             "key": "2",
             "choice": CHOICE_HERMES,
             "title": "Re-run this unit through the Hermes subagent lane (separate auth and quota).",
-            "available": bool(hermes_available),
+            "available": bool(hermes_available) and not blocked_reason,
             "unavailable_reason": (
-                ""
+                blocked_reason
+                if blocked_reason
+                else ""
                 if hermes_available
                 else "supply --hermes-model, --hermes-provider, and --hermes-reasoning to offer this lane"
             ),
@@ -579,10 +678,18 @@ def prompt_recovery_choice(
     a value outside the set re-asks; exhausting the attempts (or an input stream
     that ended) falls back to `report`, which changes nothing.
     """
+    from .cause_recovery import plan_summary_line
+
     unit_id = str(candidate.get("unit_id", ""))
     owner = str(candidate.get("owner", ""))
     kind = str(candidate.get("failure_kind", ""))
     write_line(f"Unit {unit_id} failed on {owner} as {kind}. Choose a recovery action:")
+    # The cause and its precondition, before the options: an operator choosing
+    # between three lanes needs to know which of them the cause has already
+    # closed, and why, rather than discovering it on the unavailable line.
+    summary = plan_summary_line(candidate.get("plan"))
+    if summary:
+        write_line(f"  {summary}")
     for option in options:
         suffix = "" if option.get("available") else f"  (unavailable: {option.get('unavailable_reason')})"
         write_line(f"  [{option.get('key')}] {option.get('title')}{suffix}")
@@ -720,7 +827,12 @@ def recovery_decision(
     consent: str = "",
     reason: str = "",
 ) -> dict[str, Any]:
-    """One recorded recovery decision, before any action is carried out."""
+    """One recorded recovery decision, before any action is carried out.
+
+    The candidate's plan is recorded alongside the choice. A decision that says
+    only "the operator chose wait" cannot later be read for whether waiting was
+    the right answer; one that carries the cause and the unmet requirement can.
+    """
     decision: dict[str, Any] = {
         "unit_id": str(candidate.get("unit_id", "")),
         "owner": str(candidate.get("owner", "")),
@@ -728,6 +840,9 @@ def recovery_decision(
         "choice": choice,
         "decided_at": utc_now(),
     }
+    plan = candidate.get("plan")
+    if isinstance(plan, Mapping) and plan.get("cause"):
+        decision["plan"] = dict(plan)
     if target_owner:
         decision["target_owner"] = target_owner
     if consent:

--- a/src/coding/executor_account.py
+++ b/src/coding/executor_account.py
@@ -1,0 +1,156 @@
+"""Which account one coding owner's CLI is logged in as, as a redacted tag.
+
+A limit-shaped failure is an account fact. Without knowing WHICH account hit
+the limit, the only recovery omh can offer is "wait", and the operator who has
+already switched accounts is told to wait for a window that no longer applies
+to them. The 2026-09-11 incident ended on `session limit · resets 6:10pm` with
+nothing recorded about whose session it was.
+
+What is read, and only this:
+
+- `claude-code`: `~/.claude.json` -> `oauthAccount.emailAddress`, falling back
+  to `oauthAccount.accountUuid`, falling back to the presence of the single
+  `claudeAiOauth` slot in `~/.claude/.credentials.json`. That file holds one
+  OAuth slot and nothing else, so its presence says an account is logged in
+  without saying which.
+- `codex`: `~/.codex/auth.json` -> `tokens.account_id`, falling back to whether
+  an `OPENAI_API_KEY` is configured there.
+
+What is never read: any token, key, or secret value. `accessToken`,
+`refreshToken`, `id_token`, and the API key's own value are never opened, never
+hashed, and never persisted. The only inputs to a tag are an email address, an
+account uuid, and an account id — identifiers, not credentials.
+
+Redaction. An email becomes the first two characters of its local part, an
+ellipsis, and its domain (`kh...@gmail.com`): stable across runs, enough for an
+operator to recognise their own account, and not the address itself. Every
+other identifier becomes the first 8 hex characters of its SHA-256, which is
+one-way and stable. The tag is prefixed with the owner's family (`claude:` /
+`codex:`) so two owners' tags can never compare equal by accident.
+
+Two tags being EQUAL is the claim this module is for: it is what says a limit
+was hit under the account that is still configured. Two tags being equal is
+never a claim that the accounts are the same person, and an empty tag is never
+a claim that nobody is logged in -- it says only that nothing readable named an
+account. `cause_recovery` treats an empty tag as "cannot be shown to have
+changed", which is the conservative direction.
+
+Reads only. Nothing here writes to the operator's home directory, and no
+failure propagates: an unreadable, absent, or unparseable file is an empty tag.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Final
+
+ACCOUNT_TAG_CLAIM_BOUNDARY: Final[str] = (
+    "An account tag is a redacted, one-way label for the account a local agent CLI is configured "
+    "with, read from that CLI's own config file. It is not login truth, not entitlement, not "
+    "identity, and no token, key, or secret value is read to produce it. An empty tag means "
+    "nothing readable named an account, never that no account exists."
+)
+
+# Same relative paths `executor_auth_signals` probes for presence markers,
+# restated here rather than imported: that module owns "is a marker present",
+# this one owns "which account", and one of them narrowing its probe must not
+# silently narrow the other.
+_CLAUDE_CONFIG_RELATIVE: Final[str] = ".claude.json"
+_CLAUDE_CREDENTIALS_RELATIVE: Final[str] = ".claude/.credentials.json"
+_CLAUDE_OAUTH_SLOT_KEY: Final[str] = "claudeAiOauth"
+_CODEX_AUTH_RELATIVE: Final[str] = ".codex/auth.json"
+
+# Owners whose account a local config file can name. Everything else -- the
+# runtime profiles, hermes, generic -- has no local credential store to read,
+# and gets an empty tag rather than a guess.
+ACCOUNT_TAG_OWNERS: Final[tuple[str, ...]] = ("claude-code", "codex")
+
+_OWNER_PREFIXES: Final[dict[str, str]] = {"claude-code": "claude", "codex": "codex"}
+
+# Enough of the local part to recognise an account, not enough to be the
+# address. Two characters is the same amount `kh...@gmail.com` shows.
+_EMAIL_VISIBLE_CHARS: Final[int] = 2
+_DIGEST_CHARS: Final[int] = 8
+_MAX_TAG_CHARS: Final[int] = 96
+
+
+def observed_account_tag(owner: str, *, home: Path | None = None) -> str:
+    """The redacted account tag for one owner's CLI, or an empty string.
+
+    Never raises. `home` is resolved at call time rather than defaulted to
+    `Path.home()` in the signature, matching `executor_auth_signals`: a default
+    evaluated at import time would freeze the home directory a test overrides.
+    """
+    normalized = str(owner or "").strip().casefold()
+    if normalized not in ACCOUNT_TAG_OWNERS:
+        return ""
+    base = home if home is not None else Path.home()
+    identifier = (
+        _claude_identifier(base) if normalized == "claude-code" else _codex_identifier(base)
+    )
+    if not identifier:
+        return ""
+    return f"{_OWNER_PREFIXES[normalized]}:{identifier}"[:_MAX_TAG_CHARS]
+
+
+def _claude_identifier(home: Path) -> str:
+    account = _read_json_object(home / _CLAUDE_CONFIG_RELATIVE).get("oauthAccount")
+    if isinstance(account, dict):
+        email = str(account.get("emailAddress", "") or "").strip()
+        if email:
+            return redacted_email(email)
+        uuid = str(account.get("accountUuid", "") or "").strip()
+        if uuid:
+            return short_digest(uuid)
+    # No profile to name the account, but the single OAuth slot either holds a
+    # login or it does not. Recording that much lets a later tag comparison say
+    # "the slot was empty then and is filled now" instead of saying nothing.
+    slot = _read_json_object(home / _CLAUDE_CREDENTIALS_RELATIVE).get(_CLAUDE_OAUTH_SLOT_KEY)
+    return "oauth-slot" if isinstance(slot, dict) and slot else ""
+
+
+def _codex_identifier(home: Path) -> str:
+    payload = _read_json_object(home / _CODEX_AUTH_RELATIVE)
+    tokens = payload.get("tokens")
+    if isinstance(tokens, dict):
+        account_id = str(tokens.get("account_id", "") or "").strip()
+        if account_id:
+            return short_digest(account_id)
+    # An API-key install names no account anywhere in the file. `api-key` is
+    # deliberately NOT derived from the key's value: two different keys tag the
+    # same, which makes "the account changed" unprovable for them, and the
+    # conservative answer -- wait for the reset -- is the one that follows.
+    key = payload.get("OPENAI_API_KEY")
+    return "api-key" if isinstance(key, str) and key.strip() else ""
+
+
+def redacted_email(email: str) -> str:
+    """`khope@gmail.com` -> `kh...@gmail.com`; a value with no `@` is digested."""
+    local, separator, domain = str(email).partition("@")
+    if not separator or not domain:
+        return short_digest(email)
+    visible = local[:_EMAIL_VISIBLE_CHARS]
+    if len(local) <= _EMAIL_VISIBLE_CHARS:
+        return f"{visible}@{domain}"
+    return f"{visible}...@{domain}"
+
+
+def short_digest(value: str) -> str:
+    """The first 8 hex characters of SHA-256: stable, one-way, not the input."""
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:_DIGEST_CHARS]
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    """One JSON object from the operator's home, or an empty dict. Never raises."""
+    try:
+        if not path.is_file():
+            return {}
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, UnicodeDecodeError):
+        # `json.JSONDecodeError` is a `ValueError`. A config file omh cannot
+        # read is an unknown account, never a dispatch failure: this is read on
+        # the spawn path, where raising would abort the work the tag describes.
+        return {}
+    return parsed if isinstance(parsed, dict) else {}

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -43,6 +43,7 @@ from ..workflows.observation_journal import project_run_failure_diagnostic
 from ..system.paths import OmhPaths
 from ._hermes_child_process import terminate_process_group
 from .action_gate import recheck_safety_profile_revision
+from .cause_recovery import attempt_conditions, limit_reset_text, plan_summary_line, recovery_plan
 from .coding_contracts import STRUCTURAL_SEARCH_GUIDANCE
 from .dispatch_failure_recovery import (
     HERMES_LANE_CONSENT,
@@ -131,7 +132,13 @@ from .fanout_review_budget import (
     ReviewDispatchBudget,
     normalized_review_role,
 )
-from .inflight import InflightMarkerError, clear_inflight_marker, write_inflight_marker
+from .executor_account import observed_account_tag
+from .inflight import (
+    InflightMarkerError,
+    clear_inflight_marker,
+    read_inflight_markers,
+    write_inflight_marker,
+)
 from .parallelism_policy import FANOUT_MAX_DEPTH_DEFAULT, FANOUT_RUN_SPAWN_CEILING_DEFAULT
 from .fanout_retry import (
     FANOUT_MAX_RETRIES,
@@ -2617,7 +2624,14 @@ def _run_failure_recovery(
     switched without an explicit choice — an interview answer, or an explicit
     `--on-failure=retarget:<owner>` on the command line.
     """
-    candidates = recovery_candidates([results[unit_id] for unit_id in order if unit_id in results])
+    # Markers for THIS fanout only, read once. They are what the plan's
+    # live-worker rule is checked against: a unit whose scope another session
+    # still occupies must be waited on, never given a second worker. Marker
+    # presence is not liveness and the plan says so when it fires.
+    candidates = recovery_candidates(
+        [results[unit_id] for unit_id in order if unit_id in results],
+        inflight=_recovery_inflight(paths, str(unit_dispatch_kwargs["fanout_id"])),
+    )
     if not candidates:
         return None
     emit = write_line if write_line is not None else _silent_write_line
@@ -2757,6 +2771,12 @@ def _report_recovery_options(
         f"Unit {candidate.get('unit_id')} failed on {candidate.get('owner')} as "
         f"{candidate.get('failure_kind')}. Recovery options (none taken; pass --on-failure to choose):"
     )
+    # Same line the interview prints: the operator reading a non-interactive
+    # report needs the cause and its precondition as much as the one answering
+    # a prompt does.
+    plan_line = plan_summary_line(candidate.get("plan"))
+    if plan_line:
+        emit(f"  {plan_line}")
     for option in options:
         suffix = "" if option.get("available") else f"  (unavailable: {option.get('unavailable_reason')})"
         emit(f"  [{option.get('key')}] {option.get('title')}{suffix}")
@@ -3211,6 +3231,18 @@ def _clear_inflight(paths: OmhPaths, fanout_id: str, unit_id: str) -> None:
         clear_inflight_marker(paths, fanout_id, unit_id)
     except (InflightMarkerError, OSError):
         return
+
+
+def _recovery_inflight(paths: OmhPaths, fanout_id: str) -> list[dict[str, Any]]:
+    """Markers for one fanout, for the recovery plan's live-worker rule.
+
+    `read_inflight_markers` already never raises and skips what it cannot
+    parse, so the empty list here means only "no marker was listed" — which the
+    plan reads as "no live worker was observed", never as "the scope is free".
+    """
+    if not fanout_id:
+        return []
+    return read_inflight_markers(paths, fanout_id=fanout_id)
 
 
 DISPATCH_MODEL_PREFERENCE_SCHEMA_VERSION = "omh_dispatch_model_preferences/v1"
@@ -4058,6 +4090,14 @@ def _dispatch_unit(
     stdout_text = ""
     exit_code = 1
     owner_host = omo_runtime_host() or "" if owner == "omo-runtime" else ""
+    # Which account this owner's CLI is configured as, read once here from that
+    # CLI's own config file and redacted on the way out. Read at spawn rather
+    # than at failure time because the failure is what makes it interesting and
+    # by then the operator may already have switched: without the tag recorded
+    # beside the limit, "wait for the reset" is the only recovery omh can offer,
+    # including to the operator for whom that window no longer applies. No
+    # token or key is read, and an unreadable file is an empty tag.
+    account_tag = observed_account_tag(owner)
     unit_title = str(unit.get("title") or unit.get("unit_id", unit_id))
     # Written BEFORE the spawn and cleared in `finally`. This call blocks for
     # the whole unit, so the dispatching process cannot report on itself; the
@@ -4409,7 +4449,18 @@ def _dispatch_unit(
             paths, owner, run_ref=run_ref, unit_id=unit_id, pattern_label=auth_label
         )
     elif limit_label:
-        _record_limit_signal(paths, owner, run_ref=run_ref, unit_id=unit_id, pattern_label=limit_label)
+        _record_limit_signal(
+            paths,
+            owner,
+            run_ref=run_ref,
+            unit_id=unit_id,
+            pattern_label=limit_label,
+            account_tag=account_tag,
+            # The literal reset phrase the provider wrote ("resets 6:10pm
+            # (Asia/Seoul)"), carried for display only. Nothing converts it to
+            # an instant; the elapsed answer stays the cooldown window's.
+            reset_text=limit_reset_text(output_tail, stderr_tail),
+        )
     elif exit_code == 0:
         # A successful dispatch to this executor is the freshest evidence the
         # provider is serving it again; a stale limit or auth signal must not
@@ -4601,6 +4652,11 @@ def _dispatch_unit(
         _record_capacity(paths, unit, result['capacity'])
     result['worktree_created'] = bool(worktree_record.get('created'))
     result['worktree_reused'] = bool(worktree_record.get('reused'))
+    if account_tag:
+        # Only when observed. An absent key is "no account was readable"; an
+        # empty string recorded as a value would compare equal to the next
+        # unreadable one and make an account switch look like no switch at all.
+        result["account_tag"] = account_tag
     if owner_host:
         result["owner_host"] = owner_host
     result['attempt_id'] = attempt_id
@@ -4637,6 +4693,11 @@ def _dispatch_unit(
             owner=owner,
             failure_kind=failure_kind,
             detail=f"unit {unit_id} exited {exit_code} on {owner} with a {failure_kind} output shape",
+            # The cause-specific precondition, computed from this envelope. No
+            # in-flight markers are consulted: this unit's own marker is being
+            # cleared in the `finally` above, so a live-worker verdict here
+            # would be about a worker that is on its way out.
+            plan=recovery_plan(result, last_attempt=attempt_conditions(result)),
         )
     if retry_decisions:
         # Only when something actually failed once: a unit that succeeded on
@@ -5472,7 +5533,25 @@ def _limit_shaped_label(output_tail: str, stderr_tail: str) -> str:
     return ""
 
 
-def _record_limit_signal(paths: OmhPaths, owner: str, *, run_ref: str, unit_id: str, pattern_label: str) -> None:
+def _record_limit_signal(
+    paths: OmhPaths,
+    owner: str,
+    *,
+    run_ref: str,
+    unit_id: str,
+    pattern_label: str,
+    account_tag: str = "",
+    reset_text: str = "",
+) -> None:
+    """Persist one owner's limit observation, with the account it happened under.
+
+    `account_tag` and `reset_text` are written only when they were observed: an
+    empty tag is "nothing readable named an account", and recording it as a
+    value would let a later comparison read two unknowns as the same account.
+    `last_limit_signal_for_profile` copies every stored key, so both reach the
+    readiness advisory without a second reader.
+    """
+
     def _update(state: dict[str, Any]) -> dict[str, Any]:
         state["schema_version"] = EXECUTOR_LIMIT_SIGNALS_SCHEMA_VERSION
         profiles = state.setdefault("profiles", {})
@@ -5481,6 +5560,8 @@ def _record_limit_signal(paths: OmhPaths, owner: str, *, run_ref: str, unit_id: 
             "run_ref": run_ref,
             "unit_id": unit_id,
             "pattern_label": pattern_label,
+            **({"account_tag": account_tag} if account_tag else {}),
+            **({"reset_text": reset_text} if reset_text else {}),
         }
         state["claim_boundary"] = EXECUTOR_LIMIT_SIGNALS_CLAIM_BOUNDARY
         return state

--- a/tests/test_cause_recovery.py
+++ b/tests/test_cause_recovery.py
@@ -1,0 +1,588 @@
+"""The recovery must match the cause, and every cause must have one.
+
+One test per row of `RECOVERY_ROWS`, plus the three rules that cut across the
+table: a live worker forbids a rerun whatever the cause, identical conditions
+forbid a stall rerun, and a limit under the same account inside the cooldown is
+not a rerun the operator should be offered.
+
+The last class is the derived gate. It re-reads both vocabularies from source --
+every `FAILURE_KIND_*` constant assigned in `src/coding/dispatch_failure_recovery.py`
+and every member of `UNIT_STUCK_STATES` -- and fails naming the member that has
+no row. It is deliberately NOT a frozen list of expected members: adding a
+failure kind or a stuck state stays a one-line change plus its row, which is the
+"catch the class without freezing the codebase" shape. The constants are read as
+an AST rather than imported so that a kind added by a sibling branch is caught
+the moment it is written down, whether or not anything has imported it yet.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.cause_recovery import (  # noqa: E402
+    ACTION_ANSWER_OR_CANCEL,
+    ACTION_CHECK_ACCOUNT_THEN_SWITCH_IF_ALLOWED,
+    ACTION_INSTALL_BINARY_THEN_REDISPATCH,
+    ACTION_REAUTHENTICATE_THEN_REDISPATCH,
+    ACTION_REPAIR_PERMISSIONS_THEN_REPROBE,
+    ACTION_REPORT_ONLY,
+    ACTION_REPORT_OR_CHOOSE_RECOVERY,
+    ACTION_RERUN_WITH_CHANGED_CONDITIONS_OR_CHECKPOINT,
+    ACTION_SUPPLEMENT_OBJECTS_THEN_RESUME_UNIT,
+    ACTION_WAIT_FOR_LIVE_WORKER,
+    CAUSE_ACCOUNT_LIMIT,
+    CAUSE_AWAITING_INPUT,
+    CAUSE_CRASH,
+    CAUSE_DATA_MISSING,
+    CAUSE_LIVE_WORKER_PRESENT,
+    CAUSE_PERMISSION_BLOCKED,
+    CAUSE_PROGRESS_STALLED,
+    CAUSE_TIMEOUT,
+    CAUSE_UNKNOWN,
+    RECOVERY_PLAN_SCHEMA_VERSION,
+    REQUIRE_ACCOUNT_CHANGED_OR_RESET_ELAPSED,
+    REQUIRE_CONDITIONS_CHANGED,
+    REQUIRE_OBJECTS_PRESENT,
+    REQUIRE_WORKSPACE_PREFLIGHT_OK,
+    attempt_conditions,
+    conditions_fingerprint,
+    has_recovery_row,
+    limit_reset_text,
+    plan_summary_line,
+    recovery_plan,
+    resolve_cause,
+)
+from omh.coding.dispatch_failure_recovery import (  # noqa: E402
+    CHOICE_HERMES,
+    CHOICE_RETARGET,
+    CHOICE_WAIT,
+    FAILURE_KIND_WORKSPACE_BLOCKED,
+    recovery_candidates,
+    recovery_decision,
+    recovery_options,
+    spawn_cooldown,
+)
+from omh.coding.fanout_dispatch import EXECUTOR_LIMIT_SIGNALS_SCHEMA_VERSION  # noqa: E402
+from omh.coding.workspace_preflight import (  # noqa: E402
+    CHECK_CASE_COLLISION,
+    CHECK_FILE_WRITE,
+    CHECK_GIT_INDEX_WRITE,
+    CHECK_OBJECTS_PRESENT,
+    workspace_preflight_unit_state,
+)
+from omh.coding.unit_execution_state import UNIT_STUCK_STATES  # noqa: E402
+from omh.system.local_store import atomic_write_json, utc_now  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FAILURE_KIND_SOURCE = REPO_ROOT / "src" / "coding" / "dispatch_failure_recovery.py"
+
+LAST = {
+    "owner": "codex",
+    "model": "gpt-6-astra",
+    "prompt_sha256": "abc123",
+    "worktree": "/tmp/wt-core",
+    "permissions": "acceptEdits",
+    "account_tag": "codex:11aa22bb",
+}
+
+
+def live_marker(**overrides: object) -> dict[str, object]:
+    marker = {
+        "marker_status": "present",
+        "fanout_id": "fan-1",
+        "unit_id": "core",
+        "worktree": "/tmp/wt-core",
+        "started_at": "2026-09-11T04:00:00Z",
+    }
+    marker.update(overrides)
+    return marker
+
+
+class RowPermissionBlockedTests(unittest.TestCase):
+    def test_a_permission_denial_repairs_permissions_and_reprobes(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "unit_state": "permission_blocked"})
+        self.assertEqual(plan["cause"], CAUSE_PERMISSION_BLOCKED)
+        self.assertEqual(plan["action"], ACTION_REPAIR_PERMISSIONS_THEN_REPROBE)
+        self.assertEqual(plan["requires"], [REQUIRE_WORKSPACE_PREFLIGHT_OK])
+        self.assertFalse(plan["allowed_rerun"])
+        self.assertEqual(plan["schema_version"], RECOVERY_PLAN_SCHEMA_VERSION)
+
+    def test_a_fresh_passing_preflight_is_what_allows_the_rerun(self) -> None:
+        plan = recovery_plan(
+            {
+                "unit_id": "core",
+                "unit_state": "permission_blocked",
+                "workspace_preflight": {"ok": True},
+            }
+        )
+        self.assertTrue(plan["allowed_rerun"])
+        self.assertEqual(plan["resume_unit_id"], "core")
+
+    def test_a_failing_preflight_is_not_a_pass(self) -> None:
+        plan = recovery_plan(
+            {
+                "unit_id": "core",
+                "unit_state": "permission_blocked",
+                "workspace_preflight": {"ok": False, "blocking": [CHECK_FILE_WRITE]},
+            }
+        )
+        self.assertFalse(plan["allowed_rerun"])
+        self.assertEqual(plan["unmet"], [REQUIRE_WORKSPACE_PREFLIGHT_OK])
+
+    def test_only_a_boolean_true_reads_as_a_pass(self) -> None:
+        """An `ok` this module did not understand must never read as a pass."""
+        for value in ("ok", 1, "true", None):
+            with self.subTest(ok=value):
+                plan = recovery_plan(
+                    {
+                        "unit_id": "core",
+                        "unit_state": "permission_blocked",
+                        "workspace_preflight": {"ok": value},
+                    }
+                )
+                self.assertFalse(plan["allowed_rerun"])
+
+    def test_workspace_blocked_defaults_to_the_permission_row(self) -> None:
+        self.assertEqual(
+            resolve_cause(failure_kind=FAILURE_KIND_WORKSPACE_BLOCKED), CAUSE_PERMISSION_BLOCKED
+        )
+
+    def test_a_filesystem_block_takes_the_permission_row(self) -> None:
+        """Only the FIRST blocking check decides; the preflight runs in dependency order."""
+        for first in (CHECK_FILE_WRITE, CHECK_GIT_INDEX_WRITE, CHECK_CASE_COLLISION):
+            with self.subTest(first=first):
+                self.assertEqual(
+                    resolve_cause(
+                        failure_kind=FAILURE_KIND_WORKSPACE_BLOCKED,
+                        workspace_preflight={
+                            "ok": False,
+                            "blocking": [first, CHECK_OBJECTS_PRESENT],
+                        },
+                    ),
+                    CAUSE_PERMISSION_BLOCKED,
+                )
+
+    def test_the_routing_agrees_with_the_preflights_own_state_for_every_check(self) -> None:
+        """The table and the stamp call one function; nothing may route them apart."""
+        for check in (
+            CHECK_FILE_WRITE,
+            CHECK_GIT_INDEX_WRITE,
+            CHECK_OBJECTS_PRESENT,
+            CHECK_CASE_COLLISION,
+        ):
+            with self.subTest(check=check):
+                report = {"ok": False, "blocking": [check]}
+                self.assertEqual(
+                    resolve_cause(
+                        failure_kind=FAILURE_KIND_WORKSPACE_BLOCKED, workspace_preflight=report
+                    ),
+                    resolve_cause(unit_state=workspace_preflight_unit_state(report)),
+                )
+
+
+class RowAccountLimitTests(unittest.TestCase):
+    def test_a_limit_checks_the_account_before_anything_else(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "failure_kind": "limit_shaped"}, last_attempt=LAST)
+        self.assertEqual(plan["cause"], CAUSE_ACCOUNT_LIMIT)
+        self.assertEqual(plan["action"], ACTION_CHECK_ACCOUNT_THEN_SWITCH_IF_ALLOWED)
+        self.assertEqual(plan["requires"], [REQUIRE_ACCOUNT_CHANGED_OR_RESET_ELAPSED])
+
+    def test_the_same_account_inside_the_cooldown_is_not_a_rerun(self) -> None:
+        unit = {
+            "unit_id": "core",
+            "failure_kind": "limit_shaped",
+            "account_tag": LAST["account_tag"],
+            "limit_signal": {"stale": False, "reset_text": "6:10pm (Asia/Seoul)"},
+            "proposed_attempt": dict(LAST),
+        }
+        plan = recovery_plan(unit, last_attempt=LAST)
+        self.assertFalse(plan["allowed_rerun"])
+        self.assertIn(REQUIRE_ACCOUNT_CHANGED_OR_RESET_ELAPSED, plan["unmet"])
+
+    def test_a_different_account_tag_allows_the_rerun(self) -> None:
+        unit = {
+            "unit_id": "core",
+            "failure_kind": "limit_shaped",
+            "limit_signal": {"stale": False},
+            "proposed_attempt": {**LAST, "account_tag": "codex:99ff88ee"},
+        }
+        plan = recovery_plan(unit, last_attempt=LAST)
+        self.assertTrue(plan["allowed_rerun"])
+
+    def test_an_unreadable_tag_on_either_side_cannot_show_a_change(self) -> None:
+        unit = {
+            "unit_id": "core",
+            "failure_kind": "limit_shaped",
+            "limit_signal": {"stale": False},
+            "proposed_attempt": {**LAST, "account_tag": ""},
+        }
+        self.assertFalse(recovery_plan(unit, last_attempt=LAST)["allowed_rerun"])
+
+    def test_an_elapsed_window_allows_the_rerun_under_the_same_account(self) -> None:
+        unit = {
+            "unit_id": "core",
+            "failure_kind": "limit_shaped",
+            "limit_signal": {"stale": True},
+            "proposed_attempt": dict(LAST),
+        }
+        self.assertTrue(recovery_plan(unit, last_attempt=LAST)["allowed_rerun"])
+
+    def test_reset_text_is_taken_literally_and_never_parsed(self) -> None:
+        self.assertEqual(
+            limit_reset_text("You've hit your session limit · resets 6:10pm (Asia/Seoul)"),
+            "6:10pm (Asia/Seoul)",
+        )
+        self.assertEqual(limit_reset_text("rate limited", ""), "")
+        # A word that merely ends in "resets" is not the provider saying so.
+        self.assertEqual(limit_reset_text("loaded 4 presets from disk"), "")
+
+
+class RowDataMissingTests(unittest.TestCase):
+    def test_missing_objects_are_supplemented_then_one_unit_resumes(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "unit_state": "data_missing"})
+        self.assertEqual(plan["cause"], CAUSE_DATA_MISSING)
+        self.assertEqual(plan["action"], ACTION_SUPPLEMENT_OBJECTS_THEN_RESUME_UNIT)
+        self.assertEqual(plan["requires"], [REQUIRE_OBJECTS_PRESENT])
+        self.assertFalse(plan["allowed_rerun"])
+        self.assertIn("resume unit core only, never the whole fanout", plan["reason"])
+
+    def test_verified_objects_name_the_one_unit_to_resume(self) -> None:
+        plan = recovery_plan(
+            {"unit_id": "core", "unit_state": "data_missing", "objects_present": True}
+        )
+        self.assertTrue(plan["allowed_rerun"])
+        self.assertEqual(plan["resume_unit_id"], "core")
+
+    def test_a_workspace_preflight_blocking_on_objects_takes_the_objects_row(self) -> None:
+        plan = recovery_plan(
+            {
+                "unit_id": "core",
+                "failure_kind": FAILURE_KIND_WORKSPACE_BLOCKED,
+                "workspace_preflight": {"ok": False, "blocking": [CHECK_OBJECTS_PRESENT]},
+            }
+        )
+        self.assertEqual(plan["cause"], CAUSE_DATA_MISSING)
+
+    def test_the_unit_state_the_preflight_stamped_wins_over_the_payload(self) -> None:
+        """The producer's own verdict is read first; deriving it again is the fallback."""
+        plan = recovery_plan(
+            {
+                "unit_id": "core",
+                "failure_kind": FAILURE_KIND_WORKSPACE_BLOCKED,
+                "unit_state": "data_missing",
+                "workspace_preflight": {"ok": False, "blocking": []},
+            }
+        )
+        self.assertEqual(plan["cause"], CAUSE_DATA_MISSING)
+
+
+class RowProgressStalledTests(unittest.TestCase):
+    def test_identical_conditions_forbid_the_rerun(self) -> None:
+        unit = {"unit_id": "core", "unit_state": "progress_stalled", "proposed_attempt": dict(LAST)}
+        plan = recovery_plan(unit, last_attempt=LAST)
+        self.assertEqual(plan["cause"], CAUSE_PROGRESS_STALLED)
+        self.assertEqual(plan["action"], ACTION_RERUN_WITH_CHANGED_CONDITIONS_OR_CHECKPOINT)
+        self.assertEqual(plan["requires"], [REQUIRE_CONDITIONS_CHANGED])
+        self.assertFalse(plan["allowed_rerun"])
+
+    def test_a_changed_model_is_a_changed_condition(self) -> None:
+        unit = {
+            "unit_id": "core",
+            "unit_state": "progress_stalled",
+            "proposed_attempt": {**LAST, "model": "claude-opus-5"},
+        }
+        self.assertTrue(recovery_plan(unit, last_attempt=LAST)["allowed_rerun"])
+
+    def test_no_stated_proposal_is_the_same_attempt(self) -> None:
+        """Re-running the same command is the default, so it must be the default answer."""
+        plan = recovery_plan({"unit_id": "core", "unit_state": "progress_stalled"}, last_attempt=LAST)
+        self.assertFalse(plan["allowed_rerun"])
+
+    def test_a_fingerprint_over_nothing_never_compares_equal(self) -> None:
+        self.assertEqual(conditions_fingerprint({}), "")
+        self.assertEqual(conditions_fingerprint(None), "")
+        self.assertNotEqual(conditions_fingerprint(LAST), "")
+
+    def test_attempt_conditions_reads_either_worktree_spelling(self) -> None:
+        envelope = {"owner": "codex", "model": "m", "worktree_path": "/tmp/wt"}
+        self.assertEqual(attempt_conditions(envelope)["worktree"], "/tmp/wt")
+
+
+class RowAwaitingInputTests(unittest.TestCase):
+    def test_a_question_is_answered_or_cancelled_never_re_run(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "unit_state": "awaiting_input"})
+        self.assertEqual(plan["cause"], CAUSE_AWAITING_INPUT)
+        self.assertEqual(plan["action"], ACTION_ANSWER_OR_CANCEL)
+        self.assertEqual(plan["requires"], [])
+        self.assertFalse(plan["allowed_rerun"])
+        self.assertEqual(plan["resume_unit_id"], "")
+
+
+class RowMappedThroughTests(unittest.TestCase):
+    def test_timeout_and_crash_keep_the_existing_choice(self) -> None:
+        for kind, cause in (("timeout", CAUSE_TIMEOUT), ("crash", CAUSE_CRASH)):
+            with self.subTest(kind=kind):
+                plan = recovery_plan({"unit_id": "core", "failure_kind": kind})
+                self.assertEqual(plan["cause"], cause)
+                self.assertEqual(plan["action"], ACTION_REPORT_OR_CHOOSE_RECOVERY)
+                self.assertEqual(plan["requires"], [])
+                self.assertTrue(plan["allowed_rerun"])
+                self.assertFalse(plan["blocks_new_worker"])
+
+    def test_auth_requires_the_credential_to_be_repaired_first(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "failure_kind": "auth_shaped"})
+        self.assertEqual(plan["action"], ACTION_REAUTHENTICATE_THEN_REDISPATCH)
+        self.assertFalse(plan["allowed_rerun"])
+        # Another owner carries its own credential, so the lane stays open.
+        self.assertFalse(plan["blocks_new_worker"])
+        self.assertTrue(
+            recovery_plan({"unit_id": "core", "failure_kind": "auth_shaped", "credential_repaired": True})[
+                "allowed_rerun"
+            ]
+        )
+
+    def test_a_missing_binary_requires_the_binary(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "failure_kind": "binary_missing"})
+        self.assertEqual(plan["action"], ACTION_INSTALL_BINARY_THEN_REDISPATCH)
+        self.assertFalse(plan["allowed_rerun"])
+
+    def test_nothing_recorded_claims_no_cause_specific_repair(self) -> None:
+        plan = recovery_plan({"unit_id": "core"})
+        self.assertEqual(plan["cause"], CAUSE_UNKNOWN)
+        self.assertEqual(plan["action"], ACTION_REPORT_ONLY)
+
+
+class LiveWorkerRuleTests(unittest.TestCase):
+    """The rule that wins over every row: never a second worker on a live scope."""
+
+    def test_a_live_marker_on_the_same_unit_forbids_every_cause(self) -> None:
+        for kind in ("limit_shaped", "auth_shaped", "timeout", "crash", "binary_missing"):
+            with self.subTest(kind=kind):
+                plan = recovery_plan(
+                    {"unit_id": "core", "failure_kind": kind, "credential_repaired": True},
+                    inflight=[live_marker()],
+                )
+                self.assertEqual(plan["cause"], CAUSE_LIVE_WORKER_PRESENT)
+                self.assertEqual(plan["action"], ACTION_WAIT_FOR_LIVE_WORKER)
+                self.assertFalse(plan["allowed_rerun"])
+
+    def test_it_beats_a_cause_whose_requirements_are_all_met(self) -> None:
+        unit = {
+            "unit_id": "core",
+            "unit_state": "data_missing",
+            "objects_present": True,
+        }
+        plan = recovery_plan(unit, inflight=[live_marker()])
+        self.assertEqual(plan["cause"], CAUSE_LIVE_WORKER_PRESENT)
+
+    def test_the_reason_names_the_marker_and_refuses_the_liveness_claim(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "failure_kind": "crash"}, inflight=[live_marker()])
+        self.assertIn("unit core", plan["reason"])
+        self.assertIn("fanout fan-1", plan["reason"])
+        self.assertIn("2026-09-11T04:00:00Z", plan["reason"])
+        self.assertIn("presence is not liveness", plan["reason"])
+
+    def test_a_different_unit_sharing_the_worktree_is_the_same_scope(self) -> None:
+        plan = recovery_plan(
+            {"unit_id": "other", "worktree_path": "/tmp/wt-core", "failure_kind": "crash"},
+            inflight=[live_marker()],
+        )
+        self.assertEqual(plan["cause"], CAUSE_LIVE_WORKER_PRESENT)
+
+    def test_an_absent_or_unreadable_marker_is_not_a_live_worker(self) -> None:
+        for status in ("absent", "unreadable"):
+            with self.subTest(status=status):
+                plan = recovery_plan(
+                    {"unit_id": "core", "failure_kind": "crash"},
+                    inflight=[live_marker(marker_status=status)],
+                )
+                self.assertEqual(plan["cause"], CAUSE_CRASH)
+
+    def test_an_unrelated_scope_does_not_block(self) -> None:
+        plan = recovery_plan(
+            {"unit_id": "core", "worktree_path": "/tmp/wt-core", "failure_kind": "crash"},
+            inflight=[live_marker(unit_id="docs", worktree="/tmp/wt-docs")],
+        )
+        self.assertEqual(plan["cause"], CAUSE_CRASH)
+
+
+class RecoveryOptionWiringTests(unittest.TestCase):
+    """The plan reaches the offered options, the decision record, and the print."""
+
+    def _options(self, plan: dict[str, object]) -> list[dict[str, object]]:
+        return recovery_options(
+            candidate={"unit_id": "core", "owner": "codex", "failure_kind": "limit_shaped"},
+            retargets=[{"profile": "claude-code"}],
+            hermes_available=True,
+            plan=plan,
+        )
+
+    def test_an_inherited_cause_closes_both_spawning_lanes(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "unit_state": "data_missing"})
+        options = self._options(plan)
+        by_choice = {option["choice"]: option for option in options}
+        self.assertFalse(by_choice[CHOICE_RETARGET]["available"])
+        self.assertFalse(by_choice[CHOICE_HERMES]["available"])
+        self.assertIn("data_missing", by_choice[CHOICE_RETARGET]["unavailable_reason"])
+        # Waiting is always carryable: it spawns nothing.
+        self.assertTrue(by_choice[CHOICE_WAIT]["available"])
+
+    def test_a_quota_leaves_both_lanes_open(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "failure_kind": "limit_shaped"}, last_attempt=LAST)
+        by_choice = {option["choice"]: option for option in self._options(plan)}
+        self.assertFalse(plan["allowed_rerun"])
+        self.assertTrue(by_choice[CHOICE_RETARGET]["available"])
+        self.assertTrue(by_choice[CHOICE_HERMES]["available"])
+
+    def test_candidates_carry_their_plan_and_admit_stuck_units(self) -> None:
+        units = [
+            {"unit_id": "a", "owner": "codex", "failure_kind": "limit_shaped"},
+            {"unit_id": "b", "owner": "codex", "unit_state": "progress_stalled"},
+            {"unit_id": "c", "owner": "codex", "failure_kind": "crash"},
+        ]
+        rows = recovery_candidates(units)
+        self.assertEqual([row["unit_id"] for row in rows], ["a", "b"])
+        self.assertEqual(rows[1]["plan"]["cause"], CAUSE_PROGRESS_STALLED)
+
+    def test_a_live_marker_reaches_the_candidate_through_recovery_candidates(self) -> None:
+        rows = recovery_candidates(
+            [{"unit_id": "core", "owner": "codex", "failure_kind": "limit_shaped"}],
+            inflight=[live_marker()],
+        )
+        self.assertEqual(rows[0]["plan"]["cause"], CAUSE_LIVE_WORKER_PRESENT)
+
+    def test_the_decision_record_carries_the_plan(self) -> None:
+        candidate = recovery_candidates(
+            [{"unit_id": "core", "owner": "codex", "failure_kind": "limit_shaped"}]
+        )[0]
+        decision = recovery_decision(candidate=candidate, choice=CHOICE_WAIT)
+        self.assertEqual(decision["plan"]["cause"], CAUSE_ACCOUNT_LIMIT)
+
+    def test_the_summary_line_states_the_cause_and_the_requirement(self) -> None:
+        plan = recovery_plan({"unit_id": "core", "unit_state": "data_missing"})
+        line = plan_summary_line(plan)
+        self.assertIn(CAUSE_DATA_MISSING, line)
+        self.assertIn(REQUIRE_OBJECTS_PRESENT, line)
+        self.assertIn("rerun not allowed yet", line)
+        self.assertEqual(plan_summary_line(None), "")
+
+
+# An enum member is an identifier-shaped string. `FAILURE_KIND_PRECEDENCE` is a
+# paragraph of prose that happens to share the prefix, and demanding a recovery
+# row for a paragraph would be the gate misfiring rather than catching
+# something. The shape is the discriminator, not a name on an exclusion list: a
+# kind added tomorrow is covered without an edit here, and prose added tomorrow
+# is excluded without one either.
+_KIND_VALUE_RE = re.compile(r"[a-z][a-z0-9_]*")
+
+
+class CooldownAdvisoryTests(unittest.TestCase):
+    """The refused-spawn line names whose window it was, not just that there was one."""
+
+    def _paths(self, tmp: str) -> OmhPaths:
+        root = Path(tmp)
+        return OmhPaths(omh_home=root / ".omh", hermes_home=root / ".hermes")
+
+    def _signal(self, paths: OmhPaths, entry: dict[str, object]) -> None:
+        atomic_write_json(
+            paths.executor_limit_signals_path,
+            {"schema_version": EXECUTOR_LIMIT_SIGNALS_SCHEMA_VERSION, "profiles": {"codex": entry}},
+            private=True,
+        )
+
+    def test_the_account_and_the_reset_phrase_reach_the_refusal(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            self._signal(
+                paths,
+                {
+                    "last_limit_shaped_at": utc_now(),
+                    "pattern_label": "usage_limit",
+                    "account_tag": "codex:11aa22bb",
+                    "reset_text": "6:10pm (Asia/Seoul)",
+                },
+            )
+            cooldown = spawn_cooldown(paths, "codex")
+            self.assertIsNotNone(cooldown)
+            self.assertEqual(cooldown["account_tag"], "codex:11aa22bb")
+            self.assertEqual(cooldown["reset_text"], "6:10pm (Asia/Seoul)")
+            self.assertIn("under account codex:11aa22bb", cooldown["reason"])
+            self.assertIn("resets 6:10pm (Asia/Seoul)", cooldown["reason"])
+
+    def test_an_unrecorded_account_adds_no_key_and_no_prose(self) -> None:
+        with TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            self._signal(paths, {"last_limit_shaped_at": utc_now(), "pattern_label": "usage_limit"})
+            cooldown = spawn_cooldown(paths, "codex")
+            self.assertIsNotNone(cooldown)
+            self.assertNotIn("account_tag", cooldown)
+            self.assertNotIn("reset_text", cooldown)
+            self.assertNotIn("under account", cooldown["reason"])
+
+
+def _declared_failure_kinds() -> dict[str, str]:
+    """Every `FAILURE_KIND_*` enum constant assigned in the classifier module.
+
+    Read from source rather than imported so a kind a sibling branch has just
+    written down is covered before anything imports it.
+    """
+    tree = ast.parse(FAILURE_KIND_SOURCE.read_text(encoding="utf-8"), filename=str(FAILURE_KIND_SOURCE))
+    found: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+            continue
+        value = node.value.value
+        if not isinstance(value, str) or not _KIND_VALUE_RE.fullmatch(value):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id.startswith("FAILURE_KIND_"):
+                found[target.id] = value
+    return found
+
+
+class RecoveryTableCoverageTests(unittest.TestCase):
+    """The derived gate: every vocabulary member has a row, or this names it."""
+
+    def test_every_failure_kind_constant_has_a_row(self) -> None:
+        declared = _declared_failure_kinds()
+        # A guard on the gate itself: an AST walk that silently found nothing
+        # would pass every assertion below.
+        self.assertIn("FAILURE_KIND_CRASH", declared)
+        missing = sorted(
+            f"{name} ({value})" for name, value in declared.items() if not has_recovery_row(value)
+        )
+        self.assertEqual(
+            missing,
+            [],
+            "failure kinds with no row in RECOVERY_ROWS: "
+            f"{', '.join(missing)}. Add a row (and its alias, if the cause is already named) "
+            "in src/coding/cause_recovery.py.",
+        )
+
+    def test_every_stuck_state_has_a_row(self) -> None:
+        self.assertTrue(UNIT_STUCK_STATES)
+        missing = sorted(state for state in UNIT_STUCK_STATES if not has_recovery_row(state))
+        self.assertEqual(
+            missing,
+            [],
+            "stuck unit states with no row in RECOVERY_ROWS: "
+            f"{', '.join(missing)}. Add a row or an alias in src/coding/cause_recovery.py.",
+        )
+
+    def test_the_gate_fails_for_a_member_nothing_covers(self) -> None:
+        """The gate would not be one if it passed for an unknown member."""
+        self.assertFalse(has_recovery_row("some_kind_nobody_wrote_a_row_for"))
+
+
+if __name__ == "__main__":  # pragma: no cover - parity with the suite's modules
+    unittest.main()

--- a/tests/test_executor_account.py
+++ b/tests/test_executor_account.py
@@ -1,0 +1,200 @@
+"""Account tags, read from fake home directories for both readable owners.
+
+Every fixture here writes config files shaped like the real ones into a
+`TemporaryDirectory` that stands in for `~`. Nothing reads the operator's own
+home, and no fixture carries a value shaped like a real credential -- the token
+fields exist only to prove they are NOT what a tag is built from.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.executor_account import (  # noqa: E402
+    ACCOUNT_TAG_CLAIM_BOUNDARY,
+    observed_account_tag,
+    redacted_email,
+    short_digest,
+)
+
+
+# Evaluated once, guarded: `os.geteuid` does not exist on Windows, and a
+# decorator argument is evaluated at class-creation time even when the skip
+# would have fired.
+_POSIX_NON_ROOT = os.name != "nt" and os.geteuid() != 0
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class ClaudeAccountTagTests(unittest.TestCase):
+    def test_the_email_becomes_a_redacted_tag(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(base / ".claude.json", {"oauthAccount": {"emailAddress": "khope@gmail.com"}})
+            self.assertEqual(observed_account_tag("claude-code", home=base), "claude:kh...@gmail.com")
+
+    def test_the_tag_is_stable_across_reads(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(base / ".claude.json", {"oauthAccount": {"emailAddress": "khope@gmail.com"}})
+            first = observed_account_tag("claude-code", home=base)
+            self.assertEqual(first, observed_account_tag("claude-code", home=base))
+
+    def test_two_accounts_do_not_tag_the_same(self) -> None:
+        with TemporaryDirectory() as home_a, TemporaryDirectory() as home_b:
+            write_json(Path(home_a) / ".claude.json", {"oauthAccount": {"emailAddress": "one@work.example"}})
+            write_json(Path(home_b) / ".claude.json", {"oauthAccount": {"emailAddress": "two@work.example"}})
+            self.assertNotEqual(
+                observed_account_tag("claude-code", home=Path(home_a)),
+                observed_account_tag("claude-code", home=Path(home_b)),
+            )
+
+    def test_no_email_falls_back_to_the_account_uuid(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(base / ".claude.json", {"oauthAccount": {"accountUuid": "f7c0-uuid"}})
+            self.assertEqual(
+                observed_account_tag("claude-code", home=base), f"claude:{short_digest('f7c0-uuid')}"
+            )
+
+    def test_no_profile_falls_back_to_the_single_oauth_slot(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(base / ".claude" / ".credentials.json", {"claudeAiOauth": {"expiresAt": 1}})
+            self.assertEqual(observed_account_tag("claude-code", home=base), "claude:oauth-slot")
+
+    def test_an_empty_oauth_slot_names_no_account(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(base / ".claude" / ".credentials.json", {"claudeAiOauth": {}})
+            self.assertEqual(observed_account_tag("claude-code", home=base), "")
+
+    def test_no_token_value_appears_in_the_tag(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(
+                base / ".claude" / ".credentials.json",
+                {"claudeAiOauth": {"accessToken": "not-a-real-token-value", "expiresAt": 1}},
+            )
+            write_json(base / ".claude.json", {"oauthAccount": {"emailAddress": "khope@gmail.com"}})
+            tag = observed_account_tag("claude-code", home=base)
+            self.assertNotIn("not-a-real-token-value", tag)
+            self.assertNotIn(short_digest("not-a-real-token-value"), tag)
+
+
+class CodexAccountTagTests(unittest.TestCase):
+    def test_the_account_id_becomes_a_short_digest(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(
+                base / ".codex" / "auth.json",
+                {
+                    "auth_mode": "chatgpt",
+                    "OPENAI_API_KEY": None,
+                    "tokens": {"id_token": "header.body.sig", "account_id": "acct-42"},
+                },
+            )
+            tag = observed_account_tag("codex", home=base)
+            self.assertEqual(tag, f"codex:{short_digest('acct-42')}")
+            self.assertNotIn("header.body.sig", tag)
+
+    def test_an_api_key_install_tags_as_api_key_without_reading_the_key(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(base / ".codex" / "auth.json", {"OPENAI_API_KEY": "sk-fixture-not-a-key"})
+            tag = observed_account_tag("codex", home=base)
+            self.assertEqual(tag, "codex:api-key")
+            self.assertNotIn("sk-fixture-not-a-key", tag)
+            self.assertNotIn(short_digest("sk-fixture-not-a-key"), tag)
+
+    def test_an_empty_store_names_no_account(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(base / ".codex" / "auth.json", {"auth_mode": "chatgpt", "tokens": {}})
+            self.assertEqual(observed_account_tag("codex", home=base), "")
+
+    def test_the_two_owners_never_tag_the_same(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(base / ".claude.json", {"oauthAccount": {"accountUuid": "shared"}})
+            write_json(base / ".codex" / "auth.json", {"tokens": {"account_id": "shared"}})
+            self.assertNotEqual(
+                observed_account_tag("claude-code", home=base), observed_account_tag("codex", home=base)
+            )
+
+
+class UnreadableAndAbsentTests(unittest.TestCase):
+    def test_a_missing_file_is_an_empty_tag(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            self.assertEqual(observed_account_tag("claude-code", home=base), "")
+            self.assertEqual(observed_account_tag("codex", home=base), "")
+
+    def test_unparseable_json_is_an_empty_tag_and_never_raises(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            (base / ".codex").mkdir(parents=True)
+            (base / ".codex" / "auth.json").write_text("{not json", encoding="utf-8")
+            (base / ".claude.json").write_text("[]", encoding="utf-8")
+            self.assertEqual(observed_account_tag("codex", home=base), "")
+            self.assertEqual(observed_account_tag("claude-code", home=base), "")
+
+    @unittest.skipUnless(
+        _POSIX_NON_ROOT,
+        "needs POSIX permission bits and a non-root euid: Windows does not deny the read and "
+        "root reads a write-only file regardless of its mode",
+    )
+    def test_a_file_that_cannot_be_opened_is_an_empty_tag(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            path = base / ".codex" / "auth.json"
+            write_json(path, {"tokens": {"account_id": "acct-42"}})
+            path.chmod(stat.S_IWUSR)
+            try:
+                self.assertEqual(observed_account_tag("codex", home=base), "")
+            finally:
+                # Restore before the TemporaryDirectory tears the tree down.
+                path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    def test_an_owner_with_no_local_credential_store_is_an_empty_tag(self) -> None:
+        with TemporaryDirectory() as home:
+            base = Path(home)
+            write_json(base / ".claude.json", {"oauthAccount": {"emailAddress": "khope@gmail.com"}})
+            for owner in ("hermes", "omo-runtime", "generic", ""):
+                with self.subTest(owner=owner):
+                    self.assertEqual(observed_account_tag(owner, home=base), "")
+
+
+class RedactionTests(unittest.TestCase):
+    def test_only_two_characters_of_the_local_part_survive(self) -> None:
+        self.assertEqual(redacted_email("khope020602@gmail.com"), "kh...@gmail.com")
+
+    def test_a_short_local_part_is_not_padded_into_a_false_address(self) -> None:
+        self.assertEqual(redacted_email("ab@x.example"), "ab@x.example")
+
+    def test_a_value_that_is_not_an_address_is_digested_instead(self) -> None:
+        self.assertEqual(redacted_email("no-at-sign"), short_digest("no-at-sign"))
+
+    def test_the_digest_is_one_way_and_short(self) -> None:
+        digest = short_digest("acct-42")
+        self.assertEqual(len(digest), 8)
+        self.assertNotIn("acct-42", digest)
+
+    def test_the_claim_boundary_denies_login_truth(self) -> None:
+        self.assertIn("not login truth", ACCOUNT_TAG_CLAIM_BOUNDARY)
+
+
+if __name__ == "__main__":  # pragma: no cover - parity with the suite's modules
+    unittest.main()


### PR DESCRIPTION
## Capability

Dispatch recovery now matches the cause of the failure instead of offering one menu for all of them, and refuses a rerun whose conditions cannot clear what went wrong.

## Motivation

The 2026-09-11 post-mortem (priority D): a permission denial, an account limit, missing git objects and a progress stall each need a different repair. Today `dispatch_failure_recovery` offers retarget / hermes / wait / report for everything, has no notion of a permission block or missing data, does not know that re-running identical conditions reproduces a stall, and does not record which account hit a limit — so the only advice it can give an operator who already switched accounts is "wait" for a window that no longer applies to them.

## Implementation

- `src/coding/cause_recovery.py` — one `RecoveryRow` per cause (`permission_blocked`, `account_limit`, `data_missing`, `progress_stalled`, `awaiting_input`, `auth_invalid`, `binary_missing`, `timeout`, `crash`, `unknown`): the action, what a rerun requires, whether any rerun is a recovery at all, whether the cause is inherited by a new worker, and whether the plan resumes one unit or the fanout. `conditions_fingerprint` is what makes "changed conditions" checkable rather than asserted.
- **A live in-flight marker on the same unit id or worktree outranks every row** (`wait_for_live_worker`, no rerun) — the "never add a second worker to a live scope" rule.
- `workspace_blocked` (from the merged #1489) resolves through `workspace_preflight_unit_state`, the same function that stamps the unit's state, so the routing and the envelope cannot drift; a missing payload defaults to the more conservative permission row.
- `src/coding/executor_account.py` — `observed_account_tag(owner)` reads the CLI's own config for an identifier (email / account uuid / account id) and redacts it one-way (`claude:kh...@gmail.com`, `codex:<8 hex>`). No token, key, or secret value is read, hashed, or persisted. Recorded at spawn time on the unit and in the limit signal, with the provider's reset phrase carried literally (never parsed into an instant).
- `dispatch_failure_recovery.py` wires the plan into candidates / options / decision / repair card; options that the plan forbids are not offered, and the cooldown line names the account and the reset phrase.
- `docs/FANOUT.md` — the cause → action table.

## Verification (observed)

- `PYTHONPATH=tests uv run python -m unittest discover -s tests` → **OK (skipped=3)** on this rebased tree.
- `tests/test_cause_recovery.py` (one test per row, plus: live marker forbids every cause; identical fingerprint forbids the stall rerun and a changed model allows it; same account inside the cooldown refused, different tag allowed; the preflight's own state wins over the payload) and `tests/test_executor_account.py` (both owners, fake homes, unreadable/missing files).
- **The gate**: `test_every_failure_kind_constant_has_a_row` re-derives every `FAILURE_KIND_*` from `dispatch_failure_recovery.py` via AST and `test_every_stuck_state_has_a_row` iterates `UNIT_STUCK_STATES`; each fails naming the member with no row. Adding a new kind or state is not blocked — it is required to say what its recovery is.
- ruff, compileall, `git diff --check`, and all eight `docs … --check` gates clean.

## Risks

- Importing the shared failure-kind constant created a module cycle; it is broken on the classifier's side with deferred imports inside the three using functions, the same pattern `spawn_cooldown` already uses. Import order is covered by the suite.
- No live dispatch was run: the account tag and reset phrase are exercised against fixture home directories and fixture limit signals, not a real provider refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhN96KFcrfPRQySG4Txqnm
