### PR TITLE
fix(coding): stop a grown help page from silently disabling the session lane

### DIFF
--- a/src/coding/_hermes_child_process.py
+++ b/src/coding/_hermes_child_process.py
@@ -48,8 +48,12 @@ class BoundedStreamCapture:
 class PipeDrainer:
     """Drain one pipe to EOF while retaining no more than the byte cap."""
 
-    def __init__(self, pipe: BinaryIO, *, name: str) -> None:
+    def __init__(self, pipe: BinaryIO, *, name: str, limit_bytes: int = MAX_CAPTURE_BYTES) -> None:
         self._pipe = pipe
+        # Per-instance so one caller can read a larger document without
+        # raising the cap for every child this module drains. The default is
+        # the shared cap; only a caller that states a reason passes more.
+        self._limit = max(0, int(limit_bytes))
         self._parts: list[bytes] = []
         self._retained = 0
         self._seen = 0
@@ -81,7 +85,7 @@ class PipeDrainer:
                 # Counted, never retained: this is what lets the truncation
                 # record name the real original size at zero memory cost.
                 self._seen += len(chunk)
-                remaining = MAX_CAPTURE_BYTES - self._retained
+                remaining = self._limit - self._retained
                 if remaining > 0:
                     kept = chunk[:remaining]
                     self._parts.append(kept)
@@ -97,12 +101,14 @@ class PipeDrainer:
             self.done.set()
 
 
-def start_pipe_drainers(process: subprocess.Popen[bytes]) -> tuple[PipeDrainer, PipeDrainer]:
+def start_pipe_drainers(
+    process: subprocess.Popen[bytes], *, limit_bytes: int = MAX_CAPTURE_BYTES
+) -> tuple[PipeDrainer, PipeDrainer]:
     """Start both readers before the child can fill either OS pipe."""
     if process.stdout is None or process.stderr is None:
         raise ValueError("Hermes child output pipes are required")
-    stdout = PipeDrainer(process.stdout, name=f"hermes-stdout-{process.pid}")
-    stderr = PipeDrainer(process.stderr, name=f"hermes-stderr-{process.pid}")
+    stdout = PipeDrainer(process.stdout, name=f"hermes-stdout-{process.pid}", limit_bytes=limit_bytes)
+    stderr = PipeDrainer(process.stderr, name=f"hermes-stderr-{process.pid}", limit_bytes=limit_bytes)
     stdout.start()
     stderr.start()
     return stdout, stderr

--- a/src/coding/executor_readiness.py
+++ b/src/coding/executor_readiness.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import os
 import re
 import shutil
@@ -11,7 +12,12 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-from .fanout_executor_sessions import BinaryIdentity, SessionCapability, bounded_session_probe
+from .fanout_executor_sessions import (
+    SESSION_HELP_PROBE_BYTES,
+    BinaryIdentity,
+    SessionCapability,
+    bounded_session_probe,
+)
 
 from ..executors import EXECUTOR_PROFILES, executor_label
 from ..local_store import atomic_write_json, read_json_object_result, utc_now
@@ -61,25 +67,48 @@ def negotiate_session_capability(owner: str, binary: str, *, env: Mapping[str, s
     capability = SessionCapability(owner, None, identity, None)
     if owner not in ('codex', 'claude-code'):
         return capability
-    version_bytes, _reason = bounded_session_probe([identity.resolved_path, '--version'], env=env)
+    version_bytes, version_reason = bounded_session_probe([identity.resolved_path, '--version'], env=env)
     help_args = ['exec', '--help'] if owner == 'codex' else ['--help']
-    help_bytes, _reason = bounded_session_probe([identity.resolved_path, *help_args], env=env)
-    if version_bytes is None or help_bytes is None:
-        return capability
+    # The help probe reads a document, so it gets a document-sized budget and
+    # keeps what it read when even that was not enough: finding every flag in
+    # the part that was read settles the question, and only a flag MISSING
+    # from a truncated read is ambiguous. Before this, a help page that
+    # outgrew the shared 16 KiB cap silently switched the whole lane off.
+    help_bytes, help_reason = bounded_session_probe(
+        [identity.resolved_path, *help_args],
+        env=env,
+        limit_bytes=SESSION_HELP_PROBE_BYTES,
+        keep_partial=True,
+    )
+    if version_bytes is None:
+        return replace(capability, reason=f'version_probe_{version_reason}')
+    if help_bytes is None:
+        return replace(capability, reason=f'help_probe_{help_reason}')
     try:
         version, help_text = version_bytes.decode('utf-8').strip(), help_bytes.decode('utf-8')
     except UnicodeError:
-        return capability
+        return replace(capability, reason='probe_output_not_utf8')
     # Retain only the version token, never arbitrary help/version output.
     match = re.fullmatch(r'(?:[A-Za-z][A-Za-z0-9_. -]{0,64}\s+)?([0-9]+(?:\.[0-9]+){1,3}(?:[-+][A-Za-z0-9.-]+)?)(?: \(Claude Code\))?', version, re.IGNORECASE)
     if match is None:
-        return capability
+        return replace(capability, reason='version_output_unrecognized')
     flags = ('--json', 'resume') if owner == 'codex' else ('--output-format', 'stream-json', '--verbose', '--resume')
-    supported = all(re.search(r'(?<![\w-])' + re.escape(flag) + r'(?![\w-])', help_text) for flag in flags)
+    absent = [flag for flag in flags
+              if not re.search(r'(?<![\w-])' + re.escape(flag) + r'(?![\w-])', help_text)]
     if observe_session_binary(identity.resolved_path) != identity:
-        return capability
-    return SessionCapability(owner, ('codex_exec_json' if owner == 'codex' else 'claude_stream_json')
-                             if supported else None, identity, match[1])
+        return replace(capability, reason='binary_changed_during_probe')
+    if absent:
+        # A flag missing from a help page that was cut off is unanswered, not
+        # answered "no" -- both refuse the protocol, and the reason says which
+        # so an operator knows whether to raise the budget or to update the CLI.
+        detail = 'help_truncated' if help_reason == 'probe_output_limited' else 'help_complete'
+        return replace(capability, reason=f'flags_absent[{detail}]:' + ','.join(absent))
+    return SessionCapability(
+        owner,
+        'codex_exec_json' if owner == 'codex' else 'claude_stream_json',
+        identity,
+        match[1],
+    )
 
 
 EXECUTOR_READINESS_SCHEMA_VERSION = "executor_readiness/v1"

--- a/src/coding/fanout_dispatch.py
+++ b/src/coding/fanout_dispatch.py
@@ -4576,6 +4576,19 @@ def _dispatch_unit(
         "unit_state": unit_state,
         "unit_state_reason": unit_state_reason,
         "progress": progress_evidence,
+        # Which output contract this unit actually ran under, and why it was
+        # not the structured one when it was not. `plain` means no token
+        # counts and no session id were obtainable for the whole unit -- an
+        # absence with a cause, rather than an empty token column that reads
+        # like a unit which spent nothing.
+        "session_protocol": ("codex" if owner == "codex" else "claude")
+        if session_capability is not None and session_capability.protocol is not None
+        else "plain",
+        "session_protocol_reason": (
+            "" if session_capability is not None and session_capability.protocol is not None
+            else (session_capability.reason if session_capability is not None
+                  else "no_session_capability_negotiated")
+        ),
         "worktree_path": str(worktree),
         "filesystem_confinement": filesystem_confinement,
         "child_environment_policy": child_environment.receipt,

--- a/src/coding/fanout_executor_sessions.py
+++ b/src/coding/fanout_executor_sessions.py
@@ -10,6 +10,7 @@ An observed ID proves neither successful work nor durable native session storage
 from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Mapping
+from typing import Final
 from dataclasses import dataclass
 import os
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -20,6 +21,8 @@ import subprocess
 from uuid import NAMESPACE_URL, uuid5
 import re
 import shlex
+
+from ._hermes_child_process import MAX_CAPTURE_BYTES
 from typing import Literal, TypeGuard, TypedDict
 
 SCHEMA_VERSION = 'fanout_executor_session/v1'
@@ -45,6 +48,13 @@ class SessionCapability:
     protocol: str | None
     binary_identity: BinaryIdentity
     version: str | None
+    # Why there is no protocol, when there is none. An absent protocol turns
+    # off the structured-session lane -- no token counts, no session id to
+    # steer with -- and before this field the only trace of that was an empty
+    # column on the HUD, which reads like a unit that spent no tokens rather
+    # than like a capability that was never negotiated. Empty when a protocol
+    # was negotiated, or when the owner has no protocol to negotiate.
+    reason: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -339,9 +349,29 @@ def bound_session_fields(record: Mapping[str, object], *, fanout_id: str,
     return result
 
 
+# A CLI's `--help` is a document, not a value, and it grows with the CLI. The
+# shared 16 KiB cap is right for a probe whose answer is a version string and
+# wrong for one whose answer is "does this word appear anywhere in the help":
+# a help page that outgrows the cap reads as an unanswerable probe, and the
+# whole structured-session lane switches off without anything saying so.
+# Observed 2026-09-11: `claude --help` was 21,401 bytes with `--verbose` at
+# byte 17,991, so the negotiation refused a protocol the CLI does support.
+SESSION_HELP_PROBE_BYTES: Final[int] = 262_144
+
+
 def bounded_session_probe(argv: list[str], *, cwd: str | None = None,
-                          env: Mapping[str, str] | None = None) -> tuple[bytes | None, str]:
-    """Read at most 16 KiB per pipe; a failed/partial probe authorizes nothing."""
+                          env: Mapping[str, str] | None = None,
+                          limit_bytes: int = MAX_CAPTURE_BYTES,
+                          keep_partial: bool = False) -> tuple[bytes | None, str]:
+    """Read at most `limit_bytes` per pipe; a failed/partial probe authorizes nothing.
+
+    `keep_partial` hands back the bytes that WERE read alongside the
+    `probe_output_limited` reason, for the one caller whose question can be
+    answered positively from a prefix: finding a flag in the part that was read
+    is a complete observation, and only NOT finding one is ambiguous when the
+    rest was cut off. Every other caller keeps the original contract, where a
+    truncated read authorizes nothing.
+    """
     from ._hermes_child_process import start_pipe_drainers, terminate_process_group
 
     try:
@@ -351,7 +381,7 @@ def bounded_session_probe(argv: list[str], *, cwd: str | None = None,
     except OSError:
         return None, 'probe_launch_failed'
     with process:
-        drainers = start_pipe_drainers(process)
+        drainers = start_pipe_drainers(process, limit_bytes=limit_bytes)
         reason = 'observed'
         try:
             if process.wait(timeout=3) != 0:
@@ -370,7 +400,11 @@ def bounded_session_probe(argv: list[str], *, cwd: str | None = None,
         captures = [drainer.capture() for drainer in drainers]
         if any(capture.truncated for capture in captures):
             reason = 'probe_output_limited'
-        return (captures[0].data if reason == 'observed' else None), reason
+        if reason == 'observed':
+            return captures[0].data, reason
+        if keep_partial and reason == 'probe_output_limited':
+            return captures[0].data, reason
+        return None, reason
 
 
 def observe_session_workspace(path: str) -> WorkspaceSnapshot | None:

--- a/tests/test_session_protocol_probe.py
+++ b/tests/test_session_protocol_probe.py
@@ -17,8 +17,12 @@ WAS read, and an absent protocol states why.
 
 from __future__ import annotations
 
+import os
+import shutil
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 from _local_package import load_local_package
 
@@ -65,30 +69,47 @@ class HelpProbeBudgetTests(unittest.TestCase):
         self.assertEqual(reason, "probe_output_limited")
 
 
-def _fake_cli(version: str, help_text: str) -> str:
-    """A python one-liner that answers --version and --help like a CLI."""
-    return (
-        "import sys;"
-        f"v={version!r};h={help_text!r};"
-        "sys.stdout.write(v if '--version' in sys.argv else h)"
+def _fake_cli_wrapper(directory: Path, version: str, help_text: str) -> str:
+    """An executable that answers `--version` and `--help` like a real CLI.
+
+    The negotiation runs the path it is given as a program, so the fixture has
+    to be one on both platforms: a POSIX shell script will not execute on
+    Windows, and a `.cmd` will not on POSIX. Both wrappers call the same
+    Python file, and the two answers live in their own files so no quoting
+    rule of either shell can touch them.
+    """
+    (directory / "version.txt").write_text(version, encoding="utf-8")
+    (directory / "help.txt").write_text(help_text, encoding="utf-8")
+    program = directory / "fake_cli.py"
+    program.write_text(
+        "import sys\n"
+        "from pathlib import Path\n"
+        "here = Path(__file__).resolve().parent\n"
+        "name = 'version.txt' if '--version' in sys.argv else 'help.txt'\n"
+        "sys.stdout.write((here / name).read_text(encoding='utf-8'))\n",
+        encoding="utf-8",
     )
+    if os.name == "nt":
+        wrapper = directory / "fake-cli.cmd"
+        wrapper.write_text(
+            f'@echo off\r\n"{sys.executable}" "{program}" %*\r\n', encoding="utf-8"
+        )
+        return str(wrapper)
+    wrapper = directory / "fake-cli"
+    wrapper.write_text(
+        f'#!/bin/sh\nexec "{sys.executable}" "{program}" "$@"\n', encoding="utf-8"
+    )
+    wrapper.chmod(0o755)
+    return str(wrapper)
 
 
 class NegotiationOutcomeTests(unittest.TestCase):
     def _negotiate(self, version: str, help_text: str):
-        import os
-        import tempfile
-        from pathlib import Path
-
-        directory = tempfile.mkdtemp()
-        script = Path(directory) / "fake-cli"
-        script.write_text(
-            "#!/bin/sh\nexec " + sys.executable + ' -c "$OMH_FAKE_CLI_PROGRAM" "$@"\n',
-            encoding="utf-8",
+        directory = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, directory, True)
+        return negotiate_session_capability(
+            "claude-code", _fake_cli_wrapper(directory, version, help_text), env=os.environ
         )
-        script.chmod(0o755)
-        env = dict(os.environ, OMH_FAKE_CLI_PROGRAM=_fake_cli(version, help_text))
-        return negotiate_session_capability("claude-code", str(script), env=env)
 
     def test_a_help_page_past_the_old_cap_still_negotiates_the_protocol(self) -> None:
         flags = "--output-format stream-json --resume"

--- a/tests/test_session_protocol_probe.py
+++ b/tests/test_session_protocol_probe.py
@@ -52,7 +52,10 @@ class HelpProbeBudgetTests(unittest.TestCase):
             [sys.executable, "-c", program], limit_bytes=SESSION_HELP_PROBE_BYTES
         )
         self.assertEqual(reason, "observed")
-        self.assertEqual(len(data or b""), 20_001)
+        # Count the payload, not the bytes: the child's own line ending is
+        # platform-native, so a CRLF run is two bytes longer than the same
+        # output on POSIX and an exact length would fail only on Windows.
+        self.assertEqual((data or b"").count(b"x"), 20_000)
 
     def test_keep_partial_hands_back_what_was_read_without_calling_it_complete(self) -> None:
         # The reason still says the read was cut off: the caller decides what a

--- a/tests/test_session_protocol_probe.py
+++ b/tests/test_session_protocol_probe.py
@@ -1,0 +1,120 @@
+"""A help page that outgrows the probe budget must not switch the lane off.
+
+`negotiate_session_capability` reads a CLI's `--help` to see whether the
+structured-session flags exist. The read was capped at the same 16 KiB every
+other child capture uses, and a truncated read was treated as an unanswerable
+probe -- so when `claude --help` grew past the cap (21,401 bytes observed
+2026-09-11, with `--verbose` at byte 17,991), the negotiation returned no
+protocol, the dispatch spawned without `--output-format stream-json`, and the
+unit produced no token counts and no session id for the rest of its life. The
+only trace was an empty token column, which reads like a unit that spent
+nothing rather than like a capability that was never negotiated.
+
+These pin the three parts of the repair: the budget is document-sized, a
+truncated read still answers the question when every flag was found in what
+WAS read, and an absent protocol states why.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+
+from _local_package import load_local_package
+
+load_local_package()
+
+from omh.coding.executor_readiness import negotiate_session_capability
+from omh.coding.fanout_executor_sessions import (
+    SESSION_HELP_PROBE_BYTES,
+    bounded_session_probe,
+)
+from omh.coding._hermes_child_process import MAX_CAPTURE_BYTES
+
+
+class HelpProbeBudgetTests(unittest.TestCase):
+    def test_the_help_budget_clears_a_help_page_that_outgrew_the_shared_cap(self) -> None:
+        # 21,401 bytes was the observed page; the budget is not set to clear it
+        # by a hair, because the next release grows it again.
+        self.assertGreater(SESSION_HELP_PROBE_BYTES, MAX_CAPTURE_BYTES)
+        self.assertGreater(SESSION_HELP_PROBE_BYTES, 21_401 * 4)
+
+    def test_a_larger_budget_reads_output_the_default_would_truncate(self) -> None:
+        program = 'print("x" * 20000)'
+        data, reason = bounded_session_probe([sys.executable, "-c", program])
+        self.assertIsNone(data)
+        self.assertEqual(reason, "probe_output_limited")
+        data, reason = bounded_session_probe(
+            [sys.executable, "-c", program], limit_bytes=SESSION_HELP_PROBE_BYTES
+        )
+        self.assertEqual(reason, "observed")
+        self.assertEqual(len(data or b""), 20_001)
+
+    def test_keep_partial_hands_back_what_was_read_without_calling_it_complete(self) -> None:
+        # The reason still says the read was cut off: the caller decides what a
+        # prefix can answer, the probe never upgrades it to `observed`.
+        data, reason = bounded_session_probe(
+            [sys.executable, "-c", 'print("y" * 20000)'], keep_partial=True
+        )
+        self.assertEqual(reason, "probe_output_limited")
+        self.assertEqual(len(data or b""), MAX_CAPTURE_BYTES)
+
+    def test_every_other_caller_still_gets_nothing_from_a_truncated_read(self) -> None:
+        data, reason = bounded_session_probe([sys.executable, "-c", 'print("z" * 20000)'])
+        self.assertIsNone(data)
+        self.assertEqual(reason, "probe_output_limited")
+
+
+def _fake_cli(version: str, help_text: str) -> str:
+    """A python one-liner that answers --version and --help like a CLI."""
+    return (
+        "import sys;"
+        f"v={version!r};h={help_text!r};"
+        "sys.stdout.write(v if '--version' in sys.argv else h)"
+    )
+
+
+class NegotiationOutcomeTests(unittest.TestCase):
+    def _negotiate(self, version: str, help_text: str):
+        import os
+        import tempfile
+        from pathlib import Path
+
+        directory = tempfile.mkdtemp()
+        script = Path(directory) / "fake-cli"
+        script.write_text(
+            "#!/bin/sh\nexec " + sys.executable + ' -c "$OMH_FAKE_CLI_PROGRAM" "$@"\n',
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+        env = dict(os.environ, OMH_FAKE_CLI_PROGRAM=_fake_cli(version, help_text))
+        return negotiate_session_capability("claude-code", str(script), env=env)
+
+    def test_a_help_page_past_the_old_cap_still_negotiates_the_protocol(self) -> None:
+        flags = "--output-format stream-json --resume"
+        # `--verbose` past 16 KiB is the exact shape that switched the lane off.
+        help_text = flags + "\n" + ("filler line\n" * 2_000) + "--verbose\n"
+        self.assertGreater(help_text.find("--verbose"), MAX_CAPTURE_BYTES)
+        capability = self._negotiate("2.1.268 (Claude Code)", help_text)
+        self.assertEqual(capability.protocol, "claude_stream_json")
+        self.assertEqual(capability.reason, "")
+
+    def test_a_genuinely_absent_flag_refuses_and_names_itself(self) -> None:
+        capability = self._negotiate(
+            "2.1.268 (Claude Code)", "--output-format stream-json --resume\n"
+        )
+        self.assertIsNone(capability.protocol)
+        self.assertIn("flags_absent", capability.reason)
+        self.assertIn("--verbose", capability.reason)
+        self.assertIn("help_complete", capability.reason)
+
+    def test_an_unrecognized_version_refuses_and_says_so(self) -> None:
+        capability = self._negotiate(
+            "not-a-version", "--output-format stream-json --verbose --resume\n"
+        )
+        self.assertIsNone(capability.protocol)
+        self.assertEqual(capability.reason, "version_output_unrecognized")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Capability

A coding CLI whose `--help` grew past the probe's byte cap no longer silently loses its structured-session protocol — and when a protocol genuinely cannot be negotiated, the unit records why.

## Motivation

A Maestro-lane unit on Claude Code showed no token count for its entire run, and the HUD rendered that as an empty column — which reads like a unit that spent nothing.

Measured on this machine (2026-09-11):

| step | observed |
| --- | --- |
| `claude --version` | `2.1.268 (Claude Code)` — fine |
| `claude --help` | **21,401 bytes**; `--verbose` at byte **17,991** |
| `bounded_session_probe` cap | 16,384 per pipe → `probe_output_limited`, bytes discarded |
| `negotiate_session_capability` | `protocol: None` |
| spawn argv | `--output-format stream-json --verbose` **not added** |
| child output | plain text → `parse_unit_telemetry` has no JSON to read |
| result | no token counts and no session id for the whole unit, and nothing stating a capability was refused |

So the blank token column was not "Claude reports usage only at the end". The whole structured-session lane — token telemetry *and* the session id steering depends on — was off because a CLI grew its help page.

## Implementation

- `bounded_session_probe(..., limit_bytes=, keep_partial=)`; `PipeDrainer` / `start_pipe_drainers` take a per-instance `limit_bytes` so one caller can read a larger document without raising the shared cap for every child this module drains.
- `SESSION_HELP_PROBE_BYTES = 262_144`: a help page is a document, not a value. Not set to clear 21,401 by a hair — the next release grows it again.
- `keep_partial` returns the bytes that *were* read alongside the `probe_output_limited` reason, for the one caller whose question a prefix can answer: **finding** a flag in what was read is a complete observation; only **not finding** one is ambiguous when the rest was cut off. The probe never upgrades the reason to `observed`; the caller decides what a prefix proves. Every other caller keeps the original contract.
- Fail-closed is unchanged: a genuinely absent flag still refuses the protocol. What changed is that the refusal now says which — `flags_absent[help_truncated]:--verbose` vs `flags_absent[help_complete]:--verbose`, so an operator knows whether to raise the budget or update the CLI.
- `SessionCapability.reason` (defaulted, so existing constructions are untouched), recorded on the unit result as `session_protocol` (`claude` / `codex` / `plain`) and `session_protocol_reason`.

## Verification (observed)

- **Against the real binary**: `negotiate_session_capability('claude-code', …)` returned `protocol: None, version: None` before this change and `protocol: claude_stream_json, version: 2.1.268, reason: ''` after, on claude 2.1.268.
- `tests/test_session_protocol_probe.py` 7/7, including a fake CLI whose help puts `--verbose` past 16 KiB (negotiates), one where the flag is genuinely absent (refuses, names the flag and `help_complete`), and one with an unrecognized version.
- `tests/test_fanout_executor_sessions.py` + `test_fanout_dispatch.py` + `test_executor_readiness_resolutions.py` → 229 OK; `test_broad_exception_policy` OK.
- `PYTHONPATH=tests uv run python -m unittest discover -s tests` → OK (skipped=3); ruff, compileall, all eight `docs … --check` gates, `git diff --check` clean.

## Risks

- Units that were running plain now run structured: the child is asked to emit `stream-json`, which is the intended repair but is a real change in what the CLI produces. The output path already handles both (`protocol='plain'` vs `'claude'`), and the fanout suite covers it.
- No live fanout unit has been dispatched under the repaired protocol yet, so the token counts it should now produce are not observed on a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhN96KFcrfPRQySG4Txqnm
