### PR TITLE
fix(tests): stop the D5 fixture's verdict depending on where the repo lives

### DIFF
--- a/tests/five_issue_cases/diagnostics.py
+++ b/tests/five_issue_cases/diagnostics.py
@@ -25,8 +25,23 @@ from omh.system.paths import OmhPaths
 from . import CaseResult, JsonValue
 
 
+def _fixture_interpreter() -> str:
+    """An interpreter path that does not grow with the checkout's location.
+
+    The verification command is capped at MAX_UNIT_VERIFICATION_COMMAND_CHARS,
+    and `sys.executable` inside a project venv sits UNDER the checkout, so a
+    deep worktree path used to decide whether this fixture passed (#1474).
+    The base interpreter that created the venv lives outside the checkout and
+    runs a stdlib-only script just as well; a non-venv run resolves to the
+    same path it already used.
+    """
+    base = getattr(sys, '_base_executable', '') or ''
+    return base if base and Path(base).exists() else sys.executable
+
+
 def exercise_dispatch(*, stdout: bytes = b'', stderr: bytes = b'', exit_code: int = 3,
-                      sidecar: str = 'missing', verification: bool = False) -> CaseResult:
+                      sidecar: str = 'missing', verification: bool = False,
+                      verification_newline: str = '') -> CaseResult:
     """Exercise dispatch_fanout with its real runner and an explicit fixture argv.
 
     No injected process result or confinement bypass. The only adapter replaces
@@ -59,8 +74,22 @@ def exercise_dispatch(*, stdout: bytes = b'', stderr: bytes = b'', exit_code: in
         _ = err.write_bytes(stderr)
         if verification:
             import shlex
-            unit['verification_commands'] = [shlex.join([
-                sys.executable, '-c', 'import sys; sys.stderr.buffer.write(b"compiler failed\\n"); sys.exit(7)'])]
+            # The script is a file in the temp root, not an inline `-c` payload:
+            # both halves of the command then stay clear of the contract's
+            # per-command character cap however deep the checkout sits (#1474).
+            reconfigure = (f'sys.stderr.reconfigure(newline={verification_newline!r})\n'
+                           if verification_newline else '')
+            failing_script = root / 'fail.py'
+            _ = failing_script.write_text(
+                'import sys\n'
+                + reconfigure
+                + 'sys.stderr.buffer.write(b"compiler failed\\n")\n'
+                  'sys.exit(7)\n',
+                encoding='utf-8',
+            )
+            unit['verification_commands'] = [
+                shlex.join([_fixture_interpreter(), str(failing_script)])
+            ]
         contract = write_fanout_contract(paths, build_fanout_contract(goal, [unit]))
         fanout_id = str(contract['fanout_id'])
         run_ref = fanout_id + '-core'
@@ -115,7 +144,7 @@ def exercise_dispatch(*, stdout: bytes = b'', stderr: bytes = b'', exit_code: in
                         'removed_paths': [directory], 'verified_absent': not root.exists(), 'errors': []}}
 
 
-def run_case(case_id: str) -> CaseResult:
+def run_case(case_id: str, *, verification_newline: str = '') -> CaseResult:
     if case_id not in {'D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7', 'S5'}:
         raise ValueError('unknown_diagnostics_case')
     stdout, stderr, code, sidecar, verification = b'', b'compiler failed\n', 3, 'missing', False
@@ -135,7 +164,8 @@ def run_case(case_id: str) -> CaseResult:
     elif case_id == 'D7':
         code, sidecar = 0, 'fenced'
     result = exercise_dispatch(stdout=stdout, stderr=stderr, exit_code=code,
-                               sidecar=sidecar, verification=verification)
+                               sidecar=sidecar, verification=verification,
+                               verification_newline=verification_newline)
     result['case'] = case_id
     observations = result['observations']
     summary = observations['summary']

--- a/tests/test_five_issue_fixture_transport.py
+++ b/tests/test_five_issue_fixture_transport.py
@@ -7,7 +7,6 @@ from hashlib import sha256
 import json
 import os
 from pathlib import Path
-import shlex
 import subprocess
 import sys
 from tempfile import TemporaryDirectory
@@ -175,18 +174,38 @@ class FixtureTransportTests(unittest.TestCase):
 
     def test_verification_diagnostic_bytes_survive_crlf_text_stream(self) -> None:
         from five_issue_cases import diagnostics
-        join = shlex.join
 
-        def windows_command(arguments: list[str]) -> str:
-            argv = list(arguments)
-            if len(argv) == 3 and argv[:2] == [sys.executable, '-c']:
-                argv[2] = "import sys; sys.stderr.reconfigure(newline='\\r\\n'); " + argv[2]
-            return join(argv)
-
-        with patch('shlex.join', windows_command):
-            result = diagnostics.run_case('D5')
+        result = diagnostics.run_case('D5', verification_newline='\r\n')
         self.assertTrue(result['pass'], result['observations'])
         self.assertTrue(result['cleanup']['verified_absent'])
+
+    def test_the_verification_command_does_not_grow_with_the_checkout_path(self) -> None:
+        # #1474: the command embedded `sys.executable` and an inline script, so
+        # a deep worktree pushed it past MAX_UNIT_VERIFICATION_COMMAND_CHARS and
+        # the fixture's verdict became a function of where the repo lives.
+        from five_issue_cases import diagnostics
+        from omh.coding.fanout import MAX_UNIT_VERIFICATION_COMMAND_CHARS
+
+        captured: list[str] = []
+        real_build = diagnostics.build_fanout_contract
+
+        def capture(goal: str, units: list[dict[str, object]]) -> object:
+            for unit in units:
+                commands = unit.get('verification_commands')
+                if isinstance(commands, list):
+                    captured.extend(str(command) for command in commands)
+            return real_build(goal, units)
+
+        with patch.object(diagnostics, 'build_fanout_contract', capture):
+            result = diagnostics.run_case('D5', verification_newline='\r\n')
+        self.assertTrue(result['pass'], result['observations'])
+        self.assertEqual(len(captured), 1)
+        command = captured[0]
+        checkout = str(Path(__file__).resolve().parents[1])
+        self.assertNotIn(checkout, command)
+        # Headroom for a checkout far deeper than this one, measured rather
+        # than assumed: the command may not consume the whole cap.
+        self.assertLess(len(command), MAX_UNIT_VERIFICATION_COMMAND_CHARS - 40)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Feature Report

### What Changed

Closes #1474. The D5 diagnostics fixture built its failing verification command as `sys.executable -c <inline script>`. Inside a project venv `sys.executable` sits **under the checkout**, and the test prepended a CRLF reconfigure to the inline script, so the two longest parts of the command both grew with the checkout path. A 27-character worktree name was the difference between green and red against the contract's 240-character per-command cap.

| part | before | after |
|---|---|---|
| interpreter | `sys.executable` (under the checkout: `<checkout>/.venv/bin/python`) | `sys._base_executable` — the base interpreter that created the venv, outside the checkout; falls back to `sys.executable` when absent |
| script | inline `-c` payload, with the CRLF prefix injected by monkeypatching `shlex.join` and matching the argv shape | a file in the fixture's own temp root; the CRLF variant is a `verification_newline` argument threaded through `run_case` |

The cap itself is untouched — it is a contract for real units. Only the fixture's construction changes, and no product code is touched.

### Why This Exists

A test whose verdict depends on where the repository is checked out is not a test. It passed from `…/oh-my-hermes-worktrees/hud-gateway-cost` and errored from `…/oh-my-hermes-worktrees/update-profile-registration` on the same commit, which reads as a flake until someone measures the path.

### User / Operator Impact

None at runtime. Contributors working from deep worktrees stop seeing a `FanoutContractError` that has nothing to do with their change.

### How It Works

`_fixture_interpreter()` in `tests/five_issue_cases/diagnostics.py` returns `sys._base_executable` when it exists on disk, else `sys.executable`. `exercise_dispatch(..., verification_newline=...)` writes `fail.py` into the temp root — `import sys`, an optional `sys.stderr.reconfigure(newline=...)`, the stderr write, `sys.exit(7)` — and the command becomes `shlex.join([interpreter, script_path])`. Both halves are then independent of the checkout. `run_case` gained the same keyword so the test states what it wants instead of intercepting how the command is built.

### Files And Contracts Touched

`tests/five_issue_cases/diagnostics.py`, `tests/test_five_issue_fixture_transport.py`. Test-only; no src change, no schema, no contract value changed.

### Affected Surfaces

- [ ] Hermes chat or wrapper
- [ ] Codex
- [ ] Claude Code
- [ ] Hermes runtime or handoff
- [ ] Generic executor
- [x] Not executor-specific

## Validation

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [ ] `uv run python -m omh.cli docs workflows --check`
- [ ] `uv run python -m omh.cli docs roles --check`
- [ ] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate`
- [ ] `uv run python -m omh.cli release checklist --json`
- [ ] `uv run python -m omh.cli release hermes-smoke`
- [x] `git diff --check`
- [ ] `omh --help`
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke`
- [ ] Relevant workflow-learning review queue smoke, when learning contracts changed: not applicable
- [x] Relevant dry-run or smoke command: the same test file run from a 155-character checkout — see below
- [ ] Manual Hermes/TUI check, or explicit reason it was not run: test-only change, no runtime surface

### Observed Evidence

The reproduction and the fix were both measured at the same long path, a detached `git worktree` under the session scratchpad at **155 characters**:

```
at origin/main   ->  Ran 8 tests ... FAILED (errors=1)
                     FanoutContractError: verification_commands entries must be at most 240 chars
at c5b27a60      ->  Ran 9 tests ... OK
```

From the ordinary worktree: `tests/test_five_issue_fixture_transport.py tests/test_fanout_failure_diagnostics.py tests/test_fanout_dispatch.py` — 225 tests, OK. Full suite running; the `Ran … / OK` line is posted as a comment when it finishes.

### Not Tested / Not Applicable

- Windows: `sys._base_executable` resolves the same way there and the script is written as a file either way; CI's `test-windows` jobs cover it.
- Doc/byte gates: no catalog, doc, or generated artifact touched.

## Risk

- If a future environment reports a `sys._base_executable` that exists but cannot run (a broken base install), the fixture would fail where it previously used the venv interpreter. The fallback covers absent or empty, not broken; that is the same trust the venv itself places in its base.

## Compatibility / Rollout

- Test-only. Nothing ships, nothing to update on a machine.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared handoffs or plans are labeled `prepared_not_observed`, never as execution, review, CI, or merge evidence
- [x] Evidence contains no credentials, raw prompts, raw platform events, transcripts, or unrelated private data
- [x] Known manual Hermes checks are listed, including any `omh release hermes-smoke --live` gap

## Follow-Up

- The new test pins that the command carries no checkout path and keeps at least 40 characters of headroom under the cap, so the next fixture that reaches for an absolute path fails loudly rather than silently consuming the budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
