### PR TITLE
fix(memory): bind project recall to stable repository identity

### DIFF
--- a/docs/MEMORY-PREFETCH.md
+++ b/docs/MEMORY-PREFETCH.md
@@ -47,11 +47,49 @@ The normal prefetch and handoff allowlist contains:
 | `project/<identity>` | Context for the current project label |
 | `thread/<session-id>` | Context for the current session, included only when a session ID is available |
 
-For prefetch, project identity is the nearest repository directory name, or
-`default` outside a repository. Handoff derives it from the project containing
-the supplied OMH home's parent. Same-named checkouts share a label; this isn't
-an authenticated repository or user identity. The handoff facade reads its
-supplied store only, so a global label doesn't make it discover other stores.
+Project memory uses `project_identity/v2`, not a checkout basename. The
+filesystem-only resolver prefers a valid `.omh/project-identity.json` explicit
+`prj:<64 hex>` identity. Otherwise it reads Git metadata (including linked
+worktree `commondir`) and hashes the normalized remote URL into
+`repo:<32 hex>`. Origin wins; conflicting remotes without origin fail closed.
+Credentials and transport schemes are removed before hashing. Checkout renames
+retain identity, worktrees share their common remote, and distinct forks do
+not share memory merely because their directories have the same name.
+
+Invalid explicit evidence, absent or ambiguous remotes, unreadable metadata,
+and an unbound checkout produce closed diagnostics, never a basename fallback.
+Resolution makes no subprocess, network, or model call and writes nothing.
+This is repository scoping, not authenticated repository or user identity.
+The handoff facade still reads its supplied store only; a global label does
+not make it discover other stores.
+
+### Compatibility and operator migration
+
+Automatic recall of basename-scoped records stops until reviewed migration.
+`legacy_basename` is an inspection/migration compatibility state, never a
+second project ref in an automatic result. Local-only repositories need an
+explicit identity initialized by the agent/operator maintenance command
+`omh memory project-identity init`. Capture without a resolved project identity
+refuses with that guidance; it never silently becomes user-global.
+
+Agent/operator maintenance path:
+
+1. `omh memory project-identity show` inspects resolution without writing.
+2. `omh memory project-identity report` scans project and user stores and
+   reports proposed scope changes without altering records.
+3. After review, `omh memory project-identity migrate --approve <report_digest>`
+   binds approval to that exact inventory and creates reviewed successor
+   revisions through the existing lifecycle journal. Original revisions and
+   reviews are preserved, not rewritten in place. Repeating the same completed
+   migration is a no-op.
+4. `omh memory project-identity migrate --rollback <receipt_id>` retires those
+   successors and restores original eligibility for explicit legacy inspection.
+   It does not re-enable basename-based automatic recall.
+
+Prefetch receipts are now `omh_memory_prefetch_receipt/v3`. Configuration
+identity includes both resolver version and project identity. Older v2 receipts
+remain structurally readable, but cannot establish current repository-bound
+recall evidence; identity/version mismatches are rejected.
 
 Delivery requires an explicit nonempty allowlist with a valid project entry.
 A missing required kind, invalid scope, or blank ref yields
@@ -66,7 +104,8 @@ lens. The live provider selects `observed: hermes`; handoffs select their
 executor, including Codex, Claude Code, Hermes, and generic targets. An
 unresolved executor doesn't inherit another actor's perspective.
 
-Operator `omh memory recall` without scope flags retains wildcard inspection
+Agent/operator `omh memory recall` without scope flags uses the current stable
+project allowlist. Explicit scope flags remain available for legacy inspection
 within the selected store. Supplying only half a scope fails closed.
 `--include-stale` is inspection-only and carries ineligible replay evidence;
 it can't turn stale records into approved handoff context. Inspection isn't
@@ -82,11 +121,10 @@ remains a legacy profile-local scope, not a human identity; it is excluded on a
 shared surface. Upgrade and recall never silently rewrite or assign old records.
 Use the report-first principal migration described in [Project Memory](MEMORY.md).
 
-A record in the user home is not automatically global. In particular,
-`project/default`, the capture default, doesn't match prefetch inside a
-repository named `release-tools`. That record stays stored and inspectable;
-it simply isn't in the `project/release-tools` delivery lens. `target` and
-`run` records likewise aren't implicitly added to the normal allowlist.
+A record in the user home is not automatically global. In particular, old
+`project/default` records do not match a resolved stable repository identity.
+They stay stored and explicitly inspectable until reviewed migration. `target`
+and `run` records likewise are not implicitly added to the normal allowlist.
 
 For a rollout, inspect the existing store and intended audience first. Keep
 correct project/thread labels. If an old fact really belongs across projects,
@@ -148,10 +186,12 @@ or model use.
 
 ## Receipt privacy and identity
 
-`build_prefetch_receipt` creates `omh_memory_prefetch_receipt/v2` in `prepared`
-state. It adds the opaque principal binding state, actor kind, shared-surface
-flag, aggregate allow/deny reasons, and audience-policy digest. Existing v1
-receipts remain readable but establish no principal-isolation claim. `prefetch`
+`build_prefetch_receipt` creates `omh_memory_prefetch_receipt/v3` in `prepared`
+state. It binds resolver version and project identity, with resolution state
+and closed diagnostics in the lens, alongside opaque principal binding state,
+actor kind, shared-surface flag, aggregate allow/deny reasons, and audience-policy
+digest. Existing v1/v2 receipts remain readable; they cannot establish the new
+repository-identity binding, and v1 establishes no principal-isolation claim. `prefetch`
 marks the current receipt `returned_to_host`, exposes it through
 `latest_prefetch_receipt()`, and attempts to persist it at
 `<provider-user-home>/memory/prefetch_receipt.json`. A write `OSError` doesn't

--- a/docs/MEMORY-PREFETCH.md
+++ b/docs/MEMORY-PREFETCH.md
@@ -52,9 +52,23 @@ filesystem-only resolver prefers a valid `.omh/project-identity.json` explicit
 `prj:<64 hex>` identity. Otherwise it reads Git metadata (including linked
 worktree `commondir`) and hashes the normalized remote URL into
 `repo:<32 hex>`. Origin wins; conflicting remotes without origin fail closed.
-Credentials and transport schemes are removed before hashing. Checkout renames
-retain identity, worktrees share their common remote, and distinct forks do
-not share memory merely because their directories have the same name.
+Git value quotes, escapes and inline comments are decoded before credentials
+and transport schemes are removed. Local filesystem remotes are resolved
+strictly against the checkout containing the common Git metadata directory;
+the canonical endpoint URI is domain-separated and hashed, never emitted.
+Missing or unsupported local endpoints fail closed. Relative, absolute and
+file-URI spellings of one endpoint agree, while separate sibling upstreams
+remain distinct. Local endpoint relocation changes that evidence; use an
+explicit identity when endpoint-location independence is needed.
+Checkout renames retain identity while their remote endpoint remains the same,
+worktrees share their common remote, and distinct forks do not share memory
+merely because their directories have the same name.
+
+CLI identity, capture, automatic recall and incident diagnosis use the active
+checkout, not the selected store's parent. Selecting another checkout's store
+does not authorize its project records. Incident workflow callers may supply
+`invocation_cwd`; otherwise the current working directory is the active context.
+That transient filesystem context is not persisted in incident metadata.
 
 Invalid explicit evidence, absent or ambiguous remotes, unreadable metadata,
 and an unbound checkout produce closed diagnostics, never a basename fallback.
@@ -81,7 +95,11 @@ Agent/operator maintenance path:
    binds approval to that exact inventory and creates reviewed successor
    revisions through the existing lifecycle journal. Original revisions and
    reviews are preserved, not rewritten in place. Repeating the same completed
-   migration is a no-op.
+   migration is a no-op. Report entries retain exact source revision, source
+   digest and immutable review bindings. A source or review changed between
+   reporting and locked apply is skipped with `source_changed_since_report`,
+   included in the receipt's `skipped` list, and requires a fresh report and
+   approval. Apply never substitutes the newly read revision's digest.
 4. `omh memory project-identity migrate --rollback <receipt_id>` retires those
    successors and restores original eligibility for explicit legacy inspection.
    It does not re-enable basename-based automatic recall.

--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -100,7 +100,7 @@ def cmd_memory_project_identity(args: argparse.Namespace) -> int:
 
     try:
         paths = _paths(args)
-        root = project_identity_root(paths.omh_home.parent) or project_identity_root() or Path.cwd()
+        root = project_identity_root() or Path.cwd()
         if args.identity_command == "init":
             mint_explicit_project_identity(root)
             payload = asdict(resolve_project_identity(root))
@@ -141,7 +141,7 @@ def cmd_memory_capture(args: argparse.Namespace) -> int:
             content=content,
             record_type=args.type,
             scope_kind=args.scope_kind,
-            scope_ref=(require_project_identity(project_identity_root(_paths(args).omh_home.parent) or project_identity_root() or _paths(args).omh_home.parent) if args.scope_kind == "project" and args.scope_ref is None else args.scope_ref),
+            scope_ref=(require_project_identity() if args.scope_kind == "project" and args.scope_ref is None else args.scope_ref),
             source=args.source,
             source_ref=args.source_ref,
             tags=args.tag or [],
@@ -301,7 +301,7 @@ def cmd_memory_recall(args: argparse.Namespace) -> int:
         query = " ".join(args.query).strip()
         paths = _paths(args)
         automatic = args.scope_kind is None and args.scope_ref is None
-        resolution = resolve_project_identity(project_identity_root(paths.omh_home.parent) or project_identity_root() or paths.omh_home.parent)
+        resolution = resolve_project_identity()
         payload = build_project_memory_recall_pack(
             paths,
             query,

--- a/src/commands/memory.py
+++ b/src/commands/memory.py
@@ -26,6 +26,9 @@ from ..plugin_bundle.omh.memory_blocks import (
 from ..plugin_bundle.omh.memory_dreaming import read_dreaming_state
 from ..plugin_bundle.omh.memory_principals import parse_principal_context
 from ..plugin_bundle.omh.memory_provider import OmhMemoryProvider
+from ..plugin_bundle.omh.project_identity import mint_explicit_project_identity, project_identity_root, require_project_identity, resolve_project_identity
+from ..plugin_bundle.omh.memory_records import prefetch_scope_allowlist
+from ..workflows.memory_project_identity import build_project_identity_migration_report, migrate_project_identity, rollback_project_identity_migration
 from ..plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME
 from ..memory import (
     LifecycleCandidateError,
@@ -92,6 +95,30 @@ from ..workflows.memory_migration import (
 from .common import _paths, _print_json
 
 
+def cmd_memory_project_identity(args: argparse.Namespace) -> int:
+    from dataclasses import asdict
+
+    try:
+        paths = _paths(args)
+        root = project_identity_root(paths.omh_home.parent) or project_identity_root() or Path.cwd()
+        if args.identity_command == "init":
+            mint_explicit_project_identity(root)
+            payload = asdict(resolve_project_identity(root))
+        elif args.identity_command == "show":
+            payload = asdict(resolve_project_identity(root))
+        elif args.identity_command == "report":
+            payload = build_project_identity_migration_report(paths, root=root)
+        elif args.rollback:
+            payload = rollback_project_identity_migration(paths, args.rollback, root=root)
+        else:
+            payload = migrate_project_identity(paths, approve=args.approve, root=root)
+    except (OSError, ValueError):
+        # These commands never expose filesystem paths from operating-system errors.
+        raise OmhError("project_identity_operation_refused") from None
+    _print_json(payload)
+    return 0
+
+
 def cmd_memory_status(args: argparse.Namespace) -> int:
     try:
         payload = build_project_memory_status(_paths(args))
@@ -114,7 +141,7 @@ def cmd_memory_capture(args: argparse.Namespace) -> int:
             content=content,
             record_type=args.type,
             scope_kind=args.scope_kind,
-            scope_ref=args.scope_ref,
+            scope_ref=(require_project_identity(project_identity_root(_paths(args).omh_home.parent) or project_identity_root() or _paths(args).omh_home.parent) if args.scope_kind == "project" and args.scope_ref is None else args.scope_ref),
             source=args.source,
             source_ref=args.source_ref,
             tags=args.tag or [],
@@ -272,8 +299,11 @@ def cmd_memory_reject(args: argparse.Namespace) -> int:
 def cmd_memory_recall(args: argparse.Namespace) -> int:
     try:
         query = " ".join(args.query).strip()
+        paths = _paths(args)
+        automatic = args.scope_kind is None and args.scope_ref is None
+        resolution = resolve_project_identity(project_identity_root(paths.omh_home.parent) or project_identity_root() or paths.omh_home.parent)
         payload = build_project_memory_recall_pack(
-            _paths(args),
+            paths,
             query,
             executor_target=args.executor,
             session_id=args.session_id,
@@ -283,6 +313,8 @@ def cmd_memory_recall(args: argparse.Namespace) -> int:
             max_chars=_optional_positive_int(args.max_chars, "--max-chars"),
             include_stale=args.include_stale,
             include_archived=args.include_archived,
+            allowed_scopes=prefetch_scope_allowlist(project_identity=resolution.identity, session_id=args.session_id) if automatic else None,
+            inspection=not automatic,
             observer=args.observer,
             observed=args.observed,
             query_intent=args.intent,

--- a/src/commands/memory_parser.py
+++ b/src/commands/memory_parser.py
@@ -32,6 +32,16 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     command = sub.add_parser("memory", help="Agent/operator-only OMH memory review, migration, lifecycle, and prepared-context controls.")
     memory_sub = command.add_subparsers(dest="memory_command", required=True)
 
+    identity = memory_sub.add_parser("project-identity", help="Operator-only stable repository identity and reviewed scope migration.")
+    identity_sub = identity.add_subparsers(dest="identity_command", required=True)
+    for verb in ("show", "init", "report", "migrate"):
+        action = identity_sub.add_parser(verb)
+        action.set_defaults(func=memory.cmd_memory_project_identity)
+        if verb == "migrate":
+            approval = action.add_mutually_exclusive_group(required=True)
+            approval.add_argument("--approve", metavar="REPORT_DIGEST")
+            approval.add_argument("--rollback", metavar="RECEIPT_ID")
+
     status = memory_sub.add_parser("status", help="Show OMH project-memory policy, store paths, and review counts.")
     status.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
     status.set_defaults(func=memory.cmd_memory_status)
@@ -42,7 +52,7 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     capture.add_argument("--content", default="", help="Optional raw source text. It is hashed/length-counted, not persisted raw.")
     capture.add_argument("--stdin", action="store_true", help="Read optional raw source text from stdin without persisting it raw.")
     capture.add_argument("--scope-kind", choices=tuple(sorted(SCOPE_KINDS)), default="project")
-    capture.add_argument("--scope-ref", default="default")
+    capture.add_argument("--scope-ref", default=None)
     capture.add_argument("--source", default="cli")
     capture.add_argument(
         "--source-ref",
@@ -117,7 +127,7 @@ def add_memory_commands(sub: argparse._SubParsersAction[argparse.ArgumentParser]
     incident.add_argument("--query", default="", help="Recall query; only its digest is retained.")
     incident.add_argument("--session-id", default="")
     incident.add_argument("--scope-kind", choices=tuple(sorted(SCOPE_KINDS)), default="project")
-    incident.add_argument("--scope-ref", default="default")
+    incident.add_argument("--scope-ref", default="")
     incident.add_argument("--observer", default=None)
     incident.add_argument("--observed", default=None)
     incident.add_argument("--limit", type=int, default=6)

--- a/src/plugin_bundle/omh/memory_prefetch_receipt.py
+++ b/src/plugin_bundle/omh/memory_prefetch_receipt.py
@@ -23,9 +23,11 @@ from pathlib import Path
 from typing import Any
 
 from .memory_records import PreparedPrefetch, RECORD_SUMMARY_LIMIT_CHARS
+from .project_identity import DIAGNOSTICS, RESOLVER_VERSION, ProjectIdentityResolution
 
 LEGACY_MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION = "omh_memory_prefetch_receipt/v1"
-MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION = "omh_memory_prefetch_receipt/v2"
+PRINCIPAL_MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION = "omh_memory_prefetch_receipt/v2"
+MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION = "omh_memory_prefetch_receipt/v3"
 PREFETCH_RECEIPT_FILENAME = "prefetch_receipt.json"
 MAX_PREFETCH_RECEIPT_BYTES = 64 * 1024
 RECEIPT_STATES = ("prepared", "returned_to_host")
@@ -43,6 +45,7 @@ def build_prefetch_receipt(
     session_id: str,
     home_digests: tuple[str, ...] | list[str],
     rendered_block_count: int = 0,
+    project_resolution: ProjectIdentityResolution | None = None,
 ) -> dict[str, Any]:
     """Bind one selection and its rendering to configuration, lens, session and store.
 
@@ -69,6 +72,8 @@ def build_prefetch_receipt(
         "session_id": str(pack.get("session_id", "") or session_id or ""),
         "store": {"home_digests": [str(digest) for digest in home_digests]},
         "configuration_id": selection.configuration_id,
+        "resolver_version": str(configuration["resolver_version"]),
+        "project_identity": str(configuration["project_identity"]),
         "selector_schema_version": str(configuration.get("selector_schema_version", "")),
         "recall_pack_schema_version": str(pack.get("schema_version", "")),
         "render_configuration": render_configuration,
@@ -76,6 +81,8 @@ def build_prefetch_receipt(
         "lens": {
             "scope_allowlist": [dict(scope) for scope in selection.scope_allowlist],
             "scope_status": selection.scope_status,
+            "project_identity_state": project_resolution.state if project_resolution else selection.scope_status,
+            "project_identity_diagnostics": list(project_resolution.diagnostics) if project_resolution else [],
             "perspective": {"observer": str(perspective.get("observer", "")), "observed": str(perspective.get("observed", ""))},
             "query_intent": str(pack.get("query_intent", "")),
             "query_digest": str(task_ref.get("sha256", "")),
@@ -132,9 +139,19 @@ def validate_prefetch_receipt(value: object) -> list[str]:
     except (TypeError, ValueError, RecursionError):
         return ["encoding"]
     schema_version = value.get("schema_version")
-    if schema_version not in {LEGACY_MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION, MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION}:
+    if schema_version not in {LEGACY_MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION, PRINCIPAL_MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION, MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION}:
         errors.append("schema_version")
     if schema_version == MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION:
+        if value.get("resolver_version") != RESOLVER_VERSION:
+            errors.append("resolver_version")
+        if not isinstance(value.get("project_identity"), str):
+            errors.append("project_identity")
+        identity_lens = value.get("lens")
+        if not isinstance(identity_lens, dict) or identity_lens.get("project_identity_state") not in ("resolved", "unresolved", "inspection"):
+            errors.append("project_identity_state")
+        elif not isinstance(identity_lens.get("project_identity_diagnostics"), list) or any(not isinstance(token, str) or token not in DIAGNOSTICS for token in identity_lens["project_identity_diagnostics"]):
+            errors.append("project_identity_diagnostics")
+    if schema_version in {PRINCIPAL_MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION, MEMORY_PREFETCH_RECEIPT_SCHEMA_VERSION}:
         decision = value.get("principal_decision")
         if not isinstance(decision, dict) or decision.get("binding_state") not in {"validated_local", "host_validated", "unbound"}:
             errors.append("principal_decision")

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -82,6 +82,7 @@ from .memory_dreaming import (
 )
 from .memory_eviction import build_eviction_plan
 from .memory_principals import parse_principal_context
+from .project_identity import ProjectIdentityResolution, project_identity_root, resolve_project_identity
 from .memory_prefetch_receipt import (
     build_prefetch_receipt,
     mark_prefetch_receipt_returned,
@@ -139,6 +140,8 @@ class OmhMemoryProvider(_MemoryProviderBase):
         # inside a repository; `initialize` resolves it from the working
         # directory. The user home is always read as well.
         self._project_home: Path | None = None
+        self._project_cwd: str | None = None
+        self._project_resolution = ProjectIdentityResolution()
         # prefetch() is called before every API call and the base class asks for
         # it to be fast, so the pack is rendered off the hot path and served
         # from here. `_query` is what the pack was ranked for; `_pack_count`
@@ -196,7 +199,9 @@ class OmhMemoryProvider(_MemoryProviderBase):
         self._profile_ref = str(self._principal_context.get("profile_ref", "")) if self._principal_context is not None else str(kwargs.get("active_profile", "") or "")
         if self._shared_surface:
             self._principal_context = None
-        self._project_home = _project_omh_home(kwargs.get("cwd"))
+        self._project_cwd = str(kwargs.get("cwd") or Path.cwd())
+        self._project_home = _project_omh_home(self._project_cwd)
+        self._project_resolution = resolve_project_identity(self._project_cwd)
         callback = kwargs.get("status_callback")
         self._status_callback = callback if callable(callback) else None
         self._pack = self.render_pack()
@@ -403,6 +408,7 @@ class OmhMemoryProvider(_MemoryProviderBase):
     def render_pack(self, *, now: datetime | None = None) -> str:
         """System blocks in full, reference blocks by label only, then the
         reviewed records the canonical selector chose for the queued query."""
+        self._project_resolution = resolve_project_identity(self._project_cwd)
         moment = now or datetime.now(timezone.utc)
         blocks = () if self._shared_surface else read_memory_blocks(self._omh_home)
         selection = self._block_selection(blocks=blocks, now=moment)
@@ -436,6 +442,7 @@ class OmhMemoryProvider(_MemoryProviderBase):
             session_id=self._session_id,
             home_digests=snapshot.home_digests,
             rendered_block_count=block_count,
+            project_resolution=self._project_resolution,
         )
         # The brief is a request, not a memory: it is served so the model can
         # consolidate in this turn, and it never moves the recall count.
@@ -449,14 +456,8 @@ class OmhMemoryProvider(_MemoryProviderBase):
         return (self._omh_home,)
 
     def _prefetch_scopes(self) -> list[dict[str, str]]:
-        """Explicit labels only: user-global, this project, this thread.
-
-        The project identity is the repository directory name -- the same rule
-        `omh memory recall` and the handoff apply through `project_identity` --
-        and `default` outside any repository. A record's own scope never
-        widens this list.
-        """
-        identity = self._project_home.parent.name if self._project_home is not None else "default"
+        """One stable project label, or an unresolved, fail-closed allowlist."""
+        identity = self._project_resolution.identity
         principal = str(self._principal_context.get("principal", "")) if self._principal_context is not None else ""
         return prefetch_scope_allowlist(
             project_identity=identity,
@@ -963,10 +964,9 @@ def _project_omh_home(cwd: object = None) -> Path | None:
     working directory to `initialize`, so the process cwd stands in.
     """
     try:
-        start = Path(str(cwd)).expanduser() if cwd else Path.cwd()
-        for candidate in (start, *start.parents):
-            if (candidate / ".git").exists():
-                return candidate / ".omh"
+        root = project_identity_root(str(cwd) if cwd else None)
+        if root is not None:
+            return root / ".omh"
     except OSError:
         return None
     return None

--- a/src/plugin_bundle/omh/memory_recall_selector.py
+++ b/src/plugin_bundle/omh/memory_recall_selector.py
@@ -20,6 +20,7 @@ from .memory_governance import (
     evaluate_memory_replay,
 )
 from .memory_principals import audience_policy_digest, parse_principal_context, principal_recall_decision
+from .project_identity import RESOLVER_VERSION
 from .memory_recall_support import (
     LEGACY_MEMORY_SCOPE_SCHEMA_VERSION,
     LEGACY_PROJECT_MEMORY_RECORD_SCHEMA_VERSION,
@@ -100,6 +101,8 @@ def resolve_scope_allowlist(
             return (), "unresolved"
         if scope not in scopes:
             scopes.append(scope)
+    if not inspection and sum(scope["kind"] == "project" for scope in scopes) > 1:
+        return (), "unresolved"
     if not scopes or any(kind not in {scope["kind"] for scope in scopes} for kind in required_scope_kinds):
         return (), "unresolved"
     return tuple(sorted(scopes, key=lambda scope: (scope["kind"], scope["ref"]))), "resolved"
@@ -116,6 +119,7 @@ def _selection_result(
     configuration = {
         **effective_recall_configuration(),
         "scope_allowlist": list(scopes),
+        "project_identity": next((scope["ref"] for scope in scopes if scope["kind"] == "project"), ""),
         "scope_status": scope_status,
         "perspective": pack["perspective"],
         "query_intent": pack["query_intent"],
@@ -157,6 +161,7 @@ def effective_recall_configuration() -> dict[str, object]:
     """
     return {
         "selector_schema_version": "omh_memory_recall_selector/v1",
+        "resolver_version": RESOLVER_VERSION,
         "scope_policy": "explicit_allowlist/v1",
         "recall_pack_schema_version": PROJECT_MEMORY_RECALL_PACK_SCHEMA_VERSION,
         "rrf_k": _RECALL_RRF_K,

--- a/src/plugin_bundle/omh/project_identity.py
+++ b/src/plugin_bundle/omh/project_identity.py
@@ -1,0 +1,170 @@
+"""Filesystem-only, opaque project-memory identity for the standalone bundle.
+
+Resolution is read-only. Only the explicit operator mint function writes.
+Git includes, commands, credential helpers and network services are never run.
+"""
+from __future__ import annotations
+
+import configparser
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+from urllib.parse import urlsplit
+
+RESOLVER_VERSION = "project_identity/v2"
+EXPLICIT_SCHEMA_VERSION = "project_identity_file/v1"
+LEGACY_BASENAME_STATE = "legacy_basename"
+DIAGNOSTICS = frozenset({"remote_absent", "remote_ambiguous", "explicit_invalid", "git_metadata_unreadable", "outside_repository"})
+
+
+@dataclass(frozen=True)
+class ProjectIdentityResolution:
+    resolver_version: str = RESOLVER_VERSION
+    state: str = "unresolved"
+    identity: str = ""
+    evidence: str = ""
+    diagnostics: tuple[str, ...] = ()
+
+
+class ProjectIdentityUnresolvedError(ValueError):
+    """Capture cannot invent project authority or silently widen its audience."""
+
+    def __init__(self) -> None:
+        super().__init__("scope_unresolved: run `omh memory project-identity init` in the project")
+
+
+def project_identity_root(cwd: str | Path | None = None) -> Path | None:
+    start = Path(cwd).expanduser().absolute() if cwd is not None else Path.cwd()
+    for root in (start, *start.parents):
+        if (root / ".git").exists() or (root / ".git").is_symlink() or (root / ".omh" / "project-identity.json").exists():
+            return root
+    return None
+
+
+def _unresolved(reason: str) -> ProjectIdentityResolution:
+    return ProjectIdentityResolution(diagnostics=(reason,))
+
+
+def _explicit(path: Path) -> str:
+    if path.is_symlink():
+        raise ValueError("explicit_invalid")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or set(value) != {"schema_version", "identity", "created_at", "resolver_version"}:
+        raise ValueError("explicit_invalid")
+    if value["schema_version"] != EXPLICIT_SCHEMA_VERSION or value["resolver_version"] != RESOLVER_VERSION:
+        raise ValueError("explicit_invalid")
+    identity = value["identity"]
+    if not isinstance(identity, str) or not re.fullmatch(r"prj:[0-9a-f]{64}", identity):
+        raise ValueError("explicit_invalid")
+    created = value["created_at"]
+    if not isinstance(created, str) or datetime.fromisoformat(created.replace("Z", "+00:00")).tzinfo is None:
+        raise ValueError("explicit_invalid")
+    return identity
+
+
+def _normalize_remote(raw: str) -> str:
+    value = raw.strip()
+    if "://" in value:
+        parsed = urlsplit(value)
+        host = parsed.hostname or ""
+        # Keep non-default ports: they can identify distinct repositories.
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        value = host.lower() + port + parsed.path
+    else:
+        scp = re.fullmatch(r"(?:[^/@:]+@)?([^/:]+):(.+)", value)
+        if scp:
+            value = scp[1].lower() + "/" + scp[2].lstrip("/")
+        else:
+            host, sep, path = value.rpartition("@")[-1].partition("/")
+            value = host.lower() + sep + path
+    value = value.rstrip("/")
+    if value.endswith(".git"):
+        value = value[:-4]
+    if not value or any(char in value for char in ("\n", "\r", "\x00")):
+        raise ValueError("remote_invalid")
+    return value
+
+
+def resolve_project_identity(cwd: str | Path | None = None) -> ProjectIdentityResolution:
+    try:
+        root = project_identity_root(cwd)
+        if root is None:
+            return _unresolved("outside_repository")
+        explicit = root / ".omh" / "project-identity.json"
+        if explicit.exists() or explicit.is_symlink():
+            try:
+                identity = _explicit(explicit)
+            except (OSError, ValueError, TypeError, RecursionError):
+                return _unresolved("explicit_invalid")
+            return ProjectIdentityResolution(state="resolved", identity=identity, evidence="explicit")
+        gitdir = root / ".git"
+        if gitdir.is_file():
+            marker = gitdir.read_text(encoding="utf-8").strip()
+            if not marker.startswith("gitdir: ") or "\n" in marker:
+                return _unresolved("git_metadata_unreadable")
+            gitdir = root / marker[8:].strip()
+        common = gitdir / "commondir"
+        if common.exists():
+            relative = common.read_text(encoding="utf-8").strip()
+            if not relative or "\n" in relative:
+                return _unresolved("git_metadata_unreadable")
+            gitdir = gitdir / relative
+        config = configparser.RawConfigParser(interpolation=None)
+        config.read_string((gitdir / "config").read_text(encoding="utf-8"))
+        remotes = {}
+        for section in config.sections():
+            match = re.fullmatch(r'remote "([^"]+)"', section)
+            if match and config.has_option(section, "url"):
+                remotes[match[1]] = _normalize_remote(config.get(section, "url"))
+        if not remotes:
+            return _unresolved("remote_absent")
+        if "origin" in remotes:
+            remote = remotes["origin"]
+        elif len(set(remotes.values())) > 1:
+            return _unresolved("remote_ambiguous")
+        else:
+            remote = remotes[sorted(remotes)[0]]
+        identity = "repo:" + hashlib.sha256(remote.encode("utf-8")).hexdigest()[:32]
+        return ProjectIdentityResolution(state="resolved", identity=identity, evidence="vcs_remote")
+    except (OSError, ValueError, configparser.Error):
+        return _unresolved("git_metadata_unreadable")
+
+
+def require_project_identity(cwd: str | Path | None = None) -> str:
+    resolution = resolve_project_identity(cwd)
+    if resolution.state != "resolved":
+        raise ProjectIdentityUnresolvedError()
+    return resolution.identity
+
+
+def mint_explicit_project_identity(root: str | Path) -> str:
+    """Explicit local-only opt-in. Existing invalid evidence is never overwritten."""
+    root = Path(root).expanduser()
+    path = root / ".omh" / "project-identity.json"
+    if path.exists() or path.is_symlink():
+        try:
+            return _explicit(path)
+        except (OSError, ValueError, TypeError, RecursionError):
+            raise ValueError("explicit_invalid") from None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    identity = "prj:" + secrets.token_hex(32)
+    value = {"schema_version": EXPLICIT_SCHEMA_VERSION, "identity": identity,
+             "created_at": datetime.now(timezone.utc).isoformat(), "resolver_version": RESOLVER_VERSION}
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return _explicit(path)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+        json.dump(value, stream, sort_keys=True)
+        stream.write("\n")
+    return identity
+
+
+def legacy_project_scope(root: str | Path) -> dict[str, str]:
+    """Inspection/migration only; never an automatic recall fallback."""
+    return {"kind": "project", "ref": Path(root).name or "default"}

--- a/src/plugin_bundle/omh/project_identity.py
+++ b/src/plugin_bundle/omh/project_identity.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 import re
 import secrets
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 RESOLVER_VERSION = "project_identity/v2"
 EXPLICIT_SCHEMA_VERSION = "project_identity_file/v1"
@@ -67,21 +67,66 @@ def _explicit(path: Path) -> str:
     return identity
 
 
-def _normalize_remote(raw: str) -> str:
-    value = raw.strip()
+def _git_config_value(raw: str) -> str:
+    """Decode Git quotes/escapes and comments before interpreting a remote URL."""
+    decoded: list[str] = []
+    quoted = escaped = False
+    escapes = {"n": "\n", "t": "\t", "b": "\b", '"': '"', "\\": "\\"}
+    for char in raw:
+        if escaped:
+            if char not in escapes:
+                raise ValueError("remote_invalid")
+            decoded.append(escapes[char])
+            escaped = False
+        elif char == "\\":
+            escaped = True
+        elif char == '"':
+            quoted = not quoted
+        elif char in "#;" and not quoted:
+            break
+        else:
+            decoded.append(char)
+    if quoted or escaped:
+        raise ValueError("remote_invalid")
+    return "".join(decoded).strip()
+
+
+def _local_remote(value: str, anchor: Path) -> str:
+    # Local endpoints have no host authority. Qualify them against the common
+    # Git directory's checkout, never hash an ambiguous relative spelling.
+    if not value or (os.name != "nt" and re.match(r"^(?:[A-Za-z]:|\\\\)", value)):
+        raise ValueError("remote_invalid")
+    endpoint = (anchor / Path(value).expanduser()).resolve(strict=True)
+    if not endpoint.is_dir() and not endpoint.is_file():
+        raise ValueError("remote_invalid")
+    return "local:" + endpoint.as_uri()
+
+
+def _normalize_remote(raw: str, *, local_anchor: Path) -> str:
+    value = _git_config_value(raw)
+    if any(char in value for char in ("\n", "\r", "\x00")):
+        raise ValueError("remote_invalid")
     if "://" in value:
         parsed = urlsplit(value)
+        if parsed.scheme == "file":
+            if parsed.query or parsed.fragment or parsed.hostname not in (None, "", "localhost"):
+                raise ValueError("remote_invalid")
+            local = unquote(parsed.path)
+            if os.name == "nt" and re.match(r"^/[A-Za-z]:/", local):
+                local = local[1:]
+            return _local_remote(local, local_anchor)
         host = parsed.hostname or ""
+        if not host:
+            raise ValueError("remote_invalid")
         # Keep non-default ports: they can identify distinct repositories.
         port = f":{parsed.port}" if parsed.port is not None else ""
         value = host.lower() + port + parsed.path
     else:
         scp = re.fullmatch(r"(?:[^/@:]+@)?([^/:]+):(.+)", value)
-        if scp:
+        if scp and not re.match(r"^[A-Za-z]:[\\\\/]", value):
             value = scp[1].lower() + "/" + scp[2].lstrip("/")
         else:
-            host, sep, path = value.rpartition("@")[-1].partition("/")
-            value = host.lower() + sep + path
+            return _local_remote(value, local_anchor)
     value = value.rstrip("/")
     if value.endswith(".git"):
         value = value[:-4]
@@ -114,13 +159,14 @@ def resolve_project_identity(cwd: str | Path | None = None) -> ProjectIdentityRe
             if not relative or "\n" in relative:
                 return _unresolved("git_metadata_unreadable")
             gitdir = gitdir / relative
+        gitdir = gitdir.resolve(strict=True)
         config = configparser.RawConfigParser(interpolation=None)
         config.read_string((gitdir / "config").read_text(encoding="utf-8"))
         remotes = {}
         for section in config.sections():
             match = re.fullmatch(r'remote "([^"]+)"', section)
             if match and config.has_option(section, "url"):
-                remotes[match[1]] = _normalize_remote(config.get(section, "url"))
+                remotes[match[1]] = _normalize_remote(config.get(section, "url"), local_anchor=gitdir.parent)
         if not remotes:
             return _unresolved("remote_absent")
         if "origin" in remotes:

--- a/src/workflows/_memory_lifecycle_plans.py
+++ b/src/workflows/_memory_lifecycle_plans.py
@@ -162,6 +162,17 @@ def _approved_record(replacement: Mapping[str, object], record_id: str, revision
     return record
 
 
+def project_identity_successor(record: Mapping[str, Any], scope_ref: str, now: datetime, *, operation_id: str) -> tuple[dict[str, Any], dict[str, object]]:
+    """Reviewed scope-only successor; never renew retention or rewrite source evidence."""
+    replacement = {**record, "scope": {"kind": "project", "ref": scope_ref}}
+    successor: dict[str, Any] = _approved_record(replacement, str(record["record_id"]), int(record["revision"]) + 1, "reviewed_project_identity_migration", now)
+    successor = {**record, "operation_id": operation_id, **{key: successor[key] for key in ("revision", "scope", "admission")},
+                 **({"identity": successor["identity"]} if "identity" in successor else {})}
+    successor["admission"] = {**successor["admission"], "artifact_identity": stable_artifact_identity(successor), "payload_digest": canonical_payload_digest(successor)}
+    review = _review(successor, str(successor["admission"]["review_id"]), "reviewed_project_identity_migration")
+    return successor, review
+
+
 def _review(record: Mapping[str, object], review_id: str, reviewer: str) -> dict[str, object]:
     return {"schema_version": PRINCIPAL_PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION if record.get("schema_version") == PRINCIPAL_PROJECT_MEMORY_RECORD_SCHEMA_VERSION else PROJECT_MEMORY_REVIEW_RECORD_SCHEMA_VERSION, "review_id": review_id, "artifact_identity": stable_artifact_identity(dict(record)), "decision": "approved_manual", "reviewer_claim": reviewer, **({"identity": dict(record["identity"])} if isinstance(record.get("identity"), Mapping) else {}), "payload_digest": canonical_payload_digest(dict(record)), "policy_version": MEMORY_GOVERNANCE_POLICY_VERSION, "classifier_version": MEMORY_CLASSIFIER_VERSION}
 

--- a/src/workflows/domain_handoff_projection.py
+++ b/src/workflows/domain_handoff_projection.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from ..paths import OmhPaths, project_identity
+from ..paths import OmhPaths
+from ..plugin_bundle.omh.project_identity import resolve_project_identity
 from .domain_intelligence_lineage import ProfileValidationContext
 from .domain_intelligence_store import (
     domain_store_lock,
@@ -30,7 +31,7 @@ def build_domain_handoff_projection(
     project_root = paths.omh_home.parent
     store = paths.memory_dir / "domain-intelligence"
     required = (store / ".store.lock", store / "candidates", store / "profiles", store / "reviews", store / "history")
-    if project_identity(project_root) == "default" or not store.exists():
+    if resolve_project_identity(project_root).state != "resolved" or not store.exists():
         return [], []
     if not all(path.exists() for path in required):
         return [], [_exclusion("domain-profile-store", "domain_profile_store_unhealthy")]
@@ -75,7 +76,7 @@ def _project_records(
         candidates=candidate_values,
         reviews=review_values,
     )
-    expected_scope = {"kind": "project", "ref": project_identity(project_root)}
+    expected_scope = {"kind": "project", "ref": resolve_project_identity(project_root).identity}
     included: list[dict[str, object]] = []
     excluded: list[dict[str, object]] = []
 

--- a/src/workflows/domain_intelligence_profile_resolution.py
+++ b/src/workflows/domain_intelligence_profile_resolution.py
@@ -46,15 +46,18 @@ def resolve_domain_clarification_target_result(
     project_root: Path,
     locale: str,
 ) -> DomainClarificationResolution:
-    from ..paths import project_identity
+    from ..plugin_bundle.omh.project_identity import resolve_project_identity
     from ..skills import catalog
 
     if len(message) > MAX_DOMAIN_CONTEXT_INPUT_CODE_POINTS:
         return DomainClarificationResolution("input_too_large")
 
+    resolution = resolve_project_identity(project_root)
+    if resolution.state != "resolved":
+        return DomainClarificationResolution("no_match")
     expected_scope = {
         "kind": "project",
-        "ref": project_identity(project_root),
+        "ref": resolution.identity,
         "ref_authority": "operator_or_wrapper_supplied",
         "identity_claim": "not_authenticated_identity_evidence",
     }

--- a/src/workflows/memory.py
+++ b/src/workflows/memory.py
@@ -123,7 +123,8 @@ from ..plugin_bundle.omh.memory_recall_support import (
     normalize_memory_attention_tier as normalize_memory_attention_tier,
     record_attention_tier as record_attention_tier,
 )
-from ..paths import OmhPaths, project_identity
+from ..paths import OmhPaths
+from ..plugin_bundle.omh.project_identity import require_project_identity, resolve_project_identity
 from ..profiles.setup import read_setup_profile
 from ..targets import summarize_target_registry
 
@@ -789,7 +790,7 @@ def capture_project_memory_candidate(
     content: str = "",
     record_type: str = "fact",
     scope_kind: str = "project",
-    scope_ref: str = "default",
+    scope_ref: str | None = None,
     source: str = "cli",
     source_ref: str = "",
     tags: list[str] | tuple[str, ...] | None = None,
@@ -889,6 +890,8 @@ def capture_project_memory_candidate(
         }
     if audience_principals and parsed_principal is None:
         raise ValueError("shared memory admission requires a validated acting principal")
+    if scope_ref is None:
+        scope_ref = require_project_identity(paths.omh_home.parent) if scope_kind == "project" else "default"
     effective_scope_ref = str(parsed_principal["principal"]) if scope_kind == "user" and parsed_principal is not None else scope_ref
     candidate = _build_project_memory_candidate(
         summary,
@@ -1398,6 +1401,8 @@ def memory_recall_pack_for_handoff(
     # Dropping it here was the silent failure: the handoff went out with no
     # memory and no statement that a stale record had been held back, so the
     # operator never got the chance to confirm, replace, or retire it.
+    if pack_scope["kind"] == "unresolved":
+        return {**pack, "scope": pack_scope}
     if not pack.get("enabled") or not (pack.get("included_records") or pack.get("freshness_warnings")):
         return None
     return pack
@@ -2787,6 +2792,8 @@ def build_handoff_context_pack(
     run_id: str | None = None,
 ) -> dict[str, object]:
     pack_scope = _handoff_pack_scope(paths, scope_kind=scope_kind, scope_ref=scope_ref)
+    if pack_scope["kind"] == "unresolved":
+        inspection = {"snapshots": [], "conflicts": []}
     if inspection is None:
         snapshots = _local_snapshots(paths, scope_kind=scope_kind, scope_ref=scope_ref, session_limit=session_limit, now=now)
         inspection = {"snapshots": snapshots, "conflicts": _detect_conflicts(snapshots)}
@@ -2807,6 +2814,9 @@ def build_handoff_context_pack(
             item_id = str(item.get("item_id", ""))
             if source == "omh_memory":
                 artifact = _memory_artifact_for_snapshot_item(paths, item)
+                artifact_scope = artifact.get("scope")
+                if isinstance(artifact_scope, dict) and artifact_scope.get("kind") == "project" and artifact_scope != pack_scope:
+                    continue
                 # Context packs are executor-facing exactly like recall
                 # packs, so they apply the same lens: a record about another
                 # executor is excluded here, not silently skipped, because
@@ -2847,7 +2857,7 @@ def build_handoff_context_pack(
                     "summary": str(item.get("summary", "")),
                     "source": source,
                     "truth_level": str(snapshot.get("truth_level", "")),
-                    "scope": item.get("scope", snapshot.get("scope", _scope("project", "default"))),
+                    "scope": item.get("scope", snapshot.get("scope", pack_scope)) if source == "omh_memory" else pack_scope,
                 }
                 if evaluation:
                     context_item["replay_evaluation"] = evaluation
@@ -2858,7 +2868,7 @@ def build_handoff_context_pack(
     # Reviewed domain profiles share the existing OMH-memory handoff lane, but
     # are resolved directly from their own validated store rather than trusted
     # from a caller-supplied inspection snapshot.
-    if (not scope_kind or scope_kind == "project"):
+    if pack_scope["kind"] == "project":
         from .domain_handoff_projection import build_domain_handoff_projection
 
         domain_included, domain_excluded = build_domain_handoff_projection(paths)
@@ -2889,6 +2899,7 @@ def build_handoff_context_pack(
         "session_id": session_id,
         "scope": pack_scope,
         "source_refs": _source_refs(inspection),
+        **({"metadata": {"scope_status": "scope_unresolved"}} if pack_scope["kind"] == "unresolved" else {}),
         "included_context": kept,
         "excluded_context": excluded,
         "blocked_by_conflicts": blocking_conflicts,
@@ -4666,7 +4677,8 @@ def _handoff_pack_scope(paths: OmhPaths, *, scope_kind: str | None, scope_ref: s
     if scope_kind and scope_ref:
         return _scope(str(scope_kind), str(scope_ref))
     project_root = paths.omh_home.parent
-    return _scope("project", project_identity(project_root))
+    resolution = resolve_project_identity(project_root)
+    return _scope("project", resolution.identity) if resolution.state == "resolved" else _scope("unresolved", "scope_unresolved")
 
 
 def _source_refs(inspection: dict[str, Any]) -> list[dict[str, object]]:

--- a/src/workflows/memory_evaluation.py
+++ b/src/workflows/memory_evaluation.py
@@ -35,7 +35,8 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from ..paths import OmhPaths, project_identity
+from ..paths import OmhPaths
+from ..plugin_bundle.omh.project_identity import resolve_project_identity
 from ..plugin_bundle.omh.memory_governance import canonical_payload_digest, evaluate_memory_replay, stable_artifact_identity
 from ..plugin_bundle.omh.memory_prefetch_receipt import build_prefetch_receipt, validate_prefetch_receipt
 from ..plugin_bundle.omh.memory_provider import OmhMemoryProvider
@@ -96,9 +97,8 @@ PARITY_FIELDS = (
     "selector_schema_version",
     "recall_pack_schema_version",
 )
-# The fixture corpus files its records under project/default, so the fixture
-# repository is named to resolve to that identity on both paths.
-PARITY_PROJECT_IDENTITY = "default"
+# The fixture repository carries matching remote evidence, independent of name.
+PARITY_PROJECT_IDENTITY = "fixture-checkout"
 PARITY_SESSION_ID = "session-fixture"
 PARITY_USER_GLOBAL_SCOPE = {"kind": "user-global", "ref": "default"}
 # Two retrieval reports are comparable only when every one of these agrees.
@@ -249,7 +249,7 @@ def run_live_prefetch_arms(
     prepared = prepare_prefetch_records(
         snapshot,
         query,
-        allowed_scopes=prefetch_scope_allowlist(project_identity=project_root.name, session_id=session_id),
+        allowed_scopes=prefetch_scope_allowlist(project_identity=resolve_project_identity(project_root).identity, session_id=session_id),
         session_id=session_id,
         limit=limit,
         max_chars=max_chars,
@@ -329,6 +329,7 @@ def _run_retrieval_case(
         # resolve the project identity from the directory holding `.git`.
         project_root = root / PARITY_PROJECT_IDENTITY
         (project_root / ".git").mkdir(parents=True)
+        (project_root / ".git" / "config").write_text('[remote "origin"]\n url = https://example.invalid/memory-fixture.git\n', encoding="utf-8")
         paths = OmhPaths(project_root / ".omh", root / "hermes")
         _seed_retrieval_store(paths, case)
         pack = pack_builder(
@@ -369,7 +370,7 @@ def _run_parity_arms(
     lens: dict[str, object] = {
         "scope_allowlist": [
             dict(PARITY_USER_GLOBAL_SCOPE),
-            {"kind": "project", "ref": project_identity(paths.omh_home.parent)},
+            {"kind": "project", "ref": resolve_project_identity(paths.omh_home.parent).identity},
             {"kind": "thread", "ref": PARITY_SESSION_ID},
         ],
         "executor_target": PREFETCH_EXECUTOR_TARGET,

--- a/src/workflows/memory_lifecycle_executor.py
+++ b/src/workflows/memory_lifecycle_executor.py
@@ -8,10 +8,10 @@ from typing import Any
 from ..system.paths import OmhPaths
 from ._memory_lifecycle_model import LifecycleMutation, LifecyclePlan
 from .memory_lifecycle import make_lifecycle_receipt
-from .memory_store import run_memory_operation
+from .memory_store import OperationPreflight, run_memory_operation
 
 
-def execute_memory_lifecycle(paths: OmhPaths, plan: LifecyclePlan) -> dict[str, object]:
+def execute_memory_lifecycle(paths: OmhPaths, plan: LifecyclePlan, *, preflight: OperationPreflight | None = None) -> dict[str, object]:
     """Apply one plan through the shared operation lock and durable step log."""
     steps = lifecycle_operation_steps(plan)
     operation = run_memory_operation(
@@ -20,6 +20,7 @@ def execute_memory_lifecycle(paths: OmhPaths, plan: LifecyclePlan) -> dict[str, 
         operation_type=f"memory_lifecycle_{plan.operation_type}",
         steps=steps,
         now=plan.now,
+        preflight=preflight,
     )
     if not _same_steps(operation.get("steps"), steps):
         raise ValueError("lifecycle_operation_mismatch")

--- a/src/workflows/memory_project_identity.py
+++ b/src/workflows/memory_project_identity.py
@@ -1,0 +1,237 @@
+"""Operator-reviewed, digest-bound migration of project scope identities.
+
+Reports never write. Apply and rollback use the existing lifecycle transaction
+journal; originals are moved, not edited, and reviews remain immutable.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from ..plugin_bundle.omh.memory_governance import canonical_payload_digest, stable_artifact_identity
+from ..plugin_bundle.omh.project_identity import (
+    LEGACY_BASENAME_STATE, project_identity_root, resolve_project_identity,
+)
+from ..system.local_store import atomic_write_json
+from ..system.paths import OmhPaths, default_omh_home
+from ._memory_lifecycle_model import LifecycleMutation, LifecyclePlan
+from ._memory_lifecycle_plans import project_identity_successor
+from ._memory_lifecycle_scan import json_files, read_json, safe_token
+from .memory_lifecycle_executor import execute_memory_lifecycle
+from .memory_store import checked_memory_json_path
+
+REPORT_SCHEMA = "project_identity_migration_report/v1"
+RECEIPT_SCHEMA = "project_identity_migration_receipt/v1"
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _root(paths: OmhPaths, root: Path | None) -> Path:
+    return root if root is not None else (project_identity_root(paths.omh_home.parent) or Path.cwd())
+
+
+def _stores(paths: OmhPaths, root: Path) -> dict[str, OmhPaths]:
+    project = root / ".omh"
+    user = paths.omh_home if paths.omh_home.resolve() != project.resolve() else default_omh_home()
+    stores = {"project": OmhPaths(project, paths.hermes_home)}
+    if user.resolve() != project.resolve():
+        stores["user"] = OmhPaths(user, paths.hermes_home)
+    return stores
+
+
+def _read(paths: OmhPaths, relative: str) -> dict[str, Any]:
+    value, error = read_json(paths.memory_dir, relative)
+    if error or value is None:
+        raise ValueError("migration_artifact_unreadable")
+    return value
+
+
+def _source_review(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
+    admission = record.get("admission", {})
+    review_id = admission.get("review_id") if isinstance(admission, dict) else None
+    if not safe_token(review_id):
+        raise ValueError("migration_source_review_invalid")
+    review = _read(paths, f"reviews/{review_id}.json")
+    if (review.get("schema_version") not in {"project_memory_review_record/v2", "project_memory_review_record/v3"}
+            or review.get("decision") not in {"approved_manual", "approved_auto_safe"}
+            or review.get("artifact_identity") != stable_artifact_identity(record)
+            or review.get("payload_digest") != canonical_payload_digest(record)):
+        raise ValueError("migration_source_review_mismatch")
+    return review
+
+
+def build_project_identity_migration_report(paths: OmhPaths, *, root: Path | None = None) -> dict[str, Any]:
+    root = _root(paths, root)
+    resolution = resolve_project_identity(root)
+    entries, bindings = [], []
+    if resolution.state == "resolved":
+        for store, local in _stores(paths, root).items():
+            for relative, error in json_files(local.memory_dir, "records"):
+                if error:
+                    raise ValueError("migration_store_unreadable")
+                record = _read(local, relative)
+                scope = record.get("scope", {})
+                if not isinstance(scope, dict) or scope.get("kind") != "project" or scope.get("ref") == resolution.identity:
+                    continue
+                record_id, current_ref = record.get("record_id"), scope.get("ref")
+                if not safe_token(record_id) or not safe_token(current_ref):
+                    raise ValueError("migration_metadata_invalid")
+                entries.append({"record_id": record_id, "current_ref": current_ref, "proposed_ref": resolution.identity, "store": store})
+                # Approval binds every source byte-equivalent payload and its
+                # immutable review, not just IDs or a printed scope label.
+                admission = record.get("admission", {})
+                review_id = admission.get("review_id", "") if isinstance(admission, dict) else ""
+                review = _read(local, f"reviews/{review_id}.json") if safe_token(review_id) else {}
+                bindings.append({"record": _digest(record), "review": _digest(review)})
+    body = {"schema_version": REPORT_SCHEMA, "resolution": asdict(resolution), "entries": entries,
+            "compatibility_state": LEGACY_BASENAME_STATE, "redaction_policy": "metadata_only"}
+    if resolution.state != "resolved":
+        body["guidance"] = "omh memory project-identity init"
+    return {**body, "report_digest": _digest({"report": body, "bindings": bindings})}
+
+
+def _receipt_path(paths: OmhPaths, receipt_id: str) -> Path:
+    if not re.fullmatch(r"pim_[0-9a-f]{64}", receipt_id):
+        raise ValueError("migration_receipt_invalid")
+    return checked_memory_json_path(paths, f"project-identity-migrations/{receipt_id}.json")
+
+
+def _plan(row: dict[str, Any], source: dict[str, Any], now: datetime, receipt_id: str) -> LifecyclePlan:
+    record_id, revision = row["record_id"], row["revision"]
+    target, review = project_identity_successor(source, row["proposed_ref"], now, operation_id=f"project-migrate-{receipt_id[4:28]}-{record_id}")
+    if _digest(target) != row["target_digest"]:
+        raise ValueError("migration_source_changed")
+    mutations = (
+        LifecycleMutation("preserve_original", "move", f"history/{record_id}.r{revision}.json", f"history:{record_id}:r{revision}", "history", source=f"records/{record_id}.json"),
+        LifecycleMutation("write_successor_review", "write", f'reviews/{review["review_id"]}.json', f'review:{review["review_id"]}', "review", payload=review),
+        LifecycleMutation("write_successor", "write", f"records/{record_id}.json", f"record:{record_id}:r{revision + 1}", "record", payload=target),
+    )
+    return LifecyclePlan(f"project-migrate-{receipt_id[4:28]}-{record_id}", "project_identity_migrate", record_id, revision + 1, target["scope"], now, {}, mutations)
+
+
+def migrate_project_identity(paths: OmhPaths, *, approve: str, root: Path | None = None) -> dict[str, Any]:
+    root = _root(paths, root)
+    if not re.fullmatch(r"[0-9a-f]{64}", approve):
+        raise ValueError("approval_digest_mismatch")
+    receipt_id = "pim_" + approve
+    destination = _receipt_path(paths, receipt_id)
+    stores = _stores(paths, root)
+    prior, error = read_json(paths.memory_dir, f"project-identity-migrations/{receipt_id}.json")
+    if error not in {None, "already_absent"}:
+        raise ValueError("migration_receipt_invalid")
+    resolution = resolve_project_identity(root)
+    receipt: dict[str, Any]
+    if prior is not None:
+        if prior.get("schema_version") != RECEIPT_SCHEMA or prior.get("report_digest") != approve or prior.get("project_identity") != resolution.identity or prior.get("state") not in {"prepared", "completed"}:
+            raise ValueError("migration_receipt_mismatch")
+        receipt = prior
+    else:
+        report = build_project_identity_migration_report(paths, root=root)
+        if report["report_digest"] != approve or resolution.state != "resolved":
+            raise ValueError("approval_digest_mismatch")
+        now = datetime.now(timezone.utc)
+        rows = []
+        for entry in report["entries"]:
+            local = stores[entry["store"]]
+            source = _read(local, f'records/{entry["record_id"]}.json')
+            if source.get("schema_version") not in {"project_memory_record/v2", "project_memory_record/v3"} or source.get("source_class") != "omh_local" or type(source.get("revision")) is not int:
+                raise ValueError("migration_requires_reviewed_revision")
+            _source_review(local, source)
+            successor, review = project_identity_successor(source, resolution.identity, now, operation_id=f'project-migrate-{receipt_id[4:28]}-{entry["record_id"]}')
+            if (local.memory_dir / f'history/{entry["record_id"]}.r{source["revision"]}.json').exists() or (local.memory_dir / f'reviews/{review["review_id"]}.json').exists():
+                raise ValueError("migration_successor_conflict")
+            rows.append({**entry, "revision": source["revision"], "source_digest": _digest(source), "target_digest": _digest(successor)})
+        receipt = {"schema_version": RECEIPT_SCHEMA, "receipt_id": receipt_id, "report_digest": approve,
+                   "project_identity": resolution.identity, "created_at": now.isoformat(), "successors": rows,
+                   "rollback_token": receipt_id, "state": "prepared", "redaction_policy": "metadata_only"}
+        atomic_write_json(destination, receipt, private=True)
+    now = datetime.fromisoformat(receipt["created_at"])
+    changed = []
+    for row in receipt["successors"]:
+        local = stores[row["store"]]
+        current, _ = read_json(local.memory_dir, f'records/{row["record_id"]}.json')
+        target_present = current is not None and _digest(current) == row["target_digest"]
+        if receipt["state"] == "completed":
+            if not target_present:
+                raise ValueError("migration_target_changed")
+            continue
+        if current is None or target_present:
+            source = _read(local, f'history/{row["record_id"]}.r{row["revision"]}.json')
+        else:
+            source = current
+        if _digest(source) != row["source_digest"]:
+            raise ValueError("migration_source_changed")
+        _source_review(local, source)
+        def preflight(locked: OmhPaths) -> None:
+            if resolve_project_identity(root).identity != receipt["project_identity"]:
+                raise ValueError("migration_identity_changed")
+            live_source = _read(locked, f'records/{row["record_id"]}.json')
+            if _digest(live_source) != row["source_digest"]:
+                raise ValueError("migration_source_changed")
+            _source_review(locked, live_source)
+            if (locked.memory_dir / f'history/{row["record_id"]}.r{row["revision"]}.json').exists():
+                raise ValueError("migration_successor_conflict")
+
+        result = execute_memory_lifecycle(local, _plan(row, source, now, receipt_id), preflight=preflight)
+        if "receipt" not in result:
+            raise ValueError("migration_operation_incomplete")
+        changed.append(row)
+    receipt = {**receipt, "state": "completed"}
+    atomic_write_json(destination, receipt, private=True)
+    return {**receipt, "successors": changed, "idempotent": not changed}
+
+
+def rollback_project_identity_migration(paths: OmhPaths, receipt_id: str, *, root: Path | None = None) -> dict[str, Any]:
+    destination = _receipt_path(paths, receipt_id)
+    receipt: dict[str, Any] = _read(paths, f"project-identity-migrations/{receipt_id}.json")
+    if receipt.get("schema_version") != RECEIPT_SCHEMA or receipt.get("receipt_id") != receipt_id or receipt.get("state") not in {"completed", "rolling_back", "rolled_back"}:
+        raise ValueError("migration_receipt_invalid")
+    stores = _stores(paths, _root(paths, root))
+    # Validate every target before retiring any successor.
+    for row in receipt["successors"]:
+        local = stores[row["store"]]
+        current, current_error = read_json(local.memory_dir, f'records/{row["record_id"]}.json')
+        if current_error not in {None, "already_absent"}:
+            raise ValueError("rollback_target_changed")
+        if receipt["state"] in {"rolling_back", "rolled_back"} and (current is None or _digest(current) == row["source_digest"]):
+            archived = _read(local, f'archive/project-identity-{row["record_id"]}.r{row["revision"] + 1}.json')
+            if _digest(archived) != row["target_digest"]:
+                raise ValueError("rollback_target_changed")
+            if current is not None:
+                continue
+        elif current is None or _digest(current) != row["target_digest"]:
+            raise ValueError("rollback_target_changed")
+        source = _read(local, f'history/{row["record_id"]}.r{row["revision"]}.json')
+        if _digest(source) != row["source_digest"]:
+            raise ValueError("rollback_source_changed")
+    if receipt["state"] != "rolled_back":
+        receipt = {**receipt, "state": "rolling_back"}
+        atomic_write_json(destination, receipt, private=True)
+        for row in receipt["successors"]:
+            record_id, revision = row["record_id"], row["revision"]
+            mutations = (
+                LifecycleMutation("retire_successor", "move", f"archive/project-identity-{record_id}.r{revision + 1}.json", f"archive:{record_id}:r{revision + 1}", "archive", source=f"records/{record_id}.json"),
+                LifecycleMutation("restore_original", "move", f"records/{record_id}.json", f"record:{record_id}:r{revision}", "record", source=f"history/{record_id}.r{revision}.json"),
+            )
+            plan = LifecyclePlan(f"project-rollback-{receipt_id[4:28]}-{record_id}", "project_identity_rollback", record_id, revision, {"kind": "project", "ref": row["current_ref"]}, datetime.fromisoformat(receipt["created_at"]), {}, mutations)
+            def preflight(locked: OmhPaths) -> None:
+                current = _read(locked, f"records/{record_id}.json")
+                source = _read(locked, f"history/{record_id}.r{revision}.json")
+                if _digest(current) != row["target_digest"] or _digest(source) != row["source_digest"]:
+                    raise ValueError("rollback_target_changed")
+                if (locked.memory_dir / f"archive/project-identity-{record_id}.r{revision + 1}.json").exists():
+                    raise ValueError("rollback_archive_conflict")
+
+            result = execute_memory_lifecycle(stores[row["store"]], plan, preflight=preflight)
+            if "receipt" not in result:
+                raise ValueError("rollback_operation_incomplete")
+    receipt = {**receipt, "state": "rolled_back"}
+    atomic_write_json(destination, receipt, private=True)
+    return receipt

--- a/src/workflows/memory_project_identity.py
+++ b/src/workflows/memory_project_identity.py
@@ -34,7 +34,7 @@ def _digest(value: object) -> str:
 
 
 def _root(paths: OmhPaths, root: Path | None) -> Path:
-    return root if root is not None else (project_identity_root(paths.omh_home.parent) or Path.cwd())
+    return root if root is not None else (project_identity_root() or Path.cwd())
 
 
 def _stores(paths: OmhPaths, root: Path) -> dict[str, OmhPaths]:
@@ -67,10 +67,31 @@ def _source_review(paths: OmhPaths, record: dict[str, Any]) -> dict[str, Any]:
     return review
 
 
+class ProjectIdentitySourceChangedError(ValueError):
+    """The approved snapshot no longer describes this exact record/review pair."""
+
+
+def _bound_source(paths: OmhPaths, entry: dict[str, Any], relative: str) -> dict[str, Any]:
+    source, error = read_json(paths.memory_dir, relative)
+    if error or source is None or source.get("revision") != entry["revision"] or _digest(source) != entry["source_digest"]:
+        raise ProjectIdentitySourceChangedError("source_changed_since_report")
+    review_id = entry.get("review_id")
+    if not safe_token(review_id):
+        raise ProjectIdentitySourceChangedError("source_changed_since_report")
+    review, error = read_json(paths.memory_dir, f"reviews/{review_id}.json")
+    if error or review is None or _digest(review) != entry.get("review_digest"):
+        raise ProjectIdentitySourceChangedError("source_changed_since_report")
+    return source
+
+
+def _skipped(entry: dict[str, Any]) -> dict[str, str]:
+    return {"record_id": entry["record_id"], "store": entry["store"], "reason_code": "source_changed_since_report"}
+
+
 def build_project_identity_migration_report(paths: OmhPaths, *, root: Path | None = None) -> dict[str, Any]:
     root = _root(paths, root)
     resolution = resolve_project_identity(root)
-    entries, bindings = [], []
+    entries = []
     if resolution.state == "resolved":
         for store, local in _stores(paths, root).items():
             for relative, error in json_files(local.memory_dir, "records"):
@@ -83,18 +104,19 @@ def build_project_identity_migration_report(paths: OmhPaths, *, root: Path | Non
                 record_id, current_ref = record.get("record_id"), scope.get("ref")
                 if not safe_token(record_id) or not safe_token(current_ref):
                     raise ValueError("migration_metadata_invalid")
-                entries.append({"record_id": record_id, "current_ref": current_ref, "proposed_ref": resolution.identity, "store": store})
-                # Approval binds every source byte-equivalent payload and its
-                # immutable review, not just IDs or a printed scope label.
+                # Keep the approved record/review snapshot in each report row;
+                # apply must not replace these bindings with a subsequent read.
                 admission = record.get("admission", {})
                 review_id = admission.get("review_id", "") if isinstance(admission, dict) else ""
                 review = _read(local, f"reviews/{review_id}.json") if safe_token(review_id) else {}
-                bindings.append({"record": _digest(record), "review": _digest(review)})
+                entries.append({"record_id": record_id, "current_ref": current_ref, "proposed_ref": resolution.identity, "store": store,
+                                "revision": record.get("revision"), "source_digest": _digest(record),
+                                "review_id": review_id if safe_token(review_id) else "", "review_digest": _digest(review)})
     body = {"schema_version": REPORT_SCHEMA, "resolution": asdict(resolution), "entries": entries,
             "compatibility_state": LEGACY_BASENAME_STATE, "redaction_policy": "metadata_only"}
     if resolution.state != "resolved":
         body["guidance"] = "omh memory project-identity init"
-    return {**body, "report_digest": _digest({"report": body, "bindings": bindings})}
+    return {**body, "report_digest": _digest(body)}
 
 
 def _receipt_path(paths: OmhPaths, receipt_id: str) -> Path:
@@ -137,23 +159,28 @@ def migrate_project_identity(paths: OmhPaths, *, approve: str, root: Path | None
         if report["report_digest"] != approve or resolution.state != "resolved":
             raise ValueError("approval_digest_mismatch")
         now = datetime.now(timezone.utc)
-        rows = []
+        rows, skipped = [], []
         for entry in report["entries"]:
             local = stores[entry["store"]]
-            source = _read(local, f'records/{entry["record_id"]}.json')
+            try:
+                source = _bound_source(local, entry, f'records/{entry["record_id"]}.json')
+            except ProjectIdentitySourceChangedError:
+                skipped.append(_skipped(entry))
+                continue
             if source.get("schema_version") not in {"project_memory_record/v2", "project_memory_record/v3"} or source.get("source_class") != "omh_local" or type(source.get("revision")) is not int:
                 raise ValueError("migration_requires_reviewed_revision")
             _source_review(local, source)
             successor, review = project_identity_successor(source, resolution.identity, now, operation_id=f'project-migrate-{receipt_id[4:28]}-{entry["record_id"]}')
             if (local.memory_dir / f'history/{entry["record_id"]}.r{source["revision"]}.json').exists() or (local.memory_dir / f'reviews/{review["review_id"]}.json').exists():
                 raise ValueError("migration_successor_conflict")
-            rows.append({**entry, "revision": source["revision"], "source_digest": _digest(source), "target_digest": _digest(successor)})
+            rows.append({**entry, "target_digest": _digest(successor)})
         receipt = {"schema_version": RECEIPT_SCHEMA, "receipt_id": receipt_id, "report_digest": approve,
-                   "project_identity": resolution.identity, "created_at": now.isoformat(), "successors": rows,
+                   "project_identity": resolution.identity, "created_at": now.isoformat(), "successors": rows, "skipped": skipped,
                    "rollback_token": receipt_id, "state": "prepared", "redaction_policy": "metadata_only"}
         atomic_write_json(destination, receipt, private=True)
     now = datetime.fromisoformat(receipt["created_at"])
     changed = []
+    skipped = list(receipt.get("skipped", []))
     for row in receipt["successors"]:
         local = stores[row["store"]]
         current, _ = read_json(local.memory_dir, f'records/{row["record_id"]}.json')
@@ -162,28 +189,29 @@ def migrate_project_identity(paths: OmhPaths, *, approve: str, root: Path | None
             if not target_present:
                 raise ValueError("migration_target_changed")
             continue
-        if current is None or target_present:
-            source = _read(local, f'history/{row["record_id"]}.r{row["revision"]}.json')
-        else:
-            source = current
-        if _digest(source) != row["source_digest"]:
-            raise ValueError("migration_source_changed")
-        _source_review(local, source)
-        def preflight(locked: OmhPaths) -> None:
-            if resolve_project_identity(root).identity != receipt["project_identity"]:
-                raise ValueError("migration_identity_changed")
-            live_source = _read(locked, f'records/{row["record_id"]}.json')
-            if _digest(live_source) != row["source_digest"]:
-                raise ValueError("migration_source_changed")
-            _source_review(locked, live_source)
-            if (locked.memory_dir / f'history/{row["record_id"]}.r{row["revision"]}.json').exists():
-                raise ValueError("migration_successor_conflict")
+        relative = f'history/{row["record_id"]}.r{row["revision"]}.json' if current is None or target_present else f'records/{row["record_id"]}.json'
+        try:
+            source = _bound_source(local, row, relative)
+            _source_review(local, source)
 
-        result = execute_memory_lifecycle(local, _plan(row, source, now, receipt_id), preflight=preflight)
+            def preflight(locked: OmhPaths) -> None:
+                if resolve_project_identity(root).identity != receipt["project_identity"]:
+                    raise ValueError("migration_identity_changed")
+                live_source = _bound_source(locked, row, f'records/{row["record_id"]}.json')
+                _source_review(locked, live_source)
+                if (locked.memory_dir / f'history/{row["record_id"]}.r{row["revision"]}.json').exists():
+                    raise ValueError("migration_successor_conflict")
+
+            result = execute_memory_lifecycle(local, _plan(row, source, now, receipt_id), preflight=preflight)
+        except ProjectIdentitySourceChangedError:
+            skipped.append(_skipped(row))
+            continue
         if "receipt" not in result:
             raise ValueError("migration_operation_incomplete")
         changed.append(row)
-    receipt = {**receipt, "state": "completed"}
+    skipped_keys = {(row["store"], row["record_id"]) for row in skipped}
+    receipt = {**receipt, "state": "completed", "skipped": skipped,
+               "successors": [row for row in receipt["successors"] if (row["store"], row["record_id"]) not in skipped_keys]}
     atomic_write_json(destination, receipt, private=True)
     return {**receipt, "successors": changed, "idempotent": not changed}
 

--- a/src/workflows/memory_recall_incident.py
+++ b/src/workflows/memory_recall_incident.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import replace
+from pathlib import Path
 from typing import Any
 
 from ..plugin_bundle.omh.hermes_memory import HERMES_MEMORY_FILES, read_hermes_memory_file
@@ -31,7 +32,7 @@ __all__ = ['RecallIncidentRequest', 'build_memory_recall_incident',
            'write_memory_recall_incident', 'diagnose_synthetic_recall_stage']
 
 
-def _read_live_receipt(paths: OmhPaths, request: RecallIncidentRequest) -> tuple[EvidenceSurface, dict[str, Any] | None]:
+def _read_live_receipt(paths: OmhPaths, request: RecallIncidentRequest, *, invocation_cwd: str | Path | None = None) -> tuple[EvidenceSurface, dict[str, Any] | None]:
     """Bind the provider's persisted receipt to this store, session, configuration and scope.
 
     Absent or unreadable proof is unknown. A receipt that exists but names a
@@ -69,7 +70,7 @@ def _read_live_receipt(paths: OmhPaths, request: RecallIncidentRequest) -> tuple
     home_digests = store.get('home_digests') if isinstance(store, dict) else None
     if not isinstance(home_digests, list) or digest(str(paths.omh_home.resolve())) not in home_digests:
         return rejected('receipt_store_mismatch')
-    resolution = resolve_project_identity(paths.omh_home.parent)
+    resolution = resolve_project_identity(invocation_cwd)
     if receipt.get('resolver_version') != resolution.resolver_version or receipt.get('project_identity') != resolution.identity:
         return rejected('receipt_project_identity_mismatch')
     lens = receipt['lens']
@@ -123,10 +124,10 @@ def _receipt_stage(receipt: dict[str, Any], record_id: str, claim_digest: str) -
     return 'live_selection_excluded', 'selected'
 
 
-def build_memory_recall_incident(paths: OmhPaths, request: RecallIncidentRequest) -> Incident:
-    """Inspect one scoped anchor; never attach raw recall packs to an incident."""
+def build_memory_recall_incident(paths: OmhPaths, request: RecallIncidentRequest, *, invocation_cwd: str | Path | None = None) -> Incident:
+    """Inspect an anchor under the active checkout, independently of store location."""
     if request.scope_kind == 'project' and not request.scope_ref:
-        request = replace(request, scope_ref=resolve_project_identity(paths.omh_home.parent).identity)
+        request = replace(request, scope_ref=resolve_project_identity(invocation_cwd).identity)
     pack = memory.build_project_memory_recall_pack(
         paths, request.query, session_id=request.session_id,
         scope_kind=request.scope_kind, scope_ref=request.scope_ref,
@@ -143,7 +144,7 @@ def build_memory_recall_incident(paths: OmhPaths, request: RecallIncidentRequest
             ('provider_recall_status', 'not_supplied'),
         )
     }
-    surfaces['live_prefetch_receipt'], receipt = _read_live_receipt(paths, request)
+    surfaces['live_prefetch_receipt'], receipt = _read_live_receipt(paths, request, invocation_cwd=invocation_cwd)
     surfaces['canonical_recall_pack'] = {'status': 'observed', 'basis': 'prepared_local_selection'}
     surfaces['omh_approved_records'] = {
         'status': 'unavailable' if unreadable else 'observed',
@@ -264,8 +265,8 @@ def build_memory_recall_incident(paths: OmhPaths, request: RecallIncidentRequest
                         (reason, last), basis = staged, 'live_prefetch_receipt'
     if not pack['enabled']:
         reason = 'project_memory_disabled'
-    root = project_identity_root(paths.omh_home.parent)
-    resolution = resolve_project_identity(paths.omh_home.parent)
+    root = project_identity_root(invocation_cwd)
+    resolution = resolve_project_identity(invocation_cwd)
     if root is not None and resolution.state == 'resolved' and request.scope_kind == 'project' and request.scope_ref == legacy_project_scope(root)['ref']:
         reason = LEGACY_BASENAME_STATE
         basis = 'project_identity_resolution'
@@ -295,9 +296,9 @@ def build_memory_recall_incident(paths: OmhPaths, request: RecallIncidentRequest
     return result
 
 
-def write_memory_recall_incident(paths: OmhPaths, request: RecallIncidentRequest) -> Incident:
+def write_memory_recall_incident(paths: OmhPaths, request: RecallIncidentRequest, *, invocation_cwd: str | Path | None = None) -> Incident:
     """Explicitly persist only the bounded diagnosis, never caller-supplied artifacts."""
-    result = build_memory_recall_incident(paths, request)
+    result = build_memory_recall_incident(paths, request, invocation_cwd=invocation_cwd)
     destination = paths.memory_incidents_dir / f"{result['incident_id']}.json"
     memory._assert_under_memory_root(paths, destination)
     atomic_write_json(destination, dict(result), private=True)

--- a/src/workflows/memory_recall_incident.py
+++ b/src/workflows/memory_recall_incident.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import replace
 from typing import Any
 
 from ..plugin_bundle.omh.hermes_memory import HERMES_MEMORY_FILES, read_hermes_memory_file
@@ -16,6 +17,7 @@ from ..plugin_bundle.omh.memory_prefetch_receipt import (
     MAX_PREFETCH_RECEIPT_BYTES, prefetch_receipt_path, validate_prefetch_receipt,
 )
 from ..plugin_bundle.omh.memory_recall_selector import select_memory_recall
+from ..plugin_bundle.omh.project_identity import LEGACY_BASENAME_STATE, legacy_project_scope, project_identity_root, resolve_project_identity
 from ..system.local_store import atomic_write_json, read_json_object_result
 from ..system.paths import OmhPaths
 from . import memory
@@ -67,6 +69,9 @@ def _read_live_receipt(paths: OmhPaths, request: RecallIncidentRequest) -> tuple
     home_digests = store.get('home_digests') if isinstance(store, dict) else None
     if not isinstance(home_digests, list) or digest(str(paths.omh_home.resolve())) not in home_digests:
         return rejected('receipt_store_mismatch')
+    resolution = resolve_project_identity(paths.omh_home.parent)
+    if receipt.get('resolver_version') != resolution.resolver_version or receipt.get('project_identity') != resolution.identity:
+        return rejected('receipt_project_identity_mismatch')
     lens = receipt['lens']
     perspective = lens['perspective']
     allowlist = [{**scope} for scope in lens['scope_allowlist'] if isinstance(scope, dict)]
@@ -120,6 +125,8 @@ def _receipt_stage(receipt: dict[str, Any], record_id: str, claim_digest: str) -
 
 def build_memory_recall_incident(paths: OmhPaths, request: RecallIncidentRequest) -> Incident:
     """Inspect one scoped anchor; never attach raw recall packs to an incident."""
+    if request.scope_kind == 'project' and not request.scope_ref:
+        request = replace(request, scope_ref=resolve_project_identity(paths.omh_home.parent).identity)
     pack = memory.build_project_memory_recall_pack(
         paths, request.query, session_id=request.session_id,
         scope_kind=request.scope_kind, scope_ref=request.scope_ref,
@@ -257,6 +264,11 @@ def build_memory_recall_incident(paths: OmhPaths, request: RecallIncidentRequest
                         (reason, last), basis = staged, 'live_prefetch_receipt'
     if not pack['enabled']:
         reason = 'project_memory_disabled'
+    root = project_identity_root(paths.omh_home.parent)
+    resolution = resolve_project_identity(paths.omh_home.parent)
+    if root is not None and resolution.state == 'resolved' and request.scope_kind == 'project' and request.scope_ref == legacy_project_scope(root)['ref']:
+        reason = LEGACY_BASENAME_STATE
+        basis = 'project_identity_resolution'
     config = {
         'home_digest': digest(str(paths.omh_home.resolve())),
         'session_digest': digest(request.session_id),

--- a/src/workflows/memory_recall_incident_model.py
+++ b/src/workflows/memory_recall_incident_model.py
@@ -31,7 +31,7 @@ class RecallIncidentRequest:
     query: str = ''
     session_id: str = ''
     scope_kind: str = 'project'
-    scope_ref: str = 'default'
+    scope_ref: str = ''
     observer: str | None = None
     observed: str | None = None
     limit: int = 6
@@ -50,7 +50,7 @@ class RecallIncidentRequest:
             raise IncidentInputError('scope_kind')
         for field in ('scope_ref', 'observer', 'observed'):
             value = getattr(self, field)
-            if value is not None:
+            if value is not None and not (field == 'scope_ref' and value == '' and self.scope_kind == 'project'):
                 require_opaque_metadata_ref(value, field=field)
         for field in ('limit', 'max_chars', 'provider_served_count'):
             value = getattr(self, field)
@@ -105,6 +105,7 @@ REASON_STAGES: Final[dict[str, Stage]] = {
     'invalid_record': 'invalid_or_superseded', 'review_required_legacy': 'invalid_or_superseded',
     'review_not_found': 'invalid_or_superseded', 'review_identity_mismatch': 'invalid_or_superseded',
     'scope_mismatch': 'scope_or_perspective_mismatch', 'perspective_mismatch': 'scope_or_perspective_mismatch',
+    'legacy_basename': 'scope_or_perspective_mismatch',
     'review_due': 'stale_expired_or_archived', 'stale_review_required': 'stale_expired_or_archived',
     'expired_standard': 'stale_expired_or_archived', 'expired_volatile': 'stale_expired_or_archived',
     'expired_durable': 'stale_expired_or_archived', 'archived_tier': 'stale_expired_or_archived',

--- a/src/workflows/memory_retrieval_fixtures.py
+++ b/src/workflows/memory_retrieval_fixtures.py
@@ -34,7 +34,8 @@ from ..plugin_bundle.omh.memory_governance import (
     stable_artifact_identity,
 )
 
-FIXTURE_CORPUS_VERSION = "omh-memory-retrieval-fixtures/v1"
+FIXTURE_CORPUS_VERSION = "omh-memory-retrieval-fixtures/v2"
+FIXTURE_PROJECT_IDENTITY = "repo:" + hashlib.sha256(b"example.invalid/memory-fixture").hexdigest()[:32]
 # The corpus clock. Absolute, declared once, never derived from the host.
 FIXTURE_CLOCK = datetime(2031, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
 FIXTURE_CLOCK_ISO = "2031-01-02T03:04:05Z"
@@ -61,7 +62,7 @@ def _record(
     tags: tuple[str, ...] = (),
     record_type: str = "fact",
     scope_kind: str = "project",
-    scope_ref: str = "default",
+    scope_ref: str = FIXTURE_PROJECT_IDENTITY,
     observer: str = "",
     observed: str = "",
     retention_class: str = "standard",
@@ -358,7 +359,7 @@ RETRIEVAL_CASES: tuple[dict[str, object], ...] = (
         ),
         query="release checklist",
         scope_kind="project",
-        scope_ref="default",
+        scope_ref=FIXTURE_PROJECT_IDENTITY,
         included_order=("mem_r50_in_scope",),
         absent=("mem_r51_other_scope",),
     ),

--- a/src/workflows/project_terms_capture.py
+++ b/src/workflows/project_terms_capture.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import re
 import stat
 
-from ..paths import OmhPaths, find_project_root, project_identity
+from ..paths import OmhPaths, find_project_root
+from ..plugin_bundle.omh.project_identity import require_project_identity, resolve_project_identity
 from ..system.binary_io import open_binary
 from ..system.local_store import utc_now
 from .domain_intelligence_contracts import (
@@ -71,7 +72,7 @@ def capture_project_terms_file(
     source = _read_repository_project_terms(root, from_file)
     document = parse_project_terms(source)
     inputs = build_project_terms_capture_inputs(document)
-    scope = normalize_scope("project", project_identity(root))
+    scope = normalize_scope("project", require_project_identity(root))
     domains = _preview_domains(paths, scope, inputs)
     available = _candidate_capacity_available(paths)
     required = len(inputs)
@@ -130,7 +131,8 @@ def project_terms_source_freshness(
         and digest_match is not None
         and isinstance(scope, dict)
         and scope.get("kind") == "project"
-        and scope.get("ref") == project_identity(root)
+        and scope.get("ref") == resolve_project_identity(root).identity
+        and bool(scope.get("ref"))
     )
     if not tracked:
         return _freshness_payload(

--- a/tests/domain_context_diagnostics_support.py
+++ b/tests/domain_context_diagnostics_support.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
-from omh.paths import project_identity
+from project_identity_fixture import project_identity
 from omh.workflows.domain_routing_context import DomainRoutingResolution
 
 from test_domain_routing_context import _binding

--- a/tests/domain_context_lifecycle_support.py
+++ b/tests/domain_context_lifecycle_support.py
@@ -11,6 +11,7 @@ import unittest
 from unittest import mock
 
 from _local_package import load_local_package
+from project_identity_fixture import project_identity, seed_repository_remote
 
 load_local_package()
 from omh.skills.catalog import builtin_definitions
@@ -36,6 +37,7 @@ def _canonical(value: object) -> str:
 def _repository(path: Path) -> Path:
     path.mkdir(parents=True)
     (path / ".git").mkdir()
+    seed_repository_remote(path)
     return path.resolve()
 
 
@@ -149,7 +151,7 @@ def _capture_and_approve(
     candidate_id = _capture_candidate(
         root,
         scope_kind=scope_kind,
-        scope_ref=scope_ref or root.name,
+        scope_ref=scope_ref or project_identity(root),
         domain=domain,
         phrase=phrase,
         canonical=canonical,

--- a/tests/domain_routing_context_support.py
+++ b/tests/domain_routing_context_support.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 from pathlib import Path
+from project_identity_fixture import project_identity, seed_repository_remote
 
 
 CLAIM_BOUNDARY = (
@@ -36,6 +37,7 @@ def _resolver():
 def _repository(root: Path) -> Path:
     root.mkdir(parents=True)
     (root / ".git").mkdir()
+    seed_repository_remote(root)
     return root
 
 
@@ -49,7 +51,7 @@ def _approve_profile(
     scope_kind: str = "project",
     scope_ref: str | None = None,
 ) -> dict[str, object]:
-    from omh.paths import project_identity, resolve_paths
+    from omh.paths import resolve_paths
     from omh.workflows.domain_intelligence import (
         approve_domain_candidate,
         capture_domain_candidate,

--- a/tests/project_identity_fixture.py
+++ b/tests/project_identity_fixture.py
@@ -1,0 +1,42 @@
+"""Plain-file repository fixtures; no resolver mocks or git subprocesses."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.paths import resolve_paths as _resolve_paths
+from omh.plugin_bundle.omh.project_identity import resolve_project_identity
+
+PROJECT_IDENTITY = "prj:" + "a" * 64
+
+
+def seed_project_identity(root: Path, identity: str = PROJECT_IDENTITY) -> str:
+    path = root / ".omh" / "project-identity.json"
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"schema_version": "project_identity_file/v1", "identity": identity,
+                                   "created_at": "2026-01-01T00:00:00Z", "resolver_version": "project_identity/v2"}), encoding="utf-8")
+        path.chmod(0o600)
+    return resolve_project_identity(root).identity
+
+
+def seed_repository_remote(root: Path) -> str:
+    gitdir = root / ".git"
+    gitdir.mkdir(parents=True, exist_ok=True)
+    (gitdir / "config").write_text(f'[remote "origin"]\n url = https://example.invalid/{root.name}.git\n', encoding="utf-8")
+    return resolve_project_identity(root).identity
+
+
+def memory_paths(omh_home, hermes_home=None, **kwargs):
+    """Give a memory test's named checkout explicit repository evidence."""
+    paths = _resolve_paths(omh_home, hermes_home, **kwargs)
+    if resolve_project_identity(paths.omh_home.parent).state != "resolved":
+        seed_project_identity(paths.omh_home.parent)
+    return paths
+
+
+def project_identity(root):
+    return resolve_project_identity(root).identity

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5201,7 +5201,7 @@ Latest runtime run: 20260625T090917585910Z-loop-goal-loop-8b5bec.
             self.assertTrue(applied["applied"])
             self.assertIn("receipt", applied)
 
-            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "memory", "pack", "--executor", "codex"])
+            status, stdout, stderr = run_cli(["--omh-home", str(omh_home), "memory", "pack", "--executor", "codex", "--scope-kind", "project", "--scope-ref", "default"])
 
             self.assertEqual(stderr, "")
             self.assertEqual(status, 0)

--- a/tests/test_coding_lifecycle.py
+++ b/tests/test_coding_lifecycle.py
@@ -17,7 +17,7 @@ from omh.coding_lifecycle import (
     start_codex_delegation_lifecycle,
 )
 from omh.memory import capture_project_memory_candidate
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.profiles.setup import write_setup_profile
 from omh.coding.executor_capability_snapshots import (
     build_executor_capability_snapshot,

--- a/tests/test_domain_context_lifecycle_journey.py
+++ b/tests/test_domain_context_lifecycle_journey.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from _local_package import load_local_package
+from project_identity_fixture import project_identity
 
 load_local_package()
 from omh.skills.catalog import builtin_definitions
@@ -74,7 +75,7 @@ class DomainContextLifecycleJourneyMixin:
             first_candidate_id = _capture_candidate(
                 root,
                 scope_kind="project",
-                scope_ref="redwood-project",
+                scope_ref=project_identity(root),
                 domain="redwood-operations",
                 phrase=phrase,
                 canonical="redwood_review_marker",
@@ -145,7 +146,7 @@ class DomainContextLifecycleJourneyMixin:
             replacement_id = _capture_candidate(
                 root,
                 scope_kind="project",
-                scope_ref="redwood-project",
+                scope_ref=project_identity(root),
                 domain="redwood-operations",
                 phrase=phrase,
                 canonical="redwood_review_marker",
@@ -175,7 +176,7 @@ class DomainContextLifecycleJourneyMixin:
                 "--scope-kind",
                 "project",
                 "--scope-ref",
-                "redwood-project",
+                project_identity(root),
                 "--domain",
                 "redwood-operations",
                 "--retired-by",

--- a/tests/test_domain_context_matching_efficiency.py
+++ b/tests/test_domain_context_matching_efficiency.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import unittest
 from unittest.mock import patch
 
-from omh.paths import project_identity
+from project_identity_fixture import project_identity
 from omh.workflows import domain_intelligence_profile_resolution as resolution
 
 

--- a/tests/test_domain_context_persistence_privacy.py
+++ b/tests/test_domain_context_persistence_privacy.py
@@ -8,7 +8,7 @@ from _local_package import load_local_package
 load_local_package()
 
 from omh.coding_lifecycle import start_codex_delegation_lifecycle
-from omh.paths import project_identity
+from project_identity_fixture import project_identity
 from omh.runtime_records import (
     WRAPPER_SESSION_RECORD_KEYS,
     validate_wrapper_session_record,

--- a/tests/test_domain_handoff_projection.py
+++ b/tests/test_domain_handoff_projection.py
@@ -17,7 +17,8 @@ from omh.memory import (  # noqa: E402
     memory_recall_pack_for_handoff,
     validate_handoff_context_pack,
 )
-from omh.paths import OmhPaths, project_identity, resolve_paths  # noqa: E402
+from omh.paths import OmhPaths  # noqa: E402
+from project_identity_fixture import project_identity, memory_paths as resolve_paths
 from omh.workflows.domain_intelligence import (  # noqa: E402
     approve_domain_candidate,
     capture_domain_candidate,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -43,7 +43,7 @@ from omh.memory import (
     validate_project_memory_recall_pack,
 )
 from omh.memory import file_lock
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.profiles.setup import write_setup_profile
 from omh.targets import record_target_observation
 
@@ -1358,7 +1358,7 @@ class MemoryContractTests(unittest.TestCase):
             self.assertIn("receipt", applied)
 
             inspection = build_memory_inspection(paths, summary=True, review_item_limit=2)
-            pack = build_handoff_context_pack(paths, context_limit=2)
+            pack = build_handoff_context_pack(paths, context_limit=2, scope_kind="project", scope_ref="default")
 
             self.assertEqual(inspection["snapshots"], [])
             self.assertGreaterEqual(inspection["snapshot_count"], 1)

--- a/tests/test_memory_attention_tiers.py
+++ b/tests/test_memory_attention_tiers.py
@@ -36,7 +36,7 @@ from omh.memory import (
     validate_project_memory_record,
     validate_project_memory_recall_pack,
 )
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.plugin_bundle.omh.memory_governance import canonical_payload_digest
 
 _NOW = datetime(2026, 6, 1, tzinfo=timezone.utc)

--- a/tests/test_memory_batches.py
+++ b/tests/test_memory_batches.py
@@ -25,6 +25,12 @@ from omh.workflows.memory import (
 )
 
 
+def _legacy_handoff(paths):
+    # Lifecycle fixtures deliberately retain their persisted legacy refs.
+    return build_handoff_context_pack(paths, scope_kind="project", scope_ref="default",
+                                      inspection={"snapshots": _memory_snapshots(paths), "conflicts": []})
+
+
 def _batch(label: str, *, scope: dict[str, str] | None = None) -> dict[str, object]:
     return {
         "schema_version": "memory_update_batch/v1",
@@ -81,7 +87,7 @@ class MemoryBatchTests(TestCase):
             self.assertTrue(item["item_id"].startswith("item_"))
             self.assertEqual(item["retention_class"], "standard")
             self.assertTrue(staged["batch_id"].startswith("batch_"))
-            self.assertNotIn(item["item_id"], {row["item_id"] for row in build_handoff_context_pack(paths)["included_context"]})
+            self.assertNotIn(item["item_id"], {row["item_id"] for row in _legacy_handoff(paths)["included_context"]})
 
             applied = apply_approved_memory_update_batch(
                 paths,
@@ -93,7 +99,7 @@ class MemoryBatchTests(TestCase):
                 staged["batch_id"],
                 now=datetime(2026, 9, 6, 2, 0, tzinfo=timezone.utc),
             )
-            handoff = build_handoff_context_pack(paths)
+            handoff = _legacy_handoff(paths)
             receipt = applied["receipt"]
 
             self.assertEqual(applied["status"], "applied")
@@ -1517,13 +1523,13 @@ class MemoryBatchTests(TestCase):
             with self.assertRaisesRegex(RuntimeError, "injected named write interruption"):
                 apply_approved_memory_update_batch(paths, staged["batch_id"], write_hook=interrupt_on_second_write)
 
-            interrupted = build_handoff_context_pack(paths)
+            interrupted = _legacy_handoff(paths)
             self.assertFalse({item["item_id"] for item in interrupted["included_context"]} & {row["item_id"] for row in staged["items"]})
             self.assertEqual(
                 apply_approved_memory_update_batch(paths, staged["batch_id"])["status"],
                 "applied",
             )
-            recovered = build_handoff_context_pack(paths)
+            recovered = _legacy_handoff(paths)
             ids = [item["item_id"] for item in recovered["included_context"]]
             self.assertTrue({row["item_id"] for row in staged["items"]} <= set(ids))
 
@@ -1571,7 +1577,7 @@ class MemoryBatchTests(TestCase):
                     worker.join(timeout=10)
                     self.assertEqual(worker.exitcode, 0)
                 self.assertCountEqual([queue.get(timeout=2), queue.get(timeout=2)], [("applied", first["batch_id"]), ("applied", second["batch_id"])])
-                ids = {item["item_id"] for item in build_handoff_context_pack(paths)["included_context"]}
+                ids = {item["item_id"] for item in _legacy_handoff(paths)["included_context"]}
                 self.assertTrue({first["items"][0]["item_id"], second["items"][0]["item_id"]} <= ids)
 
 

--- a/tests/test_memory_demotion.py
+++ b/tests/test_memory_demotion.py
@@ -25,7 +25,7 @@ from _local_package import load_local_package
 
 load_local_package()
 from omh.memory import approve_project_memory_candidate, capture_project_memory_candidate
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.plugin_bundle.omh.hermes_memory import (
     DEFAULT_MEMORY_FILE_CAP_CHARS,
     DEMOTION_REFERENCE_LABEL_CHARS,

--- a/tests/test_memory_fusion.py
+++ b/tests/test_memory_fusion.py
@@ -34,7 +34,7 @@ from omh.memory import (
     record_recall_usage,
     validate_project_memory_recall_pack,
 )
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 
 
 def _approve_capture(paths, summary, **kwargs):

--- a/tests/test_memory_global_scope_cli.py
+++ b/tests/test_memory_global_scope_cli.py
@@ -9,6 +9,7 @@ from typing import TypeAlias
 import unittest
 
 from _cli_harness import run_cli
+from project_identity_fixture import seed_project_identity
 
 
 Json: TypeAlias = str | int | float | bool | None | list["Json"] | dict[str, "Json"]
@@ -29,6 +30,7 @@ class GlobalScopeCliTests(unittest.TestCase):
     def test_reviewed_user_global_records_roundtrip_without_foreign_scope(self) -> None:
         with TemporaryDirectory() as temporary:
             root = Path(temporary)
+            seed_project_identity(root)
             homes = ["--omh-home", str(root / "omh"), "--hermes-home", str(root / "hermes")]
 
             def command(arguments: list[str]) -> dict[str, Json]:
@@ -70,7 +72,7 @@ class GlobalScopeCliTests(unittest.TestCase):
             assert isinstance(inspected, list)
             self.assertEqual(
                 {text(mapping(item)["record_id"]) for item in inspected},
-                {global_id, project_id},
+                {global_id},
             )
 
     def test_unknown_scope_still_fails_at_cli_boundary(self) -> None:

--- a/tests/test_memory_governance_policy.py
+++ b/tests/test_memory_governance_policy.py
@@ -14,7 +14,7 @@ import unittest
 from _local_package import load_local_package
 
 load_local_package()
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.plugin_bundle.omh.hermes_memory import classify_record_expiry
 from omh.profiles.setup import write_setup_profile
 from omh.workflows import memory

--- a/tests/test_memory_governance_retention.py
+++ b/tests/test_memory_governance_retention.py
@@ -221,7 +221,7 @@ class RecordExpiryDeadlineTests(unittest.TestCase):
         from tempfile import TemporaryDirectory
 
         from omh.memory import approve_project_memory_candidate, capture_project_memory_candidate
-        from omh.paths import resolve_paths
+        from project_identity_fixture import memory_paths as resolve_paths
 
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / ".omh", Path(tmp) / ".hermes")

--- a/tests/test_memory_mnemosyne_port.py
+++ b/tests/test_memory_mnemosyne_port.py
@@ -20,7 +20,7 @@ from omh.memory import (
     set_memory_pin,
     validate_project_memory_recall_pack,
 )
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.profiles.setup import write_setup_profile
 from omh.runtime.records import _compact_memory_recall_pack
 

--- a/tests/test_memory_perspective.py
+++ b/tests/test_memory_perspective.py
@@ -26,7 +26,7 @@ from omh.memory import (
     validate_project_memory_record,
     validate_project_memory_recall_pack,
 )
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.runtime.records import _compact_memory_recall_pack
 
 

--- a/tests/test_memory_prefetch_canonical.py
+++ b/tests/test_memory_prefetch_canonical.py
@@ -30,7 +30,7 @@ from _credential_fixtures import AWS_ACCESS_KEY_ID
 from memory_recall_fixture import reviewed, selection
 
 load_local_package()
-from omh.paths import resolve_paths
+from project_identity_fixture import PROJECT_IDENTITY, memory_paths as resolve_paths
 from omh.plugin_bundle.omh import memory_prefetch_receipt as receipts
 from omh.plugin_bundle.omh import memory_records
 from omh.plugin_bundle.omh import memory_recall_selector as selector
@@ -42,7 +42,7 @@ NOW = datetime(2026, 9, 11, tzinfo=timezone.utc)
 CAPTURED_AT = "2026-09-01T00:00:00Z"
 SESSION = "session-a"
 GLOBAL = {"kind": "user-global", "ref": "default"}
-PROJECT = {"kind": "project", "ref": "default"}
+PROJECT = {"kind": "project", "ref": PROJECT_IDENTITY}
 THREAD = {"kind": "thread", "ref": SESSION}
 
 
@@ -133,9 +133,9 @@ class CanonicalPrefetchTests(unittest.TestCase):
             root = Path(tmp)
             repo = root / "repo"
             (repo / ".git").mkdir(parents=True)
-            approve(root, "project record labelled for this repository", home="repo/.omh", scope_ref="repo")
+            approve(root, "project record labelled for this repository", home="repo/.omh")
             approve(root, "global record from the user store", scope_kind="user-global", scope_ref="default")
-            unlabelled = approve(root, "user store record still labelled project default")
+            unlabelled = approve(root, "user store record still labelled project default", scope_ref="default")
             live = provider(root, cwd=repo)
             pack = serve(live)
             self.assertIn("labelled for this repository", pack)
@@ -144,7 +144,7 @@ class CanonicalPrefetchTests(unittest.TestCase):
             receipt = live.latest_prefetch_receipt()
             assert receipt is not None
             # The selector canonicalizes the allowlist: deduplicated, sorted by (kind, ref).
-            self.assertEqual(receipt["lens"]["scope_allowlist"], [{"kind": "project", "ref": "repo"}, THREAD, GLOBAL])
+            self.assertEqual(receipt["lens"]["scope_allowlist"], [PROJECT, THREAD, GLOBAL])
             self.assertEqual(receipt["selection"]["exclusion_reason_counts"], {"scope_mismatch": 1})
             self.assertEqual(len(receipt["store"]["home_digests"]), 2)
 
@@ -171,7 +171,7 @@ class CanonicalPrefetchTests(unittest.TestCase):
             receipt = live.latest_prefetch_receipt()
             assert receipt is not None
             snapshot = memory_records.read_record_store_snapshot((root / ".omh",))
-            allowlist = memory_records.prefetch_scope_allowlist(project_identity="default", session_id=SESSION)
+            allowlist = memory_records.prefetch_scope_allowlist(project_identity=PROJECT_IDENTITY, session_id=SESSION)
             expected = selector.select_memory_recall(
                 list(snapshot.records), "release tests", allowed_scopes=allowlist, required_scope_kinds=("project",),
                 inspection=False, review_resolver=snapshot.reviews, operation_states=snapshot.operation_states,
@@ -370,7 +370,7 @@ class CanonicalPrefetchTests(unittest.TestCase):
             root = Path(tmp)
             record = approve(root, "compatible record")
             snapshot = memory_records.read_record_store_snapshot((root / ".omh",))
-            allowlist = memory_records.prefetch_scope_allowlist(project_identity="default", session_id=SESSION)
+            allowlist = memory_records.prefetch_scope_allowlist(project_identity=PROJECT_IDENTITY, session_id=SESSION)
             prepared = memory_records.prepare_prefetch_records(snapshot, "", allowed_scopes=allowlist, session_id=SESSION, now=NOW)
             self.assertEqual([item["record_id"] for item in prepared.section.rendered], [record["record_id"]])
             foreign_pack = {**prepared.selection.pack, "schema_version": "project_memory_recall_pack/v0"}

--- a/tests/test_memory_prefetch_evaluation.py
+++ b/tests/test_memory_prefetch_evaluation.py
@@ -299,7 +299,7 @@ class LiveParityReportShapeTests(unittest.TestCase):
                     lens["scope_allowlist"],
                     [
                         {"kind": "user-global", "ref": "default"},
-                        {"kind": "project", "ref": "default"},
+                        {"kind": "project", "ref": next(spec["scope_ref"] for spec in fixture["records"] if spec["scope_kind"] == "project" and not spec["contamination_class"])},
                         {"kind": "thread", "ref": PARITY_SESSION_ID},
                     ],
                 )

--- a/tests/test_memory_principal.py
+++ b/tests/test_memory_principal.py
@@ -12,7 +12,7 @@ from _local_package import load_local_package
 
 load_local_package()
 
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.plugin_bundle.omh.memory_blocks import approve_memory_block, build_memory_block, write_memory_block
 from omh.plugin_bundle.omh.memory_principals import (
     PrincipalContractError,
@@ -67,7 +67,6 @@ def _approved(
         paths,
         summary,
         scope_kind=scope_kind,
-        scope_ref="default",
         principal_context=context,
         audience_principals=audience,
         ttl_days=ttl_days,
@@ -266,13 +265,13 @@ class MemoryPrincipalTests(unittest.TestCase):
 
             # Then receipt/write evidence is decision metadata, not content or admission.
             journal = (paths.memory_dir / "write_journal.jsonl").read_text()
-            self.assertEqual(receipt["schema_version"], "omh_memory_prefetch_receipt/v2")
+            self.assertEqual(receipt["schema_version"], "omh_memory_prefetch_receipt/v3")
             self.assertEqual(receipt["principal_decision"]["principal_ref"], PRINCIPAL_A)
             self.assertNotIn("Receipt fixture fact", json.dumps(receipt))
             self.assertNotIn("native-write-body-sentinel", journal)
             self.assertIn('"admission_performed": false', journal)
 
-    def test_M8_nonshared_legacy_project_scope_remains_readable(self) -> None:
+    def test_M8_nonshared_legacy_project_scope_requires_explicit_inspection(self) -> None:
         # Given an existing v2 project record.
         with TemporaryDirectory() as tmp:
             paths = resolve_paths(Path(tmp) / "omh", Path(tmp) / "hermes")
@@ -288,8 +287,11 @@ class MemoryPrincipalTests(unittest.TestCase):
             finally:
                 provider.shutdown()
 
-            # Then the v2 project record remains available only in nonshared mode.
-            self.assertIn("Legacy project compatibility", text)
+            # Basename records remain inspectable, but never enter automatic recall.
+            self.assertNotIn("Legacy project compatibility", text)
+            from omh.workflows.memory import build_project_memory_recall_pack
+            inspection = build_project_memory_recall_pack(paths, scope_kind="project", scope_ref="default")
+            self.assertEqual(inspection["record_count"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_principal_lifecycle.py
+++ b/tests/test_memory_principal_lifecycle.py
@@ -11,7 +11,7 @@ from _local_package import load_local_package
 
 load_local_package()
 
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.plugin_bundle.omh.memory_principals import build_memory_identity
 from omh.system.local_store import atomic_write_json
 from omh.workflows.memory import approve_project_memory_candidate, capture_project_memory_candidate

--- a/tests/test_memory_project_identity_migration.py
+++ b/tests/test_memory_project_identity_migration.py
@@ -88,6 +88,69 @@ class ProjectIdentityMigrationTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "approval_digest_mismatch"):
             self.migrate(report["report_digest"])
 
+    def test_approved_source_change_is_skipped_after_report(self):
+        self._assert_approved_source_change_is_skipped("report")
+
+    def test_approved_source_change_is_skipped_at_locked_preflight(self):
+        self._assert_approved_source_change_is_skipped("preflight")
+
+    def _assert_approved_source_change_is_skipped(self, seam: str):
+        from datetime import datetime, timezone
+        from omh.workflows._memory_lifecycle_plans import _approved_record, _review
+        from omh.system.local_store import atomic_write_json
+        from omh.workflows import memory_project_identity as migration
+        approved = self.report()
+        original_report = migration.build_project_identity_migration_report
+        original_execute = migration.execute_memory_lifecycle
+        current = json.loads(self.record_path.read_bytes())
+        changed = _approved_record({**current, "summary": f"separately reviewed {seam}"}, current["record_id"], current["revision"] + 1, "independent-reviewer", datetime.now(timezone.utc))
+        admission = changed["admission"]
+        assert isinstance(admission, dict)
+        review_id = admission["review_id"]
+        review = _review(changed, review_id, "independent-reviewer")
+
+        def replace_source():
+            atomic_write_json(self.paths.memory_dir / "reviews" / f"{review_id}.json", review, private=True)
+            atomic_write_json(self.record_path, changed, private=True)
+
+        def race_report(*args, **kwargs):
+            report = original_report(*args, **kwargs)
+            replace_source()
+            return report
+
+        def race_execute(*args, **kwargs):
+            replace_source()
+            return original_execute(*args, **kwargs)
+
+        target = "build_project_identity_migration_report" if seam == "report" else "execute_memory_lifecycle"
+        with patch.object(migration, target, side_effect=race_report if seam == "report" else race_execute):
+            receipt = self.migrate(approved["report_digest"])
+        self.assertEqual(json.loads(self.record_path.read_bytes()), changed)
+        self.assertEqual(receipt["successors"], [])
+        self.assertEqual(receipt["skipped"], [{"record_id": current["record_id"], "store": "project", "reason_code": "source_changed_since_report"}])
+        self.assertFalse((self.paths.memory_dir / "history" / f'{current["record_id"]}.r{current["revision"]}.json').exists())
+        self.assertNotEqual(self.report()["report_digest"], approved["report_digest"])
+
+    def test_approved_review_change_is_not_rebound_to_fresh_review(self):
+        from omh.workflows import memory_project_identity as migration
+        from omh.system.local_store import atomic_write_json
+        approved = self.report()
+        original_report = migration.build_project_identity_migration_report
+        record = self.record
+        review_path = self.paths.memory_dir / "reviews" / f'{record["admission"]["review_id"]}.json'
+        original_review = json.loads(review_path.read_bytes())
+
+        def race_report(*args, **kwargs):
+            report = original_report(*args, **kwargs)
+            atomic_write_json(review_path, {**original_review, "reviewer_claim": "different-reviewer"}, private=True)
+            return report
+
+        with patch.object(migration, "build_project_identity_migration_report", side_effect=race_report):
+            receipt = self.migrate(approved["report_digest"])
+        self.assertEqual(self.record_path.read_bytes(), self.original)
+        self.assertEqual(receipt["successors"], [])
+        self.assertEqual(receipt["skipped"][0]["reason_code"], "source_changed_since_report")
+
     def test_successor_original_preservation_idempotency_and_rollback(self):
         report = self.report()
         receipt = self.migrate(report["report_digest"])

--- a/tests/test_memory_project_identity_migration.py
+++ b/tests/test_memory_project_identity_migration.py
@@ -1,0 +1,181 @@
+"""Report-first project identity migration preserves reviewed source revisions."""
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+from pathlib import Path
+from typing import Any
+from tempfile import TemporaryDirectory
+import unittest
+
+from _local_package import load_local_package
+from test_project_identity import repository
+
+load_local_package()
+
+
+class ProjectIdentityMigrationTests(unittest.TestCase):
+    _root: Path | None = None
+    _original: bytes | None = None
+
+    @property
+    def api(self):
+        from omh.workflows import memory_project_identity
+        return memory_project_identity
+
+    @property
+    def memory(self):
+        from omh.workflows import memory
+        return memory
+
+    @property
+    def root(self) -> Path:
+        assert self._root is not None
+        return self._root
+
+    @property
+    def paths(self):
+        from omh.paths import resolve_paths
+        return resolve_paths(self.root / ".omh", self.root.parent / "hermes")
+
+    @property
+    def original(self) -> bytes:
+        assert self._original is not None
+        return self._original
+
+    @property
+    def record(self) -> dict[str, Any]:
+        record = json.loads(self.original)
+        assert isinstance(record, dict)
+        return record
+
+    @property
+    def record_path(self) -> Path:
+        return self.paths.memory_dir / "records" / f'{self.record["record_id"]}.json'
+
+    def setUp(self):
+        temporary = Path(self.enterContext(TemporaryDirectory()))
+        self.enterContext(patch.dict(os.environ, {"OMH_HOME": str(temporary / "user")}))
+        self._root = repository(temporary / "repo")
+        candidate = self.memory.capture_project_memory_candidate(self.paths, "legacy sentinel fact", scope_ref="repo", retention_class="durable")["candidate"]
+        assert isinstance(candidate, dict)
+        record = self.memory.approve_project_memory_candidate(self.paths, candidate["candidate_id"])["record"]
+        assert isinstance(record, dict)
+        self._original = (self.paths.memory_dir / "records" / f'{record["record_id"]}.json').read_bytes()
+
+    def report(self):
+        return self.api.build_project_identity_migration_report(self.paths, root=self.root)
+
+    def migrate(self, digest):
+        return self.api.migrate_project_identity(self.paths, approve=digest, root=self.root)
+
+    def test_report_is_read_only_and_digest_bound(self):
+        before = {str(p.relative_to(self.root)): p.read_bytes() for p in self.root.rglob("*") if p.is_file()}
+        report = self.report()
+        self.assertEqual(report["schema_version"], "project_identity_migration_report/v1")
+        self.assertEqual(len(report["entries"]), 1)
+        self.assertEqual(report["entries"][0]["current_ref"], "repo")
+        self.assertEqual(report["entries"][0]["store"], "project")
+        self.assertNotIn(str(self.root), json.dumps(report))
+        self.assertEqual(before, {str(p.relative_to(self.root)): p.read_bytes() for p in self.root.rglob("*") if p.is_file()})
+        with self.assertRaisesRegex(ValueError, "approval_digest_mismatch"):
+            self.migrate("0" * 64)
+        self.assertEqual(self.record_path.read_bytes(), self.original)
+        candidate = self.memory.capture_project_memory_candidate(self.paths, "new legacy fact", scope_ref="repo")["candidate"]
+        assert isinstance(candidate, dict)
+        self.memory.approve_project_memory_candidate(self.paths, candidate["candidate_id"])
+        with self.assertRaisesRegex(ValueError, "approval_digest_mismatch"):
+            self.migrate(report["report_digest"])
+
+    def test_successor_original_preservation_idempotency_and_rollback(self):
+        report = self.report()
+        receipt = self.migrate(report["report_digest"])
+        self.assertEqual(receipt["schema_version"], "project_identity_migration_receipt/v1")
+        self.assertEqual(len(receipt["successors"]), 1)
+        current = json.loads(self.record_path.read_text(encoding="utf-8"))
+        self.assertEqual(current["revision"], self.record["revision"] + 1)
+        self.assertEqual(current["scope"]["ref"], report["resolution"]["identity"])
+        history = self.paths.memory_dir / "history" / f'{self.record["record_id"]}.r{self.record["revision"]}.json'
+        self.assertEqual(history.read_bytes(), self.original)
+        self.assertEqual(self.report()["entries"], [])
+        self.assertEqual(self.migrate(report["report_digest"])["successors"], [])
+        self.api.rollback_project_identity_migration(self.paths, receipt["receipt_id"], root=self.root)
+        self.assertEqual(self.record_path.read_bytes(), self.original)
+        pack = self.memory.build_project_memory_recall_pack(self.paths, scope_kind="project", scope_ref="repo")
+        included = pack["included_records"]
+        assert isinstance(included, list)
+        self.assertEqual([r["record_id"] for r in included], [self.record["record_id"]])
+        self.assertTrue(list((self.paths.memory_dir / "archive").glob("*.json")))
+
+    def test_report_and_migration_cover_both_stores(self):
+        from omh.paths import resolve_paths
+        user = resolve_paths(self.root.parent / "user", self.paths.hermes_home)
+        candidate = self.memory.capture_project_memory_candidate(user, "user store legacy", scope_ref="old-project", retention_class="durable")["candidate"]
+        assert isinstance(candidate, dict)
+        self.memory.approve_project_memory_candidate(user, candidate["candidate_id"])
+        report = self.report()
+        self.assertEqual({row["store"] for row in report["entries"]}, {"project", "user"})
+        receipt = self.migrate(report["report_digest"])
+        self.assertEqual(len(receipt["successors"]), 2)
+        self.api.rollback_project_identity_migration(self.paths, receipt["receipt_id"], root=self.root)
+        self.assertEqual(len(self.report()["entries"]), 2)
+
+    def test_interrupted_migration_is_not_recalled_and_resumes(self):
+        from omh.workflows import memory_store
+        from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
+        original_step = memory_store.apply_memory_operation_step
+        report = self.report()
+
+        def interrupt(paths, step):
+            result = original_step(paths, step)
+            if step["name"] == "write_successor":
+                raise RuntimeError("injected_after_successor_write")
+            return result
+
+        with patch.object(memory_store, "apply_memory_operation_step", side_effect=interrupt):
+            with self.assertRaisesRegex(RuntimeError, "injected_after_successor_write"):
+                self.migrate(report["report_digest"])
+        provider = OmhMemoryProvider(self.paths.omh_home)
+        provider.initialize("s", cwd=self.root)
+        self.assertNotIn(self.record["record_id"], provider.prefetch())
+        self.migrate(report["report_digest"])
+        provider.initialize("s", cwd=self.root)
+        self.assertIn(self.record["record_id"], provider.prefetch())
+
+    def test_interrupted_rollback_resumes_without_rewriting_original(self):
+        from omh.workflows import memory_store
+        receipt = self.migrate(self.report()["report_digest"])
+        original_step = memory_store.apply_memory_operation_step
+
+        def interrupt(paths, step):
+            result = original_step(paths, step)
+            if step["name"] == "retire_successor":
+                raise RuntimeError("injected_after_retirement")
+            return result
+
+        with patch.object(memory_store, "apply_memory_operation_step", side_effect=interrupt):
+            with self.assertRaisesRegex(RuntimeError, "injected_after_retirement"):
+                self.api.rollback_project_identity_migration(self.paths, receipt["receipt_id"], root=self.root)
+        self.api.rollback_project_identity_migration(self.paths, receipt["receipt_id"], root=self.root)
+        self.assertEqual(self.record_path.read_bytes(), self.original)
+
+    def test_automatic_recall_never_mixes_stable_and_legacy(self):
+        from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
+        candidate = self.memory.capture_project_memory_candidate(self.paths, "stable sentinel fact", retention_class="durable")["candidate"]
+        assert isinstance(candidate, dict)
+        stable = self.memory.approve_project_memory_candidate(self.paths, candidate["candidate_id"])["record"]
+        assert isinstance(stable, dict)
+        live = OmhMemoryProvider(self.paths.omh_home)
+        live.initialize("s", cwd=self.root)
+        text = live.prefetch()
+        self.assertIn(stable["record_id"], text)
+        self.assertNotIn(self.record["record_id"], text)
+        receipt = live.latest_prefetch_receipt()
+        assert receipt is not None
+        refs = [s["ref"] for s in receipt["lens"]["scope_allowlist"] if s["kind"] == "project"]
+        self.assertEqual(refs, [self.report()["resolution"]["identity"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_provider.py
+++ b/tests/test_memory_provider.py
@@ -78,7 +78,7 @@ from omh.plugin_bundle.omh.memory_records import (
 )
 from omh.plugin_bundle.omh.metadata import MEMORY_PROVIDER_NAME, PROVIDED_TOOLS
 from omh.plugin_bundle.omh.tools.memory_tool import MEMORY_ACTIONS, OMH_MEMORY_SCHEMA, omh_memory_handler
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.workflows.memory import (
     approve_project_memory_candidate,
     capture_project_memory_candidate,
@@ -2357,7 +2357,7 @@ class RecordsReachPrefetchTests(unittest.TestCase):
             # identity (`project/repo`, what `omh memory recall` resolves for
             # this checkout) and the user store's cross-project preference is
             # labelled `user-global`. Neither is inferred from the store path.
-            _approve_record(root, "Project-scoped: the API lives under src/api.", home="repo/.omh", scope_ref="repo")
+            _approve_record(root, "Project-scoped: the API lives under src/api.", home="repo/.omh")
             _approve_record(root, "User-scoped: the owner prefers Korean replies.", scope_kind="user-global", scope_ref="default")
             pack = self._provider(root, cwd=repo / "src" / "deep").prefetch("")
             self.assertIn("Project-scoped", pack)

--- a/tests/test_memory_reapproval_path.py
+++ b/tests/test_memory_reapproval_path.py
@@ -16,7 +16,7 @@ from omh.memory import (
     build_project_memory_review,
     capture_project_memory_candidate,
 )
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 
 
 def _cli(home: Path, *args):

--- a/tests/test_memory_recall_canonical.py
+++ b/tests/test_memory_recall_canonical.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 from _local_package import load_local_package
 
 load_local_package()
-from omh.paths import resolve_paths
+from project_identity_fixture import PROJECT_IDENTITY, memory_paths as resolve_paths
 from omh.plugin_bundle.omh import memory_recall_selector as selector
 from omh.workflows import memory
 from memory_recall_fixture import (
@@ -183,7 +183,7 @@ class CanonicalRecallTests(unittest.TestCase):
             paths = resolve_paths(root / ".omh", Path(tmp) / ".hermes")
             expected: list[str] = []
             with patch.object(memory, "utc_now", return_value="2026-09-01T00:00:00Z"):
-                for index, scope in enumerate((GLOBAL, PROJECT, THREAD, {"kind": "project", "ref": "foreign"})):
+                for index, scope in enumerate((GLOBAL, {"kind": "project", "ref": PROJECT_IDENTITY}, THREAD, {"kind": "project", "ref": "foreign"})):
                     captured = mapping(decode(json.dumps(memory.capture_project_memory_candidate(
                         paths, f"Release checklist fixture {index}", scope_kind=scope["kind"], scope_ref=scope["ref"],
                     ))))

--- a/tests/test_memory_recall_history.py
+++ b/tests/test_memory_recall_history.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from contextlib import chdir
 import hashlib
 from importlib import import_module
 import json
@@ -21,7 +22,7 @@ from omh.workflows.memory_lifecycle_executor import execute_memory_lifecycle
 class MemoryRecallHistoryTests(unittest.TestCase):
     def test_corrected_claim_is_diagnosed_from_history(self) -> None:
         for anchor_kind in ("record", "digest"):
-            with self.subTest(anchor_kind=anchor_kind), TemporaryDirectory() as directory:
+            with self.subTest(anchor_kind=anchor_kind), TemporaryDirectory() as directory, chdir(directory):
                 # Given a real correction that moves the old claim to history.
                 root = Path(directory)
                 paths = resolve_paths(root / "omh", root / "hermes")
@@ -65,7 +66,7 @@ class MemoryRecallHistoryTests(unittest.TestCase):
                 self.assertEqual(before, {p: p.read_bytes() for p in paths.memory_dir.rglob("*.json")})
 
     def test_history_digest_lookup_does_not_cross_project_scope(self) -> None:
-        with TemporaryDirectory() as directory:
+        with TemporaryDirectory() as directory, chdir(directory):
             # Given a superseded claim owned by another project.
             root = Path(directory)
             paths = resolve_paths(root / "omh", root / "hermes")
@@ -94,7 +95,7 @@ class MemoryRecallHistoryTests(unittest.TestCase):
             self.assertNotIn("record_id", incident["anchor"])
 
     def test_corrupt_history_cannot_prove_claim_absence(self) -> None:
-        with TemporaryDirectory() as directory:
+        with TemporaryDirectory() as directory, chdir(directory):
             # Given a history store the reader cannot completely inspect.
             root = Path(directory)
             paths = resolve_paths(root / "omh", root / "hermes")

--- a/tests/test_memory_recall_history.py
+++ b/tests/test_memory_recall_history.py
@@ -12,7 +12,7 @@ from _cli_harness import run_cli
 from _local_package import load_local_package
 
 load_local_package()
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.workflows import memory
 from omh.workflows.memory_lifecycle import build_memory_correction
 from omh.workflows.memory_lifecycle_executor import execute_memory_lifecycle

--- a/tests/test_memory_recall_incident.py
+++ b/tests/test_memory_recall_incident.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 from _local_package import load_local_package
 
 load_local_package()
-from omh.paths import resolve_paths
+from project_identity_fixture import PROJECT_IDENTITY, memory_paths as resolve_paths
 from omh.plugin_bundle.omh import memory_prefetch_receipt as receipts
 from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
 from omh.routing.chat import route_chat_message
@@ -47,7 +47,7 @@ class MemoryRecallIncidentTests(unittest.TestCase):
         # The repository loader supplies the worktree package dynamically.
         return import_module('omh.workflows.memory_recall_incident')
 
-    def approved(self, summary='Prefer structured response output', *, scope_kind='project', scope_ref='default'):
+    def approved(self, summary='Prefer structured response output', *, scope_kind='project', scope_ref=PROJECT_IDENTITY):
         candidate = memory.capture_project_memory_candidate(
             self.paths, summary, scope_kind=scope_kind, scope_ref=scope_ref)['candidate']
         assert isinstance(candidate, dict)

--- a/tests/test_memory_recall_incident.py
+++ b/tests/test_memory_recall_incident.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping
+from contextlib import chdir
 from datetime import datetime, timezone
 from importlib import import_module
 from typing import TypedDict
@@ -37,6 +38,7 @@ class MemoryRecallIncidentTests(unittest.TestCase):
 
     def setUp(self) -> None:
         self.root = Path(self.enterContext(TemporaryDirectory()))
+        self.enterContext(chdir(self.root))
 
     @property
     def paths(self):

--- a/tests/test_memory_recall_incident_cli.py
+++ b/tests/test_memory_recall_incident_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import chdir
 import hashlib
 import json
 from pathlib import Path
@@ -14,7 +15,7 @@ from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
 class MemoryRecallIncidentCliTests(unittest.TestCase):
     def test_pending_claim_diagnosis_is_private_and_explicitly_persisted(self) -> None:
         for persist in (False, True):
-            with self.subTest(persist=persist), TemporaryDirectory() as directory:
+            with self.subTest(persist=persist), TemporaryDirectory() as directory, chdir(directory):
                 # Given: a real pending candidate in isolated OMH/Hermes homes.
                 root = Path(directory)
                 seed_project_identity(root)
@@ -70,7 +71,7 @@ class MemoryRecallIncidentCliTests(unittest.TestCase):
                     self.assertFalse(incidents.exists())
 
     def test_live_receipt_binds_only_to_its_session_and_configuration(self) -> None:
-        with TemporaryDirectory() as directory:
+        with TemporaryDirectory() as directory, chdir(directory):
             # Given: an approved record and the actual provider's served receipt in this home.
             root = Path(directory)
             seed_project_identity(root)

--- a/tests/test_memory_recall_incident_cli.py
+++ b/tests/test_memory_recall_incident_cli.py
@@ -7,6 +7,7 @@ from tempfile import TemporaryDirectory
 import unittest
 
 from _cli_harness import run_cli
+from project_identity_fixture import seed_project_identity
 from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
 
 
@@ -16,6 +17,7 @@ class MemoryRecallIncidentCliTests(unittest.TestCase):
             with self.subTest(persist=persist), TemporaryDirectory() as directory:
                 # Given: a real pending candidate in isolated OMH/Hermes homes.
                 root = Path(directory)
+                seed_project_identity(root)
                 home = root / "omh"
                 prefix = ["--omh-home", str(home), "--hermes-home", str(root / "hermes")]
                 summary = "PRIVATE_CLAIM_SENTINEL"
@@ -71,6 +73,7 @@ class MemoryRecallIncidentCliTests(unittest.TestCase):
         with TemporaryDirectory() as directory:
             # Given: an approved record and the actual provider's served receipt in this home.
             root = Path(directory)
+            seed_project_identity(root)
             home = root / "omh"
             prefix = ["--omh-home", str(home), "--hermes-home", str(root / "hermes")]
             status, stdout, stderr = run_cli(prefix + ["memory", "capture", "LIVE_CLAIM_SENTINEL"])

--- a/tests/test_memory_rollup_signals.py
+++ b/tests/test_memory_rollup_signals.py
@@ -18,7 +18,7 @@ from omh.memory import (
     capture_project_memory_candidate,
     validate_project_memory_recall_pack,
 )
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.profiles.setup import write_setup_profile
 from omh.runtime.records import _compact_memory_recall_pack
 

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -31,7 +31,7 @@ from omh.memory import (
     validate_project_memory_record,
     validate_project_memory_recall_pack,
 )
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.workflows import memory as memory_workflow
 from omh.workflows.memory_lifecycle import (
     apply_memory_correction,

--- a/tests/test_project_identity.py
+++ b/tests/test_project_identity.py
@@ -1,0 +1,176 @@
+"""Offline repository identity contract, exercised through real recall surfaces."""
+from __future__ import annotations
+
+from dataclasses import asdict
+import hashlib
+import json
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+
+
+def repository(root: Path, remote: str | None = "git@EXAMPLE.test:team/project.git") -> Path:
+    (root / ".git").mkdir(parents=True)
+    (root / ".git" / "config").write_text(
+        f'[remote "origin"]\n url = {remote}\n' if remote else "[core]\n bare = false\n", encoding="utf-8")
+    return root
+
+
+class ProjectIdentityTests(unittest.TestCase):
+    _root: Path | None = None
+
+    @property
+    def api(self):
+        from omh.plugin_bundle.omh import project_identity
+        return project_identity
+
+    @property
+    def root(self) -> Path:
+        assert self._root is not None
+        return self._root
+
+    def setUp(self):
+        self._root = Path(self.enterContext(TemporaryDirectory()))
+
+    def test_same_basename_and_fork_are_distinct_without_cross_recall(self):
+        from omh.paths import resolve_paths
+        from omh.workflows import memory
+        from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
+        a = repository(self.root / "one" / "repo")
+        b = repository(self.root / "two" / "repo", "https://example.test/fork/project.git")
+        self.assertNotEqual(self.api.resolve_project_identity(a).identity, self.api.resolve_project_identity(b).identity)
+        paths = resolve_paths(a / ".omh", self.root / "hermes")
+        candidate = memory.capture_project_memory_candidate(paths, "first repository sentinel", retention_class="durable")["candidate"]
+        assert isinstance(candidate, dict)
+        record = memory.approve_project_memory_candidate(paths, candidate["candidate_id"])["record"]
+        assert isinstance(record, dict)
+        live = OmhMemoryProvider(paths.omh_home)
+        live.initialize("s", cwd=b)
+        self.assertNotIn(record["record_id"], live.prefetch())
+        live.initialize("s", cwd=a)
+        self.assertIn(record["record_id"], live.prefetch())
+        self.assertEqual(candidate["scope"]["ref"], self.api.resolve_project_identity(a).identity)
+
+    def test_rename_and_transport_normalization(self):
+        a = repository(self.root / "before")
+        identity = self.api.resolve_project_identity(a).identity
+        a.rename(self.root / "after")
+        a = self.root / "after"
+        self.assertEqual(self.api.resolve_project_identity(a).identity, identity)
+        (a / ".git" / "config").write_text('[remote "origin"]\n url = https://user:password@Example.test/team/project.git/\n', encoding="utf-8")
+        result = self.api.resolve_project_identity(a)
+        self.assertEqual(result.identity, identity)
+        self.assertEqual(identity, "repo:" + hashlib.sha256(b"example.test/team/project").hexdigest()[:32])
+        self.assertNotIn("password", json.dumps(asdict(result)))
+
+    def test_worktree_common_directory(self):
+        main = repository(self.root / "main")
+        gitdir = main / ".git" / "worktrees" / "linked"
+        gitdir.mkdir(parents=True)
+        (gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+        linked = self.root / "linked"
+        linked.mkdir()
+        (linked / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+        self.assertEqual(self.api.resolve_project_identity(main), self.api.resolve_project_identity(linked))
+
+    def test_unresolved_closed_reasons(self):
+        outside = self.api.resolve_project_identity(self.root)
+        self.assertEqual(outside.diagnostics, ("outside_repository",))
+        repo = repository(self.root / "repo", None)
+        self.assertEqual(self.api.resolve_project_identity(repo).diagnostics, ("remote_absent",))
+        (repo / ".git" / "config").write_text('[remote "a"]\n url = https://example.test/a\n[remote "b"]\n url = https://example.test/b\n', encoding="utf-8")
+        result = self.api.resolve_project_identity(repo)
+        self.assertEqual((result.state, result.identity, result.diagnostics), ("unresolved", "", ("remote_ambiguous",)))
+        (repo / ".git" / "config").unlink()
+        self.assertEqual(self.api.resolve_project_identity(repo).diagnostics, ("git_metadata_unreadable",))
+
+    def test_explicit_priority_idempotency_permissions_and_invalid_file(self):
+        repo = repository(self.root / "repo")
+        identity = self.api.mint_explicit_project_identity(repo)
+        self.assertRegex(identity, r"^prj:[0-9a-f]{64}$")
+        path = repo / ".omh" / "project-identity.json"
+        original = path.read_bytes()
+        self.assertEqual(self.api.mint_explicit_project_identity(repo), identity)
+        self.assertEqual(path.read_bytes(), original)
+        self.assertEqual(path.stat().st_mode & 0o777, 0o666 if os.name == "nt" else 0o600)
+        result = self.api.resolve_project_identity(repo)
+        self.assertEqual((result.state, result.evidence, result.identity), ("resolved", "explicit", identity))
+        path.write_text('{"identity":"private/path"}', encoding="utf-8")
+        result = self.api.resolve_project_identity(repo)
+        self.assertEqual(result.diagnostics, ("explicit_invalid",))
+        self.assertEqual(result.identity, "")
+        with self.assertRaises(ValueError):
+            self.api.mint_explicit_project_identity(repo)
+
+    def test_resolution_never_writes_or_calls_external_services(self):
+        repo = repository(self.root / "repo")
+        with patch("subprocess.Popen", side_effect=AssertionError("subprocess")), patch("socket.socket", side_effect=AssertionError("network")), patch.object(Path, "write_text", side_effect=AssertionError("write")), patch("os.open", side_effect=AssertionError("write")):
+            self.assertEqual(self.api.resolve_project_identity(repo).state, "resolved")
+
+    def test_receipts_reject_identity_changes_and_legacy_requests_are_diagnosed(self):
+        from omh.paths import resolve_paths
+        from omh.workflows import memory
+        from omh.workflows.memory_recall_incident import RecallIncidentRequest, build_memory_recall_incident
+        from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
+        from omh.plugin_bundle.omh.memory_prefetch_receipt import validate_prefetch_receipt
+        repo = repository(self.root / "repo")
+        paths = resolve_paths(repo / ".omh", self.root / "hermes")
+        candidate = memory.capture_project_memory_candidate(paths, "stable sentinel", retention_class="durable")["candidate"]
+        assert isinstance(candidate, dict)
+        record = memory.approve_project_memory_candidate(paths, candidate["candidate_id"])["record"]
+        assert isinstance(record, dict)
+        provider = OmhMemoryProvider(paths.omh_home)
+        provider.initialize("s", cwd=repo)
+        provider.prefetch()
+        receipt = provider.latest_prefetch_receipt()
+        assert receipt is not None
+        self.assertEqual(validate_prefetch_receipt(receipt), [])
+        legacy = build_memory_recall_incident(paths, RecallIncidentRequest(record_id=record["record_id"], session_id="s", scope_ref="repo"))
+        self.assertEqual(legacy["reason_code"], "legacy_basename")
+        (repo / ".git" / "config").write_text('[remote "origin"]\n url = https://example.test/other\n', encoding="utf-8")
+        incident = build_memory_recall_incident(paths, RecallIncidentRequest(record_id=record["record_id"], session_id="s", observed="hermes"))
+        self.assertEqual(incident["evidence_surfaces"]["live_prefetch_receipt"]["basis"], "receipt_project_identity_mismatch")
+        provider.queue_prefetch()
+        self.assertNotIn(record["record_id"], provider.prefetch())
+        changed_receipt = provider.latest_prefetch_receipt()
+        assert changed_receipt is not None
+        self.assertNotEqual(changed_receipt["configuration_id"], receipt["configuration_id"])
+        # Legacy schema remains structurally readable, but is not current evidence.
+        body = {key: value for key, value in receipt.items() if key not in {"receipt_id", "state", "served_at"}}
+        body["schema_version"] = "omh_memory_prefetch_receipt/v2"
+        body.pop("resolver_version")
+        body.pop("project_identity")
+        legacy_receipt = {**body, "state": receipt["state"], "served_at": receipt["served_at"],
+                          "receipt_id": hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()}
+        self.assertEqual(validate_prefetch_receipt(legacy_receipt), [])
+
+    def test_unresolved_capture_refuses_and_provider_receipt_is_bound(self):
+        from omh.paths import resolve_paths
+        from omh.workflows import memory
+        from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
+        repo = repository(self.root / "repo", None)
+        paths = resolve_paths(repo / ".omh", self.root / "hermes")
+        with self.assertRaises(self.api.ProjectIdentityUnresolvedError):
+            memory.capture_project_memory_candidate(paths, "must not silently widen")
+        self.assertFalse(paths.memory_dir.exists())
+        live = OmhMemoryProvider(paths.omh_home)
+        live.initialize("s", cwd=repo)
+        self.assertEqual(live.prefetch(), "")
+        receipt = live.latest_prefetch_receipt()
+        assert receipt is not None
+        self.assertEqual(receipt["schema_version"], "omh_memory_prefetch_receipt/v3")
+        self.assertEqual(receipt["resolver_version"], "project_identity/v2")
+        self.assertEqual(receipt["project_identity"], "")
+        self.assertEqual(receipt["lens"]["project_identity_state"], "unresolved")
+        self.assertEqual(receipt["lens"]["project_identity_diagnostics"], ["remote_absent"])
+        self.assertEqual(receipt["lens"]["scope_allowlist"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_identity.py
+++ b/tests/test_project_identity.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from contextlib import chdir
 import hashlib
 import json
 import os
@@ -56,6 +57,121 @@ class ProjectIdentityTests(unittest.TestCase):
         live.initialize("s", cwd=a)
         self.assertIn(record["record_id"], live.prefetch())
         self.assertEqual(candidate["scope"]["ref"], self.api.resolve_project_identity(a).identity)
+
+    def test_local_remotes_are_anchored_and_cannot_cross_recall(self):
+        from omh.paths import resolve_paths
+        from omh.workflows import memory
+        from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
+        a = repository(self.root / "one" / "repo", "../upstream.git")
+        b = repository(self.root / "two" / "repo", "../upstream.git")
+        for repo in (a, b):
+            (repo.parent / "upstream.git").mkdir()
+        first = self.api.resolve_project_identity(a)
+        second = self.api.resolve_project_identity(b)
+        self.assertEqual((first.state, second.state), ("resolved", "resolved"))
+        paths = resolve_paths(self.root / "user", self.root / "hermes")
+        candidate = memory.capture_project_memory_candidate(paths, "local remote sentinel", scope_ref=first.identity, retention_class="durable")["candidate"]
+        assert isinstance(candidate, dict)
+        record = memory.approve_project_memory_candidate(paths, candidate["candidate_id"])["record"]
+        assert isinstance(record, dict)
+        provider = OmhMemoryProvider(paths.omh_home)
+        provider.initialize("local", cwd=b)
+        self.assertNotIn(record["record_id"], provider.prefetch())
+        self.assertNotEqual(first.identity, second.identity)
+        provider.initialize("local", cwd=a)
+        self.assertIn(record["record_id"], provider.prefetch())
+        config = a / ".git" / "config"
+        for remote in ((a.parent / "upstream.git").as_posix(), (a.parent / "upstream.git").as_uri()):
+            config.write_text(f'[remote "origin"]\n url = {remote}\n', encoding="utf-8")
+            self.assertEqual(self.api.resolve_project_identity(a).identity, first.identity)
+        config.write_text('[remote "origin"]\n url = ../upstream.git\n', encoding="utf-8")
+        gitdir = a / ".git" / "worktrees" / "local-linked"
+        gitdir.mkdir(parents=True)
+        (gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+        linked = self.root / "local-linked"
+        linked.mkdir()
+        (linked / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+        self.assertEqual(self.api.resolve_project_identity(linked).identity, first.identity)
+        renamed = a.with_name("renamed")
+        a.rename(renamed)
+        self.assertEqual(self.api.resolve_project_identity(renamed).identity, first.identity)
+        config = renamed / ".git" / "config"
+        config.write_text('[remote "origin"]\n url = ../missing.git\n', encoding="utf-8")
+        missing = self.api.resolve_project_identity(renamed)
+        self.assertEqual((missing.state, missing.identity), ("unresolved", ""))
+        self.assertEqual(missing.diagnostics, ("git_metadata_unreadable",))
+
+    def test_quoted_git_values_strip_credentials_and_inline_comments(self):
+        repo = repository(self.root / "quoted")
+        expected = "repo:" + hashlib.sha256(b"example.test/team/project").hexdigest()[:32]
+        variants = ('"https://example.test/team/project.git"',
+                    '"https://user:password@EXAMPLE.test/team/project.git" # origin',
+                    '"https://other:rotated@EXAMPLE.test/team/project.git" ; rotated',
+                    'https://example.test/team/project.git # origin',
+                    '"git@example.test:team/project.git"')
+        for value in variants:
+            with self.subTest(value_digest=hashlib.sha256(value.encode()).hexdigest()):
+                (repo / ".git" / "config").write_text(f'[remote "origin"]\n url = {value}\n', encoding="utf-8")
+                resolution = self.api.resolve_project_identity(repo)
+                self.assertEqual(resolution.identity, expected)
+                for private in ("password", "rotated", "https", "example.test"):
+                    self.assertNotIn(private, json.dumps(asdict(resolution)))
+        (repo / ".git" / "config").write_text('[remote "origin"]\n url = "https://example.test/team/project.git\n', encoding="utf-8")
+        self.assertEqual(self.api.resolve_project_identity(repo).state, "unresolved")
+
+    def test_cli_uses_current_checkout_not_selected_store(self):
+        from _cli_harness import run_cli
+        from omh.paths import resolve_paths
+        from omh.workflows import memory
+        a = repository(self.root / "one" / "repo")
+        b = repository(self.root / "two" / "repo", "https://example.test/other/project.git")
+        paths = resolve_paths(a / ".omh", self.root / "hermes")
+        candidate = memory.capture_project_memory_candidate(paths, "foreign store sentinel", retention_class="durable")["candidate"]
+        assert isinstance(candidate, dict)
+        memory.approve_project_memory_candidate(paths, candidate["candidate_id"])
+        prefix = ["--omh-home", str(paths.omh_home), "--hermes-home", str(paths.hermes_home), "memory"]
+        with chdir(b):
+            status, stdout, stderr = run_cli(prefix + ["recall"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(json.loads(stdout)["included_records"], [])
+            status, stdout, stderr = run_cli(prefix + ["project-identity", "show"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(json.loads(stdout)["identity"], self.api.resolve_project_identity(b).identity)
+            status, stdout, stderr = run_cli(prefix + ["capture", "active checkout sentinel"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(json.loads(stdout)["candidate"]["scope"]["ref"], self.api.resolve_project_identity(b).identity)
+            status, stdout, stderr = run_cli(prefix + ["recall", "--scope-kind", "project", "--scope-ref", self.api.resolve_project_identity(a).identity])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(json.loads(stdout)["record_count"], 1)
+        with chdir(self.root):
+            status, stdout, stderr = run_cli(prefix + ["recall"])
+            self.assertEqual(status, 0, stderr)
+            self.assertEqual(json.loads(stdout)["included_records"], [])
+
+    def test_incident_accepts_current_checkout_receipt_in_external_user_store(self):
+        from omh.paths import resolve_paths
+        from omh.workflows import memory
+        from omh.workflows.memory_recall_incident import RecallIncidentRequest, build_memory_recall_incident
+        from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
+        repo = repository(self.root / "active")
+        identity = self.api.resolve_project_identity(repo).identity
+        paths = resolve_paths(self.root / "external-user", self.root / "hermes")
+        candidate = memory.capture_project_memory_candidate(paths, "external user sentinel", scope_ref=identity, retention_class="durable")["candidate"]
+        assert isinstance(candidate, dict)
+        record = memory.approve_project_memory_candidate(paths, candidate["candidate_id"])["record"]
+        assert isinstance(record, dict)
+        provider = OmhMemoryProvider(paths.omh_home)
+        provider.initialize("external", cwd=repo)
+        self.assertIn(record["record_id"], provider.prefetch())
+        with chdir(repo):
+            for reference in (identity, ""):
+                incident = build_memory_recall_incident(paths, RecallIncidentRequest(record_id=record["record_id"], session_id="external", scope_ref=reference, observed="hermes"))
+                self.assertEqual(incident["evidence_surfaces"]["live_prefetch_receipt"], {"status": "observed", "basis": "canonical_1452_receipt_bound"})
+                self.assertEqual(incident["reason_code"], "rendered_delivery_not_observed")
+        foreign = repository(self.root / "foreign", "https://example.test/foreign.git")
+        with chdir(foreign):
+            incident = build_memory_recall_incident(paths, RecallIncidentRequest(record_id=record["record_id"], session_id="external", scope_ref=identity))
+            self.assertEqual(incident["evidence_surfaces"]["live_prefetch_receipt"]["basis"], "receipt_project_identity_mismatch")
 
     def test_rename_and_transport_normalization(self):
         a = repository(self.root / "before")
@@ -131,10 +247,10 @@ class ProjectIdentityTests(unittest.TestCase):
         receipt = provider.latest_prefetch_receipt()
         assert receipt is not None
         self.assertEqual(validate_prefetch_receipt(receipt), [])
-        legacy = build_memory_recall_incident(paths, RecallIncidentRequest(record_id=record["record_id"], session_id="s", scope_ref="repo"))
+        legacy = build_memory_recall_incident(paths, RecallIncidentRequest(record_id=record["record_id"], session_id="s", scope_ref="repo"), invocation_cwd=repo)
         self.assertEqual(legacy["reason_code"], "legacy_basename")
         (repo / ".git" / "config").write_text('[remote "origin"]\n url = https://example.test/other\n', encoding="utf-8")
-        incident = build_memory_recall_incident(paths, RecallIncidentRequest(record_id=record["record_id"], session_id="s", observed="hermes"))
+        incident = build_memory_recall_incident(paths, RecallIncidentRequest(record_id=record["record_id"], session_id="s", observed="hermes"), invocation_cwd=repo)
         self.assertEqual(incident["evidence_surfaces"]["live_prefetch_receipt"]["basis"], "receipt_project_identity_mismatch")
         provider.queue_prefetch()
         self.assertNotIn(record["record_id"], provider.prefetch())

--- a/tests/test_project_terms.py
+++ b/tests/test_project_terms.py
@@ -20,7 +20,8 @@ from domain_store_snapshot_support import (
     repository_tree_snapshot,
 )
 
-from omh.paths import project_identity, resolve_paths
+from omh.paths import resolve_paths
+from project_identity_fixture import project_identity, seed_project_identity
 from omh.system import binary_io
 from omh.workflows import domain_intelligence_store
 from omh.workflows.domain_intelligence_store import MAX_DOMAIN_CANDIDATE_FILES
@@ -84,6 +85,7 @@ def _repository(root: Path) -> Path:
     root.mkdir()
     (root / ".git").mkdir()
     (root / "PROJECT_TERMS.md").write_bytes(_VALID_DOCUMENT)
+    seed_project_identity(root)
     return root
 
 
@@ -163,6 +165,7 @@ class ProjectTermsCharacterizationTests(unittest.TestCase):
         # Given
         with TemporaryDirectory() as temporary:
             project_root = Path(temporary).resolve()
+            seed_project_identity(project_root)
             profile = {
                 "scope": {
                     "kind": "project",

--- a/tests/test_project_terms_lifecycle_journey.py
+++ b/tests/test_project_terms_lifecycle_journey.py
@@ -19,7 +19,8 @@ from omh.coding.handoff_input_manifest import (  # noqa: E402
     validate_handoff_input_manifest,
 )
 from omh.memory import build_handoff_context_pack, validate_handoff_context_pack  # noqa: E402
-from omh.paths import project_identity, resolve_paths  # noqa: E402
+from omh.paths import resolve_paths  # noqa: E402
+from project_identity_fixture import project_identity, seed_project_identity
 from omh.routing.chat import route_chat_message  # noqa: E402
 from omh.routing.domain_context_eligibility import classify_domain_context_eligibility  # noqa: E402
 from omh.workflows.role_context_packs import (  # noqa: E402
@@ -57,6 +58,7 @@ def _repository(root: Path, *, source: bytes = _VALID_SOURCE) -> Path:
     root.mkdir(parents=True)
     (root / ".git").mkdir()
     (root / "PROJECT_TERMS.md").write_bytes(source)
+    seed_project_identity(root)
     return root.resolve()
 
 

--- a/tests/test_role_context_packs.py
+++ b/tests/test_role_context_packs.py
@@ -35,7 +35,7 @@ from omh.memory import (
     freshness_reason_detail,
     memory_recall_pack_for_handoff,
 )
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.runtime.records import validate_handoff_context_pack_fields
 from omh.workflows.role_context_packs import (
     ROLE_CONTEXT_PACK_ORIGINS,

--- a/tests/test_task_authority_envelope.py
+++ b/tests/test_task_authority_envelope.py
@@ -50,7 +50,8 @@ from omh.coding.fanout_dispatch import (  # noqa: E402
     verify_safety_profile_matches_contract,
 )
 from omh.runtime.records import build_coding_delegation_record  # noqa: E402
-from omh.system.paths import OmhPaths, resolve_paths  # noqa: E402
+from omh.system.paths import OmhPaths  # noqa: E402
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.workflows.memory import (  # noqa: E402
     build_handoff_context_pack,
     build_project_memory_recall_pack,

--- a/tests/test_wrapper_golden_examples.py
+++ b/tests/test_wrapper_golden_examples.py
@@ -16,7 +16,8 @@ from omh.hermes_planning import build_hermes_plan_payload
 from omh.ingress import extract_message_text, extract_source_metadata
 from omh.skills.catalog import builtin_definitions, omh_skill_display_name
 from omh.skills.render import workflow_reference_payload
-from omh.paths import project_identity, resolve_paths
+from omh.paths import resolve_paths
+from project_identity_fixture import project_identity
 from omh.wrapper_contract import build_chat_interaction_payload
 from omh.wrapper.route_hints import build_chat_route_hint_payload
 

--- a/tests/test_wrapper_sessions.py
+++ b/tests/test_wrapper_sessions.py
@@ -21,7 +21,7 @@ from omh.coding.executor_capability_snapshots import (
     write_executor_capability_snapshot,
 )
 from omh.coding_delegation import build_coding_delegation_payload
-from omh.paths import resolve_paths
+from project_identity_fixture import memory_paths as resolve_paths
 from omh.memory import capture_project_memory_candidate
 from omh.profiles.setup import write_setup_profile
 from omh.runtime_artifacts import (

--- a/tools/qa/issue_1509_project_identity.py
+++ b/tools/qa/issue_1509_project_identity.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from tempfile import TemporaryDirectory
 from typing import Any
+from unittest.mock import patch
+from datetime import datetime, timezone
 
 from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
 
@@ -59,7 +61,13 @@ def exercise(scratch: Path) -> dict[str, object]:
         assert receipt is not None
         assert receipt["schema_version"] == "omh_memory_prefetch_receipt/v3"
         assert len([scope for scope in receipt["lens"]["scope_allowlist"] if scope["kind"] == "project"]) == 1
+        incident = cli(root, "recall-incident", "--record-id", included, "--session-id", "qa-session", "--observed", "hermes")
+        assert incident["evidence_surfaces"]["live_prefetch_receipt"]["status"] == "observed"
+        assert incident["reason_code"] == "rendered_delivery_not_observed"
         provider.shutdown()
+    approve(first, "foreign checkout store sentinel", home=first / ".omh")
+    assert cli(second, "recall", home=first / ".omh")["included_records"] == []
+    assert cli(second, "project-identity", "show", home=first / ".omh")["identity"] == second_id
     renamed = first.with_name("renamed")
     first.rename(renamed)
     assert cli(renamed, "project-identity", "show")["identity"] == first_id
@@ -71,6 +79,23 @@ def exercise(scratch: Path) -> dict[str, object]:
     linked.mkdir()
     (linked / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
     assert cli(linked, "project-identity", "show")["identity"] == first_id
+    (renamed / ".git" / "config").write_text('[remote "origin"]\n url = "https://user:password@example.invalid/first/project.git" # origin\n', encoding="utf-8")
+    assert cli(linked, "project-identity", "show")["identity"] == first_id
+
+    local_user = scratch / "local-user"
+    local_repos = [repository(scratch / name / "same-name", "unused") for name in ("local-one", "local-two")]
+    for local in local_repos:
+        (local.parent / "upstream.git").mkdir()
+        (local / ".git" / "config").write_text('[remote "origin"]\n url = ../upstream.git\n', encoding="utf-8")
+    assert cli(local_repos[0], "project-identity", "show")["identity"] != cli(local_repos[1], "project-identity", "show")["identity"]
+    local_id = approve(local_repos[0], "local endpoint sentinel", home=local_user)
+    local_provider = OmhMemoryProvider(local_user)
+    local_provider.initialize("local", cwd=local_repos[0], agent_context="subagent")
+    assert local_id in local_provider.prefetch()
+    local_provider.initialize("local", cwd=local_repos[1], agent_context="subagent")
+    assert local_id not in local_provider.prefetch()
+    local_provider.shutdown()
+    assert cli(local_repos[1], "recall", home=local_user)["included_records"] == []
 
     migration_root = repository(scratch / "migration", "migration/project")
     migration_user = scratch / "migration-user"
@@ -97,7 +122,45 @@ def exercise(scratch: Path) -> dict[str, object]:
     for home in (migration_root / ".omh", migration_user):
         assert cli(migration_root, "recall", home=home)["included_records"] == []
         assert cli(migration_root, "recall", "--scope-kind", "project", "--scope-ref", "legacy-checkout", home=home)["record_count"] == 1
+    # Inject an independent reviewed successor at exact synchronous boundaries;
+    # the actual report, preflight, transaction and source preservation still run.
+    from omh.paths import resolve_paths
+    from omh.workflows import memory_project_identity as migration
+    from omh.workflows._memory_lifecycle_plans import _approved_record, _review
+    from omh.system.local_store import atomic_write_json
+
+    for seam in ("report", "preflight"):
+        race_root = repository(scratch / f"race-{seam}", f"race/{seam}")
+        race_home = scratch / f"race-{seam}-user"
+        record_id = approve(race_root, "approved legacy source", home=race_home, legacy=True)
+        paths = resolve_paths(race_home, hermes)
+        approved = migration.build_project_identity_migration_report(paths, root=race_root)
+        source_path = paths.memory_dir / "records" / f"{record_id}.json"
+        source = json.loads(source_path.read_bytes())
+        replacement = _approved_record({**source, "summary": "independently reviewed successor"}, record_id, source["revision"] + 1, "qa-reviewer", datetime.now(timezone.utc))
+        admission = replacement["admission"]
+        assert isinstance(admission, dict)
+        review_id = admission["review_id"]
+        review = _review(replacement, review_id, "qa-reviewer")
+        original_operation = migration.build_project_identity_migration_report if seam == "report" else migration.execute_memory_lifecycle
+
+        def race(*args, **kwargs):
+            result = original_operation(*args, **kwargs) if seam == "report" else None
+            atomic_write_json(paths.memory_dir / "reviews" / f"{review_id}.json", review, private=True)
+            atomic_write_json(source_path, replacement, private=True)
+            return result if seam == "report" else original_operation(*args, **kwargs)
+
+        target = "build_project_identity_migration_report" if seam == "report" else "execute_memory_lifecycle"
+        with patch.object(migration, target, side_effect=race):
+            refused = migration.migrate_project_identity(paths, root=race_root, approve=approved["report_digest"])
+        assert refused["successors"] == []
+        assert refused["skipped"] == [{"record_id": record_id, "store": "user", "reason_code": "source_changed_since_report"}]
+        assert json.loads(source_path.read_bytes()) == replacement
+
     return {"same_basename_isolation": True, "capture_recall": True, "rename_stability": True,
+            "local_remote_isolation": True, "quoted_credentials_normalized": True,
+            "foreign_store_isolation": True, "external_store_receipt_accepted": True,
+            "approval_race_report_skipped": True, "approval_race_preflight_skipped": True,
             "worktree_sharing": True, "migration_stores": 2, "migrated_successors": 2,
             "report_read_only": True, "idempotent": True, "rollback": True, "cli_calls": calls}
 

--- a/tools/qa/issue_1509_project_identity.py
+++ b/tools/qa/issue_1509_project_identity.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Real local CLI/provider QA for #1509. All fixtures are owned and removed."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from omh.plugin_bundle.omh.memory_provider import OmhMemoryProvider
+
+
+def repository(root: Path, remote: str) -> Path:
+    (root / ".git").mkdir(parents=True)
+    (root / ".git" / "config").write_text(f'[remote "origin"]\n url = https://example.invalid/{remote}.git\n', encoding="utf-8")
+    return root
+
+
+def exercise(scratch: Path) -> dict[str, object]:
+    env = {key: value for key, value in os.environ.items() if not key.startswith(("OMH_", "HERMES_", "GIT_"))}
+    user, hermes = scratch / "user", scratch / "hermes"
+    env.update(OMH_HOME=str(user), HERMES_HOME=str(hermes), HOME=str(scratch / "home"), USERPROFILE=str(scratch / "home"))
+    calls = 0
+
+    def cli(root: Path, *args: str, home: Path = user) -> dict[str, Any]:
+        nonlocal calls
+        process = subprocess.run([sys.executable, "-m", "omh.cli", "--omh-home", str(home), "--hermes-home", str(hermes), "memory", *args], cwd=root, env=env, text=True, capture_output=True, timeout=30)
+        calls += 1
+        if process.returncode:
+            raise AssertionError(f"cli_failed:{args[0]}:{process.returncode}")
+        return json.loads(process.stdout)
+
+    def approve(root: Path, summary: str, *, home: Path = user, legacy: bool = False) -> str:
+        options = ("--scope-ref", "legacy-checkout") if legacy else ()
+        captured = cli(root, "capture", summary, "--retention-class", "durable", *options, home=home)
+        candidate_id = captured["candidate"]["candidate_id"]
+        revision = cli(root, "review", "--candidate", candidate_id, home=home)["cards"][0]["review_revision"]
+        return cli(root, "approve", candidate_id, "--candidate-revision", revision, home=home)["record"]["record_id"]
+
+    first = repository(scratch / "first" / "same-name", "first/project")
+    second = repository(scratch / "second" / "same-name", "second/project")
+    first_id = cli(first, "project-identity", "show")["identity"]
+    second_id = cli(second, "project-identity", "show")["identity"]
+    assert first_id != second_id
+    first_record = approve(first, "first checkout sentinel")
+    second_record = approve(second, "second checkout sentinel")
+    for root, included, excluded in ((first, first_record, second_record), (second, second_record, first_record)):
+        pack = cli(root, "recall")
+        assert {row["record_id"] for row in pack["included_records"]} == {included}
+        provider = OmhMemoryProvider(user)
+        provider.initialize("qa-session", cwd=root, agent_context="subagent")
+        text = provider.prefetch()
+        assert included in text and excluded not in text
+        receipt = provider.latest_prefetch_receipt()
+        assert receipt is not None
+        assert receipt["schema_version"] == "omh_memory_prefetch_receipt/v3"
+        assert len([scope for scope in receipt["lens"]["scope_allowlist"] if scope["kind"] == "project"]) == 1
+        provider.shutdown()
+    renamed = first.with_name("renamed")
+    first.rename(renamed)
+    assert cli(renamed, "project-identity", "show")["identity"] == first_id
+    assert cli(renamed, "recall")["included_records"][0]["record_id"] == first_record
+    gitdir = renamed / ".git" / "worktrees" / "linked"
+    gitdir.mkdir(parents=True)
+    (gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+    linked = scratch / "linked"
+    linked.mkdir()
+    (linked / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+    assert cli(linked, "project-identity", "show")["identity"] == first_id
+
+    migration_root = repository(scratch / "migration", "migration/project")
+    migration_user = scratch / "migration-user"
+    legacy_ids = [approve(migration_root, "project legacy sentinel", home=migration_root / ".omh", legacy=True),
+                  approve(migration_root, "user legacy sentinel", home=migration_user, legacy=True)]
+    before = {p: p.read_bytes() for home in (migration_root / ".omh", migration_user) for p in home.rglob("*") if p.is_file()}
+    report = cli(migration_root, "project-identity", "report", home=migration_user)
+    assert len(report["entries"]) == 2
+    assert {row["store"] for row in report["entries"]} == {"project", "user"}
+    assert before == {p: p.read_bytes() for home in (migration_root / ".omh", migration_user) for p in home.rglob("*") if p.is_file()}
+    receipt = cli(migration_root, "project-identity", "migrate", "--approve", report["report_digest"], home=migration_user)
+    assert len(receipt["successors"]) == 2
+    provider = OmhMemoryProvider(migration_user)
+    provider.initialize("migration-session", cwd=migration_root, agent_context="subagent")
+    text = provider.prefetch()
+    assert all(record_id in text for record_id in legacy_ids)
+    provider.shutdown()
+    assert cli(migration_root, "project-identity", "migrate", "--approve", report["report_digest"], home=migration_user)["successors"] == []
+    rollback = cli(migration_root, "project-identity", "migrate", "--rollback", receipt["receipt_id"], home=migration_user)
+    assert rollback["state"] == "rolled_back"
+    for path, original in before.items():
+        if path.parent.name in {"records", "reviews"}:
+            assert path.read_bytes() == original
+    for home in (migration_root / ".omh", migration_user):
+        assert cli(migration_root, "recall", home=home)["included_records"] == []
+        assert cli(migration_root, "recall", "--scope-kind", "project", "--scope-ref", "legacy-checkout", home=home)["record_count"] == 1
+    return {"same_basename_isolation": True, "capture_recall": True, "rename_stability": True,
+            "worktree_sharing": True, "migration_stores": 2, "migrated_successors": 2,
+            "report_read_only": True, "idempotent": True, "rollback": True, "cli_calls": calls}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    with TemporaryDirectory(prefix="omh-1509-qa-", dir=Path.cwd()) as temporary:
+        scratch = Path(temporary)
+        summary = exercise(scratch)
+    summary.update(schema_version="issue_1509_project_identity_qa/v1", passed=True, cleanup_verified=not scratch.exists())
+    encoded = json.dumps(summary, sort_keys=True, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Bind project memory to a versioned, opaque, stable repository identity (`project_identity/v2`) instead of the checkout directory basename. Automatic project recall, capture defaults, handoffs, project terms, and prefetch receipts now resolve identity from explicit local evidence or a normalized Git remote digest, fail closed when evidence is missing or ambiguous, and never mix stable and legacy basename scopes in one automatic recall result. A report-first, digest-approved migration moves legacy basename-scoped records to the stable identity through reviewed successor revisions with byte-preserved originals and resumable rollback.

Closes #1509

## Why

A directory basename is neither unique nor stable: two unrelated repositories named the same shared reviewed project memory (including records held in user-level or imported stores), and renaming or moving a checkout silently changed the derived scope so correctly scoped records disappeared from automatic recall. The shipped documentation admitted both failure modes ("Same-named checkouts share a label").

## What changes for users

- Same-named but unrelated repositories (and forks) no longer recall each other's project records.
- Renaming or moving a checkout no longer changes its project identity; linked worktrees of one repository share the intended identity.
- Repositories without a Git remote get an explicit opt-in identity via `omh memory project-identity init`.
- Legacy basename-scoped records stop appearing in automatic recall until the operator runs the report-first migration: `omh memory project-identity report` (read-only), then `omh memory project-identity migrate --approve <report_digest>`, with `--rollback <receipt_id>` available.
- `omh memory project-identity show` exposes the current resolution state, evidence class, and closed diagnostic tokens.

## How it works (boundary level)

- New self-contained resolver `src/plugin_bundle/omh/project_identity.py` (stdlib only, filesystem-only, no subprocess/network/writes): explicit `<project>/.omh/project-identity.json` wins; otherwise the nearest `.git` entry (directory or linked-worktree file, following `commondir`) yields a remote URL that is normalized (scheme/userinfo stripped, scp-like syntax mapped, trailing `.git` removed, host lowercased) and retained only as a SHA-256 digest (`repo:<hex>`). Missing, ambiguous, unreadable, or conflicting evidence resolves to `unresolved` with closed diagnostic tokens — never raw paths, URLs, or credentials.
- Consumers rewired to the resolver: provider prefetch scopes, capture defaults, canonical recall/handoff scope, project-terms capture, lifecycle/evaluation derivation, and recall-incident diagnosis (which names the explicit `legacy_basename` compatibility state). All fail closed on `unresolved`.
- Prefetch receipts move to `omh_memory_prefetch_receipt/v3`, binding the selector configuration identity to the resolver version and opaque project identity; v2 receipts remain readable as legacy, and mismatched resolver/identity receipts are rejected.
- Migration (`src/workflows/memory_project_identity.py` + `omh memory project-identity` command group): the report is read-only and digest-stamped; migration recomputes the report and requires digest equality (approval binding + idempotency), creates reviewed successor revisions through the existing lifecycle successor machinery, never rewrites old scope evidence in place, and supports rollback that retires the successors named by the receipt.
- `docs/MEMORY-PREFETCH.md` gains the compatibility note: basename-scoped automatic recall stops until reviewed migration; local-only projects need `project-identity init`.

## Observed verification

- RED-first: 10 scenarios recorded and captured failing before production edits (`.omc/issue-1509/red-scenarios.md`, `red.log`); 14 focused scenarios pass after (`green.log`).
- Full suite: `PYTHONPATH=tests uv run python -m unittest discover -s tests -v` — 11,530 tests, OK (3 pre-existing skips).
- Gates: `ruff check src tests`, `compileall`, all eight `docs * --check` byte gates, and `git diff --check` exit 0.
- Real-surface QA (`tools/qa/issue_1509_project_identity.py`, run from a temp dir, parent-reverified): 47 CLI calls covering same-basename isolation across two stores, rename stability, linked-worktree sharing, fork distinction, report read-only proof, digest-bound approval, approval-race boundaries, idempotent second run, rollback, and cleanup verification — all pass (`.omc/issue-1509/qa.json`).
- Independent gate review, two rounds: round 1 rejected with five blockers (relative-remote collision, store-path eligibility leak, quoted-URL credential retention, external-store receipt rejection, migration TOCTOU); round 2 reproduced every blocker against the fix head and resolved all five with no blocking regressions (`.omo/evidence/issue-1509-gate-review-round2.md`).

## Risks and rollout notes

- **Compatibility break by design (risk/contract-change):** basename-scoped records leave automatic recall until the explicit migration completes; the migration is report-first and rollback-safe, and the docs section states this plainly.
- Receipt schema v3 is additive; v2 receipts validate as legacy but new selections build v3 only.
- Not exercised: live Hermes host delivery and Windows execution (CI covers Windows; resolver uses stdlib path/file APIs only and tests assert the POSIX/Windows permission pattern).
