### PR TITLE
fix: bind OMH runtime state to the active Hermes profile

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -35,8 +35,12 @@ The copied plugin and package use the same stateless resolver, in this order:
 1. A trusted programmatic/CLI home pair (also supports offline operations).
 2. The active profile's `plugins.entries.omh.settings.omh_home`, with the
    existing legacy `config.omh_home` fallback.
-3. Legacy `OMH_HOME` from Hermes' active credential scope, never another routed
-   profile's process environment.
+3. Legacy `OMH_HOME` from Hermes' active credential scope, verified against
+   the host's profile-home-keyed snapshot (its `.env` plus already hydrated
+   external sources), never another routed profile's process environment.
+   Anonymous scope mappings have no owner identity: mismatching/unverifiable
+   values are refused before I/O. Use an absolute profile setting for bindings
+   supplied only through an ad hoc in-memory secret mapping.
 4. For standalone/launch-owner operation only, the legacy `OMH_HOME`/`~/.omh`
    default. The independent OMH CLI has no Hermes dependency and retains its
    explicit `--omh-home`, `--hermes-home`, and `--scope project` behavior.
@@ -47,7 +51,11 @@ an empty substitute store. Relative profile settings are anchored at that
 profile's Hermes home. `~` still names the OS user's home. Prefer absolute paths;
 `$HERMES_HOME` is expanded against the active profile, but an already-expanded
 native `${HERMES_HOME}` value that disagrees with that profile is rejected with
-an absolute-path diagnostic. Unresolved variables are rejected.
+an absolute-path diagnostic. Validation follows the winning raw configuration
+leaf, including administrator-managed precedence; a shadowed user template
+cannot veto a managed absolute setting. Unresolved variables are rejected.
+Evidence `project_root` and `workdir` accept literal paths (including `~`), not
+variable references: model paths never query credentials or environment values.
 
 Native tools/hooks do not treat home-looking model arguments or observation
 metadata as permission to choose another store. Provider and optional
@@ -60,16 +68,17 @@ launched TUI widget must likewise receive its owning process's home pair;
 Python context scopes do not cross process boundaries.
 
 This binding uses native `hermes_constants` profile APIs,
-`agent.secret_scope`, `agent.runtime_cwd`, and the read-only config loader plus
-its strict readability validator. A present but incompatible/broken host is
+`agent.secret_scope` (including `build_profile_secret_scope`),
+`agent.runtime_cwd`, `hermes_cli.managed_scope.load_managed_config`, and the
+read-only config loader plus its strict readability validator. A present but incompatible/broken host is
 not treated as standalone. Setup/profile synchronization does not stamp one
 profile's store into every child or migrate data; configure each routed
 profile explicitly before activation. Existing child settings are preserved.
 
 Maintainers can run the opt-in synthetic real-loader suite with a Hermes
 checkout's `scripts/run_tests.sh`, passing this repository's
-`tests/native/test_profile_runtime.py` and
-`--native-source=/absolute/path/to/hermes`. Use an explicit pytest root/cache
+`tests/native/test_profile_runtime.py`, `tests/native/test_review_native.py`,
+and `--native-source=/absolute/path/to/hermes`. Use an explicit pytest root/cache
 inside the test workspace. The ordinary OMH unittest suite needs no Hermes
 installation. These tests distinguish actual turn-start behavior from positive
 recall after the native background queue; this change does not alter upstream

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -11,6 +11,70 @@ AI agents and operators who need a pasteable protocol should use the root
 [Agent Install Protocol](../INSTALL_FOR_AGENTS.md). That protocol defines what
 to run, what to report, and what is still unobserved after install.
 
+## Runtime state in Hermes profiles (operator reference)
+
+A native Hermes profile must select its own OMH store, or deliberately select
+an explicitly shared store. Configure the existing plugin setting in that
+profile's `config.yaml`:
+
+```yaml
+plugins:
+  entries:
+    omh:
+      settings:
+        omh_home: ~/omh-stores/profile-a
+```
+
+Two trusted profiles may explicitly name the same directory. That shares OMH
+records and home-wide ledgers; it does not make them separate stores. Existing
+memory principal/admission checks still apply within shared stores. Different
+directories are not an OS sandbox.
+
+The copied plugin and package use the same stateless resolver, in this order:
+
+1. A trusted programmatic/CLI home pair (also supports offline operations).
+2. The active profile's `plugins.entries.omh.settings.omh_home`, with the
+   existing legacy `config.omh_home` fallback.
+3. Legacy `OMH_HOME` from Hermes' active credential scope, never another routed
+   profile's process environment.
+4. For standalone/launch-owner operation only, the legacy `OMH_HOME`/`~/.omh`
+   default. The independent OMH CLI has no Hermes dependency and retains its
+   explicit `--omh-home`, `--hermes-home`, and `--scope project` behavior.
+
+A routed profile without a binding, an unscoped multiplex call, and blank or
+malformed settings are unavailable with a binding error. They do not create
+an empty substitute store. Relative profile settings are anchored at that
+profile's Hermes home. `~` still names the OS user's home. Prefer absolute paths;
+`$HERMES_HOME` is expanded against the active profile, but an already-expanded
+native `${HERMES_HOME}` value that disagrees with that profile is rejected with
+an absolute-path diagnostic. Unresolved variables are rejected.
+
+Native tools/hooks do not treat home-looking model arguments or observation
+metadata as permission to choose another store. Provider and optional
+observer/egress/browser instances bind before their first I/O; providers refuse
+reinitialization with another Hermes home. Project recall uses the host's
+logical cwd rather than a multiplex launch repository; absent/deleted logical
+context selects no project. Evidence subprocesses receive only the existing
+minimal non-secret environment plus the resolved OMH/Hermes homes. A separately
+launched TUI widget must likewise receive its owning process's home pair;
+Python context scopes do not cross process boundaries.
+
+This binding uses native `hermes_constants` profile APIs,
+`agent.secret_scope`, `agent.runtime_cwd`, and the read-only config loader plus
+its strict readability validator. A present but incompatible/broken host is
+not treated as standalone. Setup/profile synchronization does not stamp one
+profile's store into every child or migrate data; configure each routed
+profile explicitly before activation. Existing child settings are preserved.
+
+Maintainers can run the opt-in synthetic real-loader suite with a Hermes
+checkout's `scripts/run_tests.sh`, passing this repository's
+`tests/native/test_profile_runtime.py` and
+`--native-source=/absolute/path/to/hermes`. Use an explicit pytest root/cache
+inside the test workspace. The ordinary OMH unittest suite needs no Hermes
+installation. These tests distinguish actual turn-start behavior from positive
+recall after the native background queue; this change does not alter upstream
+turn-start pack invalidation or claim live model delivery.
+
 ## Command Audience
 
 | Audience | Normal interaction |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -30,7 +30,7 @@ records and home-wide ledgers; it does not make them separate stores. Existing
 memory principal/admission checks still apply within shared stores. Different
 directories are not an OS sandbox.
 
-The copied plugin and package use the same stateless resolver, in this order:
+The copied plugin and package use the same uncached root resolver, in this order:
 
 1. A trusted programmatic/CLI home pair (also supports offline operations).
 2. The active profile's `plugins.entries.omh.settings.omh_home`, with the
@@ -45,6 +45,18 @@ The copied plugin and package use the same stateless resolver, in this order:
    default. The independent OMH CLI has no Hermes dependency and retains its
    explicit `--omh-home`, `--hermes-home`, and `--scope project` behavior.
 
+Importing `hermes_constants` alone does not select native operation. A plain
+OMH CLI colocated with a compatible Hermes installation still uses process
+environment variables. Native home/secret scopes or multiplex mode select the
+native lane. Actual registration through Hermes' `PluginContext` or memory
+provider collector also marks that **bundle instance** as native: ordinary
+single-owner memory loading and later callbacks can run without task scopes.
+That marker records only the execution lane, never a profile, home or secret.
+Missing scope-probe APIs are ambiguous and fail closed; missing required
+callable APIs in an active native host are reported as a bounded
+`RuntimeBindingError` before configuration or store reads, not downgraded to
+standalone. Internal host import faults still propagate.
+
 A routed profile without a binding, an unscoped multiplex call, and blank or
 malformed settings are unavailable with a binding error. They do not create
 an empty substitute store. Relative profile settings are anchored at that
@@ -53,12 +65,31 @@ profile's Hermes home. `~` still names the OS user's home. Prefer absolute paths
 native `${HERMES_HOME}` value that disagrees with that profile is rejected with
 an absolute-path diagnostic. Validation follows the winning raw configuration
 leaf, including administrator-managed precedence; a shadowed user template
-cannot veto a managed absolute setting. Unresolved variables are rejected.
-Evidence `project_root` and `workdir` accept literal paths (including `~`), not
-variable references: model paths never query credentials or environment values.
+cannot veto a managed absolute setting. Literal paths and setting presence
+must also agree with the effective native configuration. Unresolved variables
+are rejected. Evidence `project_root` and `workdir` accept literal absolute or
+relative paths and the current user's `~`/`~/...`, but not `~other-user/...`
+or variable references: model paths never query other OS users, credentials
+or environment values.
+
+Explicit empty-string/whitespace home arguments are rejected in both user and
+project scope rather than silently selecting a default. This intentionally
+tightens the former empty-string fallback: omit the argument (`None` in Python)
+to request defaults. Blank configured native bindings never inherit ambient
+state. Filesystem failures while resolving runtime homes are also bounded
+`RuntimeBindingError`s. Hooks classify failed binding before observation I/O;
+pre-tool binding failure blocks the call because its rules cannot be checked.
+Direct runtime readers still raise on unreadable state instead of claiming idle.
+Evidence child binding failure returns an error without spawning a command.
 
 Native tools/hooks do not treat home-looking model arguments or observation
-metadata as permission to choose another store. Provider and optional
+metadata as permission to choose another store. Legacy model-facing home fields
+are explicitly rejected by native tools before observation or store I/O, even
+when blank or equal to the active home; omit them. Their schemas retain and
+label standalone operator overrides, and trusted offline APIs remain separate.
+Standalone observations honor explicit top-level operator homes in both package
+and copied-bundle paths; nested observation metadata is never store authority.
+Provider and optional
 observer/egress/browser instances bind before their first I/O; providers refuse
 reinitialization with another Hermes home. Project recall uses the host's
 logical cwd rather than a multiplex launch repository; absent/deleted logical
@@ -66,6 +97,25 @@ context selects no project. Evidence subprocesses receive only the existing
 minimal non-secret environment plus the resolved OMH/Hermes homes. A separately
 launched TUI widget must likewise receive its owning process's home pair;
 Python context scopes do not cross process boundaries.
+
+Runtime homes are canonicalized (including symlinks) for store identity and
+per-home guards. Core project-store paths were already canonicalized; native
+logical cwd is passed through without replacing it with the process cwd. Stable
+project identity and bound absent-cwd behavior are unchanged.
+
+Repository-scoped artifact defaults are explicit:
+
+| Invocation | `omh_home_named` | `project_artifact_dir` |
+| --- | --- | --- |
+| Standalone or colocated OMH CLI, no explicit home | false | Logical repository `.omh/`, or user store outside a repository |
+| Ordinary single-owner native profile | false | Logical repository `.omh/`, or profile-selected store outside a repository |
+| Routed native profile (multiplex or a non-launch home) | true | Profile-selected OMH store; never a launch repository |
+| Trusted explicit OMH home/pair | true | Explicit OMH store, including inside a repository |
+
+When logical cwd is absent there is no inferred repository; artifacts use the
+selected store. Explicit `--scope project` still selects the logical project's
+`.omh`/`.hermes`; without a logical cwd it fails rather than borrowing process
+cwd. Naming a runtime store does not change the project's stable identity.
 
 This binding uses native `hermes_constants` profile APIs,
 `agent.secret_scope` (including `build_profile_secret_scope`),

--- a/src/plugin_bundle/omh/__init__.py
+++ b/src/plugin_bundle/omh/__init__.py
@@ -80,6 +80,8 @@ def register(ctx: _PluginContext) -> None:
     Naming ``register_memory_provider`` here is also what makes this directory
     visible to Hermes' provider discovery, which text-scans ``__init__.py``.
     """
+    from . import runtime_paths
+    runtime_paths.note_host_registration(ctx)
     from .memory_provider import OmhMemoryProvider
 
     _register_optional_surface(ctx, "register_memory_provider", OmhMemoryProvider())

--- a/src/plugin_bundle/omh/agent_board_bridge.py
+++ b/src/plugin_bundle/omh/agent_board_bridge.py
@@ -6,6 +6,8 @@ Only a correlated normal-loop pre/post pair can create an OMH receipt.
 """
 from __future__ import annotations
 
+from . import runtime_paths
+
 from collections.abc import Generator, Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -249,15 +251,15 @@ class _PrepareCall:
 # handler on the caller's thread, so a ContextVar cannot carry the pre to the
 # handler. This process-local registry is keyed by the host's own session/task
 # identity; each entry is consumed exactly once by the matching handler call.
-_PREPARE_CALLS: dict[tuple[str, str], _PrepareCall] = {}
+_PREPARE_CALLS: dict[tuple[Path, str, str], _PrepareCall] = {}
 _PREPARE_CALLS_LOCK = RLock()
 _MAX_PREPARE_CALLS = 64
-_BRIDGES: dict[tuple[Path, str | None], AgentBoardBridge] = {}
+_BRIDGES: dict[tuple[Path, Path, str | None], AgentBoardBridge] = {}
 _BRIDGES_LOCK = RLock()
 
 
 def _arm_prepare_call(host: HostIdentity, digest: str) -> None:
-    key = (host.session_id, host.task_id)
+    key = (runtime_paths.default_hermes_home(), host.session_id, host.task_id)
     with _PREPARE_CALLS_LOCK:
         _ = _PREPARE_CALLS.pop(key, None)
         if len(_PREPARE_CALLS) >= _MAX_PREPARE_CALLS:
@@ -270,7 +272,7 @@ def _disarm_prepare_call(host: HostIdentity | None) -> None:
     if host is None:
         return
     with _PREPARE_CALLS_LOCK:
-        _ = _PREPARE_CALLS.pop((host.session_id, host.task_id), None)
+        _ = _PREPARE_CALLS.pop((runtime_paths.default_hermes_home(), host.session_id, host.task_id), None)
 
 
 def _input_digest(arguments: Mapping[str, object]) -> str:
@@ -293,7 +295,7 @@ def handler_identity(args: Mapping[str, object], kwargs: Mapping[str, object]) -
     if not isinstance(session_id, str) or not isinstance(task_id, str):
         return None
     with _PREPARE_CALLS_LOCK:
-        pending = _PREPARE_CALLS.pop((session_id, task_id), None)
+        pending = _PREPARE_CALLS.pop((runtime_paths.default_hermes_home(), session_id, task_id), None)
     if pending is None or pending.digest != _input_digest(args):
         return None
     return pending.host
@@ -302,7 +304,7 @@ def handler_identity(args: Mapping[str, object], kwargs: Mapping[str, object]) -
 def installed_bridge(board: str) -> AgentBoardBridge:
     root = effective_root(board)
     home = default_omh_home().expanduser().resolve()
-    key = (home, root)
+    key = (runtime_paths.default_hermes_home(), home, root)
     with _BRIDGES_LOCK:
         bridge = _BRIDGES.get(key)
         if bridge is None:

--- a/src/plugin_bundle/omh/approval_bypass.py
+++ b/src/plugin_bundle/omh/approval_bypass.py
@@ -22,6 +22,8 @@ timestamp are recorded — never a session key, command, or prompt.
 """
 from __future__ import annotations
 
+from . import runtime_paths
+
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -56,7 +58,7 @@ APPROVAL_BYPASS_HOST_STATE_CLAIM_BOUNDARY = (
 
 
 def _runtime_dir(omh_home: str = "") -> Path:
-    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    root = Path(omh_home).expanduser() if omh_home else runtime_paths.default_omh_home()
     return root / "runtime"
 
 
@@ -132,7 +134,7 @@ def _approvals_mode_off(hermes_home: str = "") -> bool:
     and anything unreadable or oddly shaped reads as False (not bypassed) so
     this can only ever add a truthful ON, never mask one.
     """
-    home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    home = Path(hermes_home).expanduser() if hermes_home else runtime_paths.default_hermes_home()
     try:
         text = (home / "config.yaml").read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):

--- a/src/plugin_bundle/omh/awareness_delivery.py
+++ b/src/plugin_bundle/omh/awareness_delivery.py
@@ -24,6 +24,8 @@ cannot grow.
 
 from __future__ import annotations
 
+from . import runtime_paths
+
 import errno
 import hashlib
 import json
@@ -72,7 +74,7 @@ def _is_session_fingerprint(value: str) -> bool:
 
 
 def _runtime_dir(omh_home: str = "") -> Path:
-    root = Path(os.path.expandvars(omh_home or os.environ.get("OMH_HOME", "~/.omh"))).expanduser()
+    root = runtime_paths.expand_path(omh_home) if omh_home else runtime_paths.default_omh_home()
     return root / "runtime"
 
 

--- a/src/plugin_bundle/omh/browser_bridge.py
+++ b/src/plugin_bundle/omh/browser_bridge.py
@@ -1,6 +1,8 @@
 """Explicit browser host binding. No browser imports or IO on unrelated calls."""
 from __future__ import annotations
 
+from . import runtime_paths
+
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -48,6 +50,7 @@ def register(ctx, config):
     effects_enabled = (config.get("effects_enabled") is True
                        and callable(getattr(ctx, "browser_effect_approval", None))
                        and all(callable(getattr(adapter, name, None)) for name in ("preview", "resume", "abort")))
+    home, _ = runtime_paths.resolve_homes(config.get("omh_home"))
     manager = None
     admission: ContextVar[_Admission | None] = ContextVar("omh_browser_admission", default=None)
 
@@ -86,10 +89,6 @@ def register(ctx, config):
         nonlocal manager
         if manager is None:
             from omh.workflows.browser_lease_store import BrowserLeaseStore, BrowserSessionManager
-            from pathlib import Path
-            import os
-
-            home = config.get("omh_home") or os.environ.get("OMH_HOME") or str(Path.home() / ".omh")
             manager = BrowserSessionManager(BrowserLeaseStore(home), adapter)
         return manager
 

--- a/src/plugin_bundle/omh/degradation.py
+++ b/src/plugin_bundle/omh/degradation.py
@@ -59,6 +59,16 @@ DEGRADATION_CHAT_NOTE = (
 )
 
 
+def runtime_binding_degradation(error: BaseException) -> dict[str, object]:
+    """Binding failed before hook I/O; never reflect exception text or retry."""
+    return {
+        "omh_degradation": degradation_payload([
+            (COMPONENT_RUNTIME_STATUS_READ, safe_error_type(type(error).__name__))]),
+        "context": "[OMH Degraded] components=" + COMPONENT_RUNTIME_STATUS_READ
+        + ". Runtime home binding failed; no runtime state was read or written.",
+    }
+
+
 def safe_error_type(error_type: str) -> str:
     """Return a bounded, character-safe exception class name."""
     text = re.sub(r"[^A-Za-z0-9_.-]", "", str(error_type or ""))

--- a/src/plugin_bundle/omh/delegation_routing.py
+++ b/src/plugin_bundle/omh/delegation_routing.py
@@ -26,6 +26,8 @@ reads it.
 
 from __future__ import annotations
 
+from . import runtime_paths
+
 import os
 import re
 import tempfile
@@ -247,14 +249,7 @@ def write_delegation_route(
 def _config_path(hermes_home: str | Path | None) -> Path:
     if hermes_home:
         return Path(hermes_home).expanduser() / "config.yaml"
-    try:
-        from hermes_constants import get_hermes_home
-    except ImportError:
-        # The bundled plugin is also importable without a Hermes runtime.
-        home = Path(os.environ.get("HERMES_HOME") or "~/.hermes").expanduser()
-    else:
-        home = get_hermes_home()
-    return home / "config.yaml"
+    return runtime_paths.default_hermes_home() / "config.yaml"
 
 
 def _delegation_child_indents(lines: list[str]) -> dict[int, int]:

--- a/src/plugin_bundle/omh/egress_attempts.py
+++ b/src/plugin_bundle/omh/egress_attempts.py
@@ -7,9 +7,10 @@ registered wrapper.
 
 from __future__ import annotations
 
+from . import runtime_paths
+
 import hashlib
 import json
-import os
 import secrets
 import threading
 from dataclasses import dataclass
@@ -227,8 +228,7 @@ class RegistrationContext(Protocol):
 def register(ctx: RegistrationContext, raw: object) -> None:
     """Install only after ``ctx.get_config(...).enabled`` selected this feature."""
     targets, invalid, global_error = _parse_config(raw)
-    home_value = raw.get("omh_home", os.environ.get("OMH_HOME", "~/.omh")) if isinstance(raw, dict) else "~/.omh"
-    home = Path(str(home_value)).expanduser()
+    home, _ = runtime_paths.resolve_homes(raw.get("omh_home") if isinstance(raw, dict) else None)
     from tools.registry import registry
     scope = getattr(getattr(ctx, "_manager", None), "scope_key", None)
     guard = Guard(home, targets, invalid, global_error, lambda name: registry.get_entry(name, scope=scope))

--- a/src/plugin_bundle/omh/hermes_delegation.py
+++ b/src/plugin_bundle/omh/hermes_delegation.py
@@ -24,6 +24,8 @@ mixture routing is visible as such instead of masquerading as a routed one.
 
 from __future__ import annotations
 
+from . import runtime_paths
+
 import json
 import os
 import re
@@ -160,7 +162,7 @@ _CHAIN_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
 
 
 def mixture_chain_overrides_path(omh_home: str | Path | None = None) -> Path:
-    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    root = Path(omh_home).expanduser() if omh_home else runtime_paths.default_omh_home()
     return root / "routing" / "model-chains.json"
 
 
@@ -430,7 +432,7 @@ def is_provider_id_token(value: object) -> bool:
 
 
 def provider_entitlements_path(omh_home: str | Path | None = None) -> Path:
-    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    root = Path(omh_home).expanduser() if omh_home else runtime_paths.default_omh_home()
     return root / "routing" / "providers.json"
 
 
@@ -623,7 +625,7 @@ MODEL_PROVIDER_ROUTES_SCHEMA_VERSION = "model_provider_routes/v1"
 
 
 def model_provider_routes_path(omh_home: str | Path | None = None) -> Path:
-    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    root = Path(omh_home).expanduser() if omh_home else runtime_paths.default_omh_home()
     return root / "routing" / "model-providers.json"
 
 
@@ -764,7 +766,7 @@ _PROVENANCE_ORIGINS = (
 
 
 def delegation_route_provenance_path(omh_home: str | Path | None = None) -> Path:
-    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    root = Path(omh_home).expanduser() if omh_home else runtime_paths.default_omh_home()
     return root / "routing" / "route-provenance.json"
 
 
@@ -1049,7 +1051,7 @@ MODEL_PRICE_OVERRIDES_SCHEMA_VERSION = "model_price_overrides/v1"
 
 
 def model_price_overrides_path(omh_home: str | Path | None = None) -> Path:
-    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    root = Path(omh_home).expanduser() if omh_home else runtime_paths.default_omh_home()
     return root / "routing" / "model-prices.json"
 
 
@@ -1661,7 +1663,7 @@ def read_hermes_native_subagents(
 ) -> dict[str, Any]:
     """Project owned native children, or explicitly global fallback activity."""
     current = float(now) if now is not None else time.time()
-    home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    home = Path(hermes_home).expanduser() if hermes_home else runtime_paths.default_hermes_home()
     # Category labels honor the user's ~/.omh/routing/model-chains.json
     # overrides so a customized chain labels its children like a shipped one.
     active_chains = effective_mixture_category_chains(omh_home)

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import errno
 from datetime import datetime, timezone
 import hashlib
@@ -159,7 +161,7 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
     # Turn start is the freshest in-process view of the Shift+Tab yolo flag:
     # a toggle shows on the HUD at the user's next message, not only at the
     # next tool call.
-    record_approval_bypass(omh_home=str(kwargs.get("omh_home", "") or ""))
+    record_approval_bypass(omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))))
     context_parts: list[str] = []
     payload: dict[str, object] = {}
     user_message = "" if _tracker_event_is_present(kwargs) else str(kwargs.get("user_message", "") or "")
@@ -198,7 +200,7 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
             if not claim_route_guidance_delivery(
                 session_id=session_id,
                 route_fingerprint=route_fingerprint,
-                omh_home=str(kwargs.get("omh_home", "") or ""),
+                omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
             ):
                 route_hint_context = ""
                 message_matches_awareness = False
@@ -249,26 +251,26 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
     # with the HUD checklist unnoticed. Honors the caller's awareness opt-out.
     if include_awareness:
         outcomes = unacknowledged_outcomes(
-            str(kwargs.get("omh_home", "") or ""),
-            str(kwargs.get("hermes_home", "") or ""),
+            str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
+            str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)),
             session_id,
         )
         todo_reminder = open_todo_reminder(
-            omh_home=str(kwargs.get("omh_home", "") or ""),
-            hermes_home=str(kwargs.get("hermes_home", "") or ""),
+            omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
+            hermes_home=str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)),
             session_ref=session_id,
             outcomes=outcomes,
         )
         if todo_reminder:
             context_parts.append(todo_reminder)
         workflow_context = active_workflow_context(
-            str(kwargs.get("omh_home", "") or ""), session_id
+            str(runtime_paths.plugin_home(kwargs.get("omh_home"))), session_id
         )
         if workflow_context:
             payload["omh_active_workflow"] = workflow_context
             context_parts.append(render_active_workflow_context(workflow_context))
         budget_context = context_budget_continuation(
-            str(kwargs.get("omh_home", "") or ""), session_id, str(kwargs.get("model", "") or "")
+            str(runtime_paths.plugin_home(kwargs.get("omh_home"))), session_id, str(kwargs.get("model", "") or "")
         )
         if budget_context:
             payload["omh_context_budget"] = budget_context
@@ -286,8 +288,8 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
                 ""
                 if outcomes
                 else _todo_stall_status(
-                    str(kwargs.get("omh_home", "") or ""),
-                    str(kwargs.get("hermes_home", "") or ""),
+                    str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
+                    str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)),
                     session_id,
                 )
             ),
@@ -298,8 +300,8 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
 
     omh_home: str | None = None
     try:
-        omh_home = str(kwargs.get("omh_home", "") or "") or None
-        hermes_home = str(kwargs.get("hermes_home", "") or "") or None
+        omh_home = str(runtime_paths.plugin_home(kwargs.get("omh_home"))) or None
+        hermes_home = str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)) or None
         try:
             activity = read_omh_activity(omh_home=omh_home, limit=3)
         except Exception as exc:

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -19,6 +19,7 @@ from ..degradation import (
     COMPONENT_RUNTIME_STATUS_READ,
     degradation_payload,
     safe_error_type,
+    runtime_binding_degradation,
 )
 from ..active_workflow_context import active_workflow_context, render_active_workflow_context
 from ..approval_bypass import record_approval_bypass
@@ -161,14 +162,8 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
     try:
         omh_home = str(runtime_paths.plugin_home(kwargs.get("omh_home")))
         hermes_home = str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True))
-    except (OSError, RuntimeError) as exc:
-        error_type = "RuntimeError" if getattr(exc, "errno", None) == errno.ELOOP else type(exc).__name__
-        degradation = degradation_payload([(COMPONENT_RUNTIME_STATUS_READ, safe_error_type(error_type))])
-        return {
-            "omh_degradation": degradation,
-            "context": "[OMH Degraded] components=" + COMPONENT_RUNTIME_STATUS_READ
-            + ". Runtime home binding failed; no runtime state was read or written.",
-        }
+    except (runtime_paths.RuntimeBindingError, OSError, RuntimeError) as exc:
+        return runtime_binding_degradation(exc)
     record_active_main_agent_model(kwargs.get("model"))
     observe_plugin_hook_call("pre_llm_call", kwargs)
     # Turn start is the freshest in-process view of the Shift+Tab yolo flag:

--- a/src/plugin_bundle/omh/hooks/llm_hooks.py
+++ b/src/plugin_bundle/omh/hooks/llm_hooks.py
@@ -156,12 +156,25 @@ def _tracker_event_is_present(kwargs: dict) -> bool:
 
 def pre_llm_call(**kwargs) -> dict[str, object] | None:
     """Inject bounded OMH role/status context without storing prompts."""
+    # Bind before any observer or awareness I/O. A failed root must not reach
+    # downstream defaults as None, or fail before the status classifier runs.
+    try:
+        omh_home = str(runtime_paths.plugin_home(kwargs.get("omh_home")))
+        hermes_home = str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True))
+    except (OSError, RuntimeError) as exc:
+        error_type = "RuntimeError" if getattr(exc, "errno", None) == errno.ELOOP else type(exc).__name__
+        degradation = degradation_payload([(COMPONENT_RUNTIME_STATUS_READ, safe_error_type(error_type))])
+        return {
+            "omh_degradation": degradation,
+            "context": "[OMH Degraded] components=" + COMPONENT_RUNTIME_STATUS_READ
+            + ". Runtime home binding failed; no runtime state was read or written.",
+        }
     record_active_main_agent_model(kwargs.get("model"))
     observe_plugin_hook_call("pre_llm_call", kwargs)
     # Turn start is the freshest in-process view of the Shift+Tab yolo flag:
     # a toggle shows on the HUD at the user's next message, not only at the
     # next tool call.
-    record_approval_bypass(omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))))
+    record_approval_bypass(omh_home=omh_home)
     context_parts: list[str] = []
     payload: dict[str, object] = {}
     user_message = "" if _tracker_event_is_present(kwargs) else str(kwargs.get("user_message", "") or "")
@@ -200,7 +213,7 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
             if not claim_route_guidance_delivery(
                 session_id=session_id,
                 route_fingerprint=route_fingerprint,
-                omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
+                omh_home=omh_home,
             ):
                 route_hint_context = ""
                 message_matches_awareness = False
@@ -251,26 +264,26 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
     # with the HUD checklist unnoticed. Honors the caller's awareness opt-out.
     if include_awareness:
         outcomes = unacknowledged_outcomes(
-            str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
-            str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)),
+            omh_home,
+            hermes_home,
             session_id,
         )
         todo_reminder = open_todo_reminder(
-            omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
-            hermes_home=str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)),
+            omh_home=omh_home,
+            hermes_home=hermes_home,
             session_ref=session_id,
             outcomes=outcomes,
         )
         if todo_reminder:
             context_parts.append(todo_reminder)
         workflow_context = active_workflow_context(
-            str(runtime_paths.plugin_home(kwargs.get("omh_home"))), session_id
+            omh_home, session_id
         )
         if workflow_context:
             payload["omh_active_workflow"] = workflow_context
             context_parts.append(render_active_workflow_context(workflow_context))
         budget_context = context_budget_continuation(
-            str(runtime_paths.plugin_home(kwargs.get("omh_home"))), session_id, str(kwargs.get("model", "") or "")
+            omh_home, session_id, str(kwargs.get("model", "") or "")
         )
         if budget_context:
             payload["omh_context_budget"] = budget_context
@@ -288,8 +301,8 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
                 ""
                 if outcomes
                 else _todo_stall_status(
-                    str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
-                    str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)),
+                    omh_home,
+                    hermes_home,
                     session_id,
                 )
             ),
@@ -298,10 +311,7 @@ def pre_llm_call(**kwargs) -> dict[str, object] | None:
         if claim_finding:
             context_parts.append(f"[OMH continuation claim] {claim_finding}")
 
-    omh_home: str | None = None
     try:
-        omh_home = str(runtime_paths.plugin_home(kwargs.get("omh_home"))) or None
-        hermes_home = str(runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)) or None
         try:
             activity = read_omh_activity(omh_home=omh_home, limit=3)
         except Exception as exc:

--- a/src/plugin_bundle/omh/hooks/session_hooks.py
+++ b/src/plugin_bundle/omh/hooks/session_hooks.py
@@ -8,13 +8,18 @@ import os
 from pathlib import Path
 import uuid
 
+from ..degradation import runtime_binding_degradation
 from ..host_observation import observe_plugin_hook_call
 
 
-def on_session_end(**kwargs) -> dict[str, str] | None:
+def on_session_end(**kwargs) -> dict[str, object] | None:
     """Record a metadata-only plugin checkpoint when OMH runtime state exists."""
+    try:
+        home = runtime_paths.plugin_home(kwargs.get("omh_home"))
+        runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)
+    except (runtime_paths.RuntimeBindingError, OSError, RuntimeError) as exc:
+        return runtime_binding_degradation(exc)
     observe_plugin_hook_call("on_session_end", kwargs)
-    home = runtime_paths.plugin_home(kwargs.get("omh_home"))
     runtime_dir = home / "runtime"
     if not runtime_dir.exists():
         return None

--- a/src/plugin_bundle/omh/hooks/session_hooks.py
+++ b/src/plugin_bundle/omh/hooks/session_hooks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 from datetime import datetime, timezone
 import json
 import os
@@ -12,7 +14,7 @@ from ..host_observation import observe_plugin_hook_call
 def on_session_end(**kwargs) -> dict[str, str] | None:
     """Record a metadata-only plugin checkpoint when OMH runtime state exists."""
     observe_plugin_hook_call("on_session_end", kwargs)
-    home = _expand_path(str(kwargs.get("omh_home", "") or "") or os.environ.get("OMH_HOME", "~/.omh"))
+    home = runtime_paths.plugin_home(kwargs.get("omh_home"))
     runtime_dir = home / "runtime"
     if not runtime_dir.exists():
         return None

--- a/src/plugin_bundle/omh/hooks/tool_hooks.py
+++ b/src/plugin_bundle/omh/hooks/tool_hooks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import json
 from typing import Protocol, TypeGuard
 
@@ -16,7 +18,7 @@ def pre_tool_call(**kwargs: object) -> dict[str, object] | None:
     # The approval-bypass ledger observes session state, not this call's
     # outcome, so it ticks before the rule gate — a blocked call still sees
     # the same Shift+Tab flag.
-    record_approval_bypass(omh_home=str(kwargs.get("omh_home", "") or ""))
+    record_approval_bypass(omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))))
     # User-authored toolcall rules intervene first: a block directive is the
     # strongest host-supported response (hermes_cli/plugins.py,
     # `_get_pre_tool_call_directive_details`: "``block`` vetoes the tool call
@@ -27,7 +29,7 @@ def pre_tool_call(**kwargs: object) -> dict[str, object] | None:
         tool_name=kwargs.get("tool_name"),
         tool_input=kwargs.get("tool_input") if "tool_input" in kwargs else kwargs.get("args"),
         session_id=str(kwargs.get("session_id", "") or kwargs.get("task_id", "") or ""),
-        omh_home=str(kwargs.get("omh_home", "") or ""),
+        omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
     )
     if rule_directive is not None:
         # A blocked call never dispatches, so it must not tick the
@@ -50,7 +52,7 @@ def pre_tool_call(**kwargs: object) -> dict[str, object] | None:
     # the only place OMH can see either fact.
     record_tool_call(
         kwargs.get("tool_name"),
-        omh_home=str(kwargs.get("omh_home", "") or ""),
+        omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
         tool_call_id=kwargs.get("tool_call_id"),
         turn_id=kwargs.get("turn_id"),
     )
@@ -88,7 +90,7 @@ def post_tool_call(**kwargs: object) -> None:
         post_agent_board(kwargs)
     record_tool_call_close(
         kwargs.get("tool_call_id"),
-        omh_home=str(kwargs.get("omh_home", "") or ""),
+        omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
     )
     return None
 

--- a/src/plugin_bundle/omh/hooks/tool_hooks.py
+++ b/src/plugin_bundle/omh/hooks/tool_hooks.py
@@ -5,6 +5,7 @@ from .. import runtime_paths
 import json
 from typing import Protocol, TypeGuard
 
+from ..degradation import runtime_binding_degradation
 from ..approval_bypass import record_approval_bypass
 from ..host_observation import observe_plugin_hook_call
 from ..omh_roles import extract_role_marker, resolve_role_name, role_aliases, role_names
@@ -14,11 +15,19 @@ from ..toolcall_rules import toolcall_rule_directive
 
 def pre_tool_call(**kwargs: object) -> dict[str, object] | None:
     """Return only host-supported pre-tool directives or role warnings."""
+    try:
+        omh_home = str(runtime_paths.plugin_home(kwargs.get("omh_home")))
+        runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)
+    except (runtime_paths.RuntimeBindingError, OSError, RuntimeError) as exc:
+        # A missing rules owner cannot safely authorize the tool. This is the
+        # native host's supported veto, not a swallowed rule failure.
+        return {**runtime_binding_degradation(exc), "action": "block",
+                "message": "OMH runtime binding unavailable; tool rules could not be checked. Tool call blocked."}
     _ = observe_plugin_hook_call("pre_tool_call", kwargs)
     # The approval-bypass ledger observes session state, not this call's
     # outcome, so it ticks before the rule gate — a blocked call still sees
     # the same Shift+Tab flag.
-    record_approval_bypass(omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))))
+    record_approval_bypass(omh_home=omh_home)
     # User-authored toolcall rules intervene first: a block directive is the
     # strongest host-supported response (hermes_cli/plugins.py,
     # `_get_pre_tool_call_directive_details`: "``block`` vetoes the tool call
@@ -29,7 +38,7 @@ def pre_tool_call(**kwargs: object) -> dict[str, object] | None:
         tool_name=kwargs.get("tool_name"),
         tool_input=kwargs.get("tool_input") if "tool_input" in kwargs else kwargs.get("args"),
         session_id=str(kwargs.get("session_id", "") or kwargs.get("task_id", "") or ""),
-        omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
+        omh_home=omh_home,
     )
     if rule_directive is not None:
         # A blocked call never dispatches, so it must not tick the
@@ -52,7 +61,7 @@ def pre_tool_call(**kwargs: object) -> dict[str, object] | None:
     # the only place OMH can see either fact.
     record_tool_call(
         kwargs.get("tool_name"),
-        omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
+        omh_home=omh_home,
         tool_call_id=kwargs.get("tool_call_id"),
         turn_id=kwargs.get("turn_id"),
     )
@@ -68,7 +77,7 @@ def pre_tool_call(**kwargs: object) -> dict[str, object] | None:
     return payload
 
 
-def post_tool_call(**kwargs: object) -> None:
+def post_tool_call(**kwargs: object) -> dict[str, object] | None:
     """Close the in-flight ledger entry pre_tool_call opened for this call.
 
     A supported Hermes observer hook (`install/hook_integrity.py`
@@ -80,6 +89,11 @@ def post_tool_call(**kwargs: object) -> None:
     ceiling. A host that omits tool_call_id is a silent no-op here; the
     entry pre_tool_call never opened simply never closes early.
     """
+    try:
+        omh_home = str(runtime_paths.plugin_home(kwargs.get("omh_home")))
+        runtime_paths.plugin_home(kwargs.get("hermes_home"), hermes=True)
+    except (runtime_paths.RuntimeBindingError, OSError, RuntimeError) as exc:
+        return runtime_binding_degradation(exc)
     _ = observe_plugin_hook_call("post_tool_call", kwargs)
     try:
         from ..agent_board_bridge import post_agent_board
@@ -90,7 +104,7 @@ def post_tool_call(**kwargs: object) -> None:
         post_agent_board(kwargs)
     record_tool_call_close(
         kwargs.get("tool_call_id"),
-        omh_home=str(runtime_paths.plugin_home(kwargs.get("omh_home"))),
+        omh_home=omh_home,
     )
     return None
 

--- a/src/plugin_bundle/omh/host_observation.py
+++ b/src/plugin_bundle/omh/host_observation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from . import runtime_paths
+
 from contextlib import contextmanager
 from datetime import datetime, timezone
 import errno
@@ -132,7 +134,7 @@ def _observation_metadata(args: dict[str, Any], kwargs: dict[str, Any]) -> dict[
     for source in (args.get("observation"), kwargs.get("observation"), kwargs.get("omh_observation")):
         if isinstance(source, dict):
             metadata.update(source)
-    for key in ("host", "session_id", "source", "message", "omh_home", "hermes_home"):
+    for key in ("host", "session_id", "source", "message"):
         if args.get(key) is not None:
             metadata.setdefault(key, args.get(key))
         if kwargs.get(key) is not None:
@@ -186,8 +188,8 @@ def _record_observation(metadata: dict[str, Any], *, event: str, tool: str, hook
             from omh.plugin_observations import record_plugin_host_observation
 
             paths = resolve_paths(
-                omh_home=str(metadata.get("omh_home", "") or "") or None,
-                hermes_home=str(metadata.get("hermes_home", "") or "") or None,
+                omh_home=runtime_paths.default_omh_home(),
+                hermes_home=runtime_paths.default_hermes_home(),
             )
             return record_plugin_host_observation(
                 paths,
@@ -270,7 +272,7 @@ def _record_standalone_observation(
     evidence_refs: list[str],
     message: str,
 ) -> dict[str, Any]:
-    omh_home = _expand_path(str(metadata.get("omh_home", "") or "") or os.environ.get("OMH_HOME", "~/.omh"))
+    omh_home = runtime_paths.default_omh_home()
     runtime_dir = omh_home / "runtime"
     runtime_dir.mkdir(parents=True, exist_ok=True)
     try:

--- a/src/plugin_bundle/omh/host_observation.py
+++ b/src/plugin_bundle/omh/host_observation.py
@@ -147,6 +147,14 @@ def _observation_metadata(args: dict[str, Any], kwargs: dict[str, Any]) -> dict[
         metadata.setdefault("evidence_refs", args.get("evidence_refs"))
     if kwargs.get("evidence_refs") is not None:
         metadata.setdefault("evidence_refs", kwargs.get("evidence_refs"))
+    # Only standalone operator arguments may name homes. Nested observation
+    # metadata never grants store authority, even on a standalone invocation.
+    for key in ("omh_home", "hermes_home"):
+        metadata.pop(key, None)
+        if kwargs.get(key) is not None:
+            metadata[key] = kwargs[key]
+        elif args.get(key) is not None:
+            metadata[key] = args[key]
     return metadata
 
 
@@ -188,8 +196,8 @@ def _record_observation(metadata: dict[str, Any], *, event: str, tool: str, hook
             from omh.plugin_observations import record_plugin_host_observation
 
             paths = resolve_paths(
-                omh_home=runtime_paths.default_omh_home(),
-                hermes_home=runtime_paths.default_hermes_home(),
+                omh_home=runtime_paths.plugin_home(metadata.get("omh_home")),
+                hermes_home=runtime_paths.plugin_home(metadata.get("hermes_home"), hermes=True),
             )
             return record_plugin_host_observation(
                 paths,
@@ -272,7 +280,8 @@ def _record_standalone_observation(
     evidence_refs: list[str],
     message: str,
 ) -> dict[str, Any]:
-    omh_home = runtime_paths.default_omh_home()
+    omh_home = runtime_paths.plugin_home(metadata.get("omh_home"))
+    runtime_paths.plugin_home(metadata.get("hermes_home"), hermes=True)
     runtime_dir = omh_home / "runtime"
     runtime_dir.mkdir(parents=True, exist_ok=True)
     try:

--- a/src/plugin_bundle/omh/live_session.py
+++ b/src/plugin_bundle/omh/live_session.py
@@ -20,6 +20,8 @@ without this surface rather than acting on the silence.
 """
 from __future__ import annotations
 
+from . import runtime_paths
+
 from pathlib import Path
 from typing import Any
 
@@ -45,7 +47,7 @@ def live_tui_session_rows(hermes_home: str = "") -> list[dict[str, Any]]:
     import sqlite3
     from urllib.parse import quote
 
-    home = Path(hermes_home).expanduser() if hermes_home else Path.home() / ".hermes"
+    home = Path(hermes_home).expanduser() if hermes_home else runtime_paths.default_hermes_home()
     path = home / "state.db"
     if not path.exists():
         return []

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -40,15 +40,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-try:  # Present only inside the Hermes process.
-    from agent.memory_provider import MemoryProvider as _MemoryProviderBase
-    from agent.memory_provider import RecallStatus as RecallStatus
-except ModuleNotFoundError as exc:  # Standalone has no Hermes dependency.
-    if exc.name not in {"agent", "agent.memory_provider"}:
-        raise
+# A missing optional module or exported symbol is a capability gap; an
+# internal import failure in an existing host module must still propagate.
+_memory_api = runtime_paths._optional_module("agent.memory_provider")
+_MemoryProviderBase = getattr(_memory_api, "MemoryProvider", object)
+RecallStatus = getattr(_memory_api, "RecallStatus", None)
+if RecallStatus is None:
     from dataclasses import dataclass
-
-    _MemoryProviderBase = object
 
     @dataclass(frozen=True)
     class RecallStatus:  # type: ignore[no-redef]

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -210,9 +210,9 @@ class OmhMemoryProvider(_MemoryProviderBase):
         self._profile_ref = str(self._principal_context.get("profile_ref", "")) if self._principal_context is not None else str(kwargs.get("active_profile", "") or "")
         if self._shared_surface:
             self._principal_context = None
-        self._project_cwd = str(kwargs.get("cwd") or Path.cwd())
-        self._project_home = _project_omh_home(self._project_cwd)
-        self._project_resolution = resolve_project_identity(self._project_cwd)
+        cwd = runtime_paths.expand_path(kwargs["cwd"]) if kwargs.get("cwd") else runtime_paths.runtime_cwd()
+        self._project_cwd = str(cwd) if cwd is not None else None
+        self._project_home = _project_omh_home(cwd) if cwd is not None else None
         callback = kwargs.get("status_callback")
         self._status_callback = callback if callable(callback) else None
         self._pack = self.render_pack()
@@ -419,7 +419,11 @@ class OmhMemoryProvider(_MemoryProviderBase):
     def render_pack(self, *, now: datetime | None = None) -> str:
         """System blocks in full, reference blocks by label only, then the
         reviewed records the canonical selector chose for the queued query."""
-        self._project_resolution = resolve_project_identity(self._project_cwd)
+        # None is a bound absence, not permission to inspect the process cwd.
+        self._project_resolution = (
+            resolve_project_identity(self._project_cwd) if self._project_cwd is not None
+            else ProjectIdentityResolution(diagnostics=("outside_repository",))
+        )
         moment = now or datetime.now(timezone.utc)
         blocks = () if self._shared_surface else read_memory_blocks(self._omh_home)
         selection = self._block_selection(blocks=blocks, now=moment)

--- a/src/plugin_bundle/omh/memory_provider.py
+++ b/src/plugin_bundle/omh/memory_provider.py
@@ -30,6 +30,8 @@ provider reads OMH's own store, renders it, and records what it saw.
 
 from __future__ import annotations
 
+from . import runtime_paths
+
 import hashlib
 import json
 import os
@@ -41,7 +43,9 @@ from typing import Any
 try:  # Present only inside the Hermes process.
     from agent.memory_provider import MemoryProvider as _MemoryProviderBase
     from agent.memory_provider import RecallStatus as RecallStatus
-except ImportError:  # pragma: no cover - exercised by the repo's own test run
+except ModuleNotFoundError as exc:  # Standalone has no Hermes dependency.
+    if exc.name not in {"agent", "agent.memory_provider"}:
+        raise
     from dataclasses import dataclass
 
     _MemoryProviderBase = object
@@ -128,8 +132,11 @@ class OmhMemoryProvider(_MemoryProviderBase):
         # without entering the session lifecycle. `initialize` is a session
         # start: it renders the pack and settles the previous session's
         # unconsolidated turns. A question is not a session start.
-        self._omh_home = Path(omh_home).expanduser() if omh_home else _default_omh_home()
-        self._hermes_home = Path(str(hermes_home)).expanduser() if hermes_home else None
+        self._omh_home, self._hermes_home = runtime_paths.resolve_homes(omh_home, hermes_home)
+        if hermes_home is None and runtime_paths._host() is None:
+            # Standalone callers may supply the native comparison root at first
+            # initialize; no Hermes store is read before that explicit binding.
+            self._hermes_home = None
         self._session_id = ""
         self._writes_enabled = True
         self._principal_context: dict[str, object] | None = None
@@ -182,13 +189,17 @@ class OmhMemoryProvider(_MemoryProviderBase):
             return False
 
     def initialize(self, session_id: str, **kwargs: Any) -> None:
+        hermes_home = kwargs.get("hermes_home")
+        if hermes_home is not None:
+            supplied_home = runtime_paths.expand_path(hermes_home)
+            if self._hermes_home is not None and supplied_home != self._hermes_home:
+                raise runtime_paths.RuntimeBindingError("OMH provider cannot be initialized for another profile")
+            self._hermes_home = supplied_home
         self._query = ""
         self._pack, self._pack_count, self._pack_has_memory = "", 0, False
         self._served_pack, self._served_count, self._served_has_memory = "", 0, False
         self._prepared_receipt, self._served_receipt = None, None
         self._session_id = str(session_id or "")
-        hermes_home = kwargs.get("hermes_home")
-        self._hermes_home = Path(str(hermes_home)).expanduser() if hermes_home else None
         self._writes_enabled = str(kwargs.get("agent_context", "") or "") in _WRITING_CONTEXTS
         platform = str(kwargs.get("platform", "") or "")
         self._shared_surface = bool(kwargs.get("shared_surface", bool(platform and platform != "cli")))
@@ -953,7 +964,7 @@ def _attr(value: object) -> str:
 
 
 def _default_omh_home() -> Path:
-    return Path(os.path.expandvars(os.environ.get("OMH_HOME", "") or "~/.omh")).expanduser()
+    return runtime_paths.default_omh_home()
 
 
 def _project_omh_home(cwd: object = None) -> Path | None:
@@ -961,10 +972,13 @@ def _project_omh_home(cwd: object = None) -> Path | None:
 
     The same rule `omh --scope project` uses: a `.git` directory in a checkout
     or a `.git` file in a linked worktree marks the root. Hermes passes no
-    working directory to `initialize`, so the process cwd stands in.
+    working directory to `initialize`, so use its logical context cwd.
     """
     try:
-        root = project_identity_root(str(cwd) if cwd else None)
+        start = runtime_paths.expand_path(cwd) if cwd else runtime_paths.runtime_cwd()
+        if start is None:
+            return None
+        root = project_identity_root(start)
         if root is not None:
             return root / ".omh"
     except OSError:

--- a/src/plugin_bundle/omh/native_activity_observer.py
+++ b/src/plugin_bundle/omh/native_activity_observer.py
@@ -104,8 +104,10 @@ class NativeObserver:
 
 def register(ctx: ObserverHost) -> NativeObserver:
     """Create a private profile key at registration, never on dispatch."""
-    home = runtime_paths.default_hermes_home()
-    omh_home, home = runtime_paths.resolve_homes(ctx.get_config("omh_home", None), home)
+    # In a native host omh_home is the common profile setting, not a separate
+    # programmatic override. Standalone adapter contexts retain their API.
+    override = ctx.get_config("omh_home", None) if runtime_paths._host() is None else None
+    omh_home, home = runtime_paths.resolve_homes(override)
     paths = OmhPaths(omh_home, home)
     key_path = paths.runtime_dir / "group-activity-keys" / f"{profile_slot(paths.hermes_home)}.key"
     with file_lock(key_path, private=True, timeout_seconds=1) as lock:

--- a/src/plugin_bundle/omh/native_activity_observer.py
+++ b/src/plugin_bundle/omh/native_activity_observer.py
@@ -1,12 +1,11 @@
 """Adapter for Hermes on_room_member_activity, not a room-terminal contract."""
 from __future__ import annotations
 
+from . import runtime_paths
+
 from collections.abc import Callable
 from datetime import datetime, timezone
-from importlib import import_module
 import json
-import os
-from pathlib import Path
 import secrets
 from typing import Protocol, runtime_checkable
 
@@ -105,10 +104,9 @@ class NativeObserver:
 
 def register(ctx: ObserverHost) -> NativeObserver:
     """Create a private profile key at registration, never on dispatch."""
-    home = import_module("hermes_constants").get_hermes_home()
-    configured = ctx.get_config("omh_home", None)
-    omh_home = configured if isinstance(configured, str) and configured else os.environ.get("OMH_HOME", "~/.omh")
-    paths = OmhPaths(Path(omh_home).expanduser().resolve(), Path(home).expanduser().resolve())
+    home = runtime_paths.default_hermes_home()
+    omh_home, home = runtime_paths.resolve_homes(ctx.get_config("omh_home", None), home)
+    paths = OmhPaths(omh_home, home)
     key_path = paths.runtime_dir / "group-activity-keys" / f"{profile_slot(paths.hermes_home)}.key"
     with file_lock(key_path, private=True, timeout_seconds=1) as lock:
         if not lock["enforced"]:

--- a/src/plugin_bundle/omh/runtime_paths.py
+++ b/src/plugin_bundle/omh/runtime_paths.py
@@ -1,0 +1,181 @@
+"""Stateless runtime roots shared by the copied plugin and the OMH package.
+
+Only trusted API parameters and host configuration select stores. Never feed
+model arguments or observation metadata into these overrides. No binding is
+cached here: native tasks/threads carry their own Hermes scope; long-lived
+providers bind the returned pair before doing I/O.
+"""
+from __future__ import annotations
+
+from importlib import import_module
+import os
+from pathlib import Path
+import re
+
+
+class RuntimeBindingError(ValueError):
+    """No safe runtime store can be selected (messages contain no path values)."""
+
+
+_VARIABLE = re.compile(r"\$(?:\{(?:env:)?([A-Za-z_][A-Za-z_0-9]*)\}|([A-Za-z_][A-Za-z_0-9]*))|%([A-Za-z_][A-Za-z_0-9]*)%")
+_MISSING = object()
+
+
+def _host():
+    try:
+        return import_module("hermes_constants")
+    except ModuleNotFoundError as exc:
+        if exc.name != "hermes_constants":
+            raise
+        return None
+
+
+def expand_path(value: str | Path, *, hermes_home: Path | None = None, relative_to: Path | None = None) -> Path:
+    if not isinstance(value, (str, Path)) or not str(value).strip() or "\0" in str(value):
+        raise RuntimeBindingError("OMH runtime home must be a nonblank path")
+
+    def replace(match):
+        name = next(group for group in match.groups() if group is not None)
+        host = _host()
+        if name == "HERMES_HOME":
+            resolved = str(hermes_home or default_hermes_home())
+        elif host is not None:
+            resolved = import_module("agent.secret_scope").get_secret(name)
+        else:
+            resolved = os.environ.get(name)
+        if not isinstance(resolved, str) or not resolved.strip():
+            raise RuntimeBindingError("OMH runtime path variable is unavailable in this profile")
+        return resolved
+
+    expanded = _VARIABLE.sub(replace, str(value))
+    if _VARIABLE.search(expanded) or "${" in expanded:
+        raise RuntimeBindingError("OMH runtime path contains an unresolved variable")
+    path = Path(expanded).expanduser()
+    if relative_to is not None and not path.is_absolute():
+        path = relative_to / path
+    return path.resolve()
+
+
+def default_hermes_home() -> Path:
+    host = _host()
+    if host is not None:
+        secrets = import_module("agent.secret_scope")
+        if secrets.is_multiplex_active() and host.get_hermes_home_override() is None:
+            raise RuntimeBindingError("OMH requires an active Hermes profile scope")
+    value = host.get_hermes_home() if host is not None else (os.environ.get("HERMES_HOME") or "~/.hermes")
+    # Hermes already resolves its profile home. Do not expand it through an
+    # environment lookup which could recursively select the launch profile.
+    if not isinstance(value, (str, Path)) or not str(value).strip() or "\0" in str(value):
+        raise RuntimeBindingError("Hermes runtime home is invalid")
+    return Path(value).expanduser().resolve()
+
+
+def _setting(config):
+    node = config
+    for key in ("plugins", "entries", "omh"):
+        if not isinstance(node, dict):
+            raise RuntimeBindingError("OMH profile configuration must be a mapping")
+        if key not in node:
+            return _MISSING
+        node = node[key]
+    if not isinstance(node, dict):
+        raise RuntimeBindingError("OMH profile configuration must be a mapping")
+    for key in ("settings", "config"):
+        if key not in node:
+            continue
+        settings = node[key]
+        if not isinstance(settings, dict):
+            raise RuntimeBindingError("OMH profile settings must be a mapping")
+        if "omh_home" in settings:
+            return settings["omh_home"]
+    return _MISSING
+
+
+def _configured_home(home: Path):
+    config = import_module("hermes_cli.config")
+    # This host validator only reads. The normal behavioral loader deliberately
+    # tolerates malformed/unreadable YAML and can reuse last-known-good data;
+    # neither is safe for selecting a state owner. Validate before using it.
+    try:
+        raw = config.require_readable_config_before_write(home / "config.yaml")
+    except (RuntimeError, OSError, ValueError) as exc:
+        raise RuntimeBindingError("OMH profile configuration is unreadable or invalid") from exc
+    original = _setting(raw)
+    if original is not _MISSING:
+        original_path = expand_path(original, hermes_home=home, relative_to=home)
+    effective = _setting(config.load_config_readonly())
+    if effective is _MISSING:
+        return _MISSING
+    path = expand_path(effective, hermes_home=home, relative_to=home)
+    # Native config currently expands ${HERMES_HOME} through the process env.
+    # Reject an expansion that changed owner; bare $HERMES_HOME is expanded here
+    # against the profile. Do not silently bypass managed/effective config.
+    if original is not _MISSING and _VARIABLE.search(str(original)) and path != original_path:
+        raise RuntimeBindingError("OMH home expansion disagrees with the active profile; use an absolute path")
+    return path
+
+
+def resolve_homes(omh_home: str | Path | None = None, hermes_home: str | Path | None = None) -> tuple[Path, Path]:
+    """Trusted pair > profile settings > scoped legacy env > standalone default.
+
+    A complete explicit pair permits offline CLI operations and intentional
+    sharing. An unbound routed profile is unavailable, never a new empty store
+    and never the launch profile's store.
+    """
+    home = expand_path(hermes_home) if hermes_home is not None else default_hermes_home()
+    if omh_home is not None:
+        return expand_path(omh_home, hermes_home=home), home
+    host = _host()
+    if host is None:
+        return expand_path(os.environ.get("OMH_HOME") or "~/.omh", hermes_home=home), home
+    active_home = default_hermes_home()
+    if home != active_home:
+        raise RuntimeBindingError("OMH requires an explicit home pair for an offline profile")
+    secrets = import_module("agent.secret_scope")
+    multiplex = secrets.is_multiplex_active()
+    if multiplex and host.get_hermes_home_override() is None:
+        raise RuntimeBindingError("OMH requires an active Hermes profile scope")
+    configured = _configured_home(home)
+    if configured is not _MISSING:
+        return configured, home
+    scope = secrets.current_secret_scope()
+    launch_home = Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve()
+    # Registration can carry only a home override. A foreign home with no
+    # secret scope must not inherit env even when multiplex is not yet active.
+    if home != launch_home and scope is None:
+        raise RuntimeBindingError("OMH home is not configured for this profile")
+    value = secrets.get_secret("OMH_HOME")
+    if scope is not None and home != launch_home and "OMH_HOME" not in scope:
+        value = None
+    if value is not None:
+        return expand_path(value, hermes_home=home, relative_to=home if multiplex or home != launch_home else None), home
+    if multiplex or home != launch_home:
+        raise RuntimeBindingError("OMH home is not configured for this profile")
+    return expand_path("~/.omh", hermes_home=home), home
+
+
+def default_omh_home() -> Path:
+    return resolve_homes()[0]
+
+
+def plugin_home(value: object = None, *, hermes: bool = False) -> Path:
+    """Native callbacks cannot choose a store through arguments/observations.
+
+    Retain explicit standalone reader APIs for operator integrations. Within a
+    native host, these same legacy fields are not authority to cross profiles.
+    """
+    if _host() is None and value:
+        return expand_path(value)
+    return default_hermes_home() if hermes else default_omh_home()
+
+
+def runtime_cwd() -> Path | None:
+    """Use host context discovery; never fall back to a foreign launch repo."""
+    if _host() is None:
+        return Path.cwd()
+    cwd = import_module("agent.runtime_cwd")
+    secrets = import_module("agent.secret_scope")
+    launch_home = Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve()
+    if secrets.is_multiplex_active() or default_hermes_home() != launch_home:
+        return cwd.resolve_context_cwd()
+    return cwd.resolve_agent_cwd()

--- a/src/plugin_bundle/omh/runtime_paths.py
+++ b/src/plugin_bundle/omh/runtime_paths.py
@@ -30,6 +30,36 @@ def _host():
         return None
 
 
+def _profile_variable(name: str, home: Path):
+    secrets = import_module("agent.secret_scope")
+    scope = secrets.current_secret_scope()
+    launch_home = Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve()
+    if scope is None:
+        if secrets.is_multiplex_active() or home != launch_home:
+            raise RuntimeBindingError("OMH requires an owned profile variable binding")
+        return secrets.get_secret(name)
+    value = scope.get(name)
+    if value is None and not secrets.is_multiplex_active() and home == launch_home:
+        # Single-owner native scopes remain dotenv overlays on their OWN process.
+        return secrets.get_secret(name)
+    if value is not None:
+        # Secret mappings carry no owner identity. A native manager may set only
+        # home while retaining its caller's mapping. Verify the selected value
+        # against the host's home-keyed snapshot (dotenv + hydrated sources),
+        # without hydrating sources, inspecting registries or changing scopes.
+        owned = secrets.build_profile_secret_scope(home).get(name)
+        if owned != value:
+            raise RuntimeBindingError("OMH profile variable ownership is unverified; configure an absolute home")
+    return value
+
+
+def expand_input_path(value: str | Path) -> Path:
+    """Observation/model paths are not a credential or environment lookup API."""
+    if _VARIABLE.search(str(value)) or "${" in str(value):
+        raise RuntimeBindingError("OMH input paths do not support variable references")
+    return expand_path(value)
+
+
 def expand_path(value: str | Path, *, hermes_home: Path | None = None, relative_to: Path | None = None) -> Path:
     if not isinstance(value, (str, Path)) or not str(value).strip() or "\0" in str(value):
         raise RuntimeBindingError("OMH runtime home must be a nonblank path")
@@ -39,8 +69,10 @@ def expand_path(value: str | Path, *, hermes_home: Path | None = None, relative_
         host = _host()
         if name == "HERMES_HOME":
             resolved = str(hermes_home or default_hermes_home())
+        elif name == "HOME":
+            resolved = str(Path.home())
         elif host is not None:
-            resolved = import_module("agent.secret_scope").get_secret(name)
+            resolved = _profile_variable(name, hermes_home or default_hermes_home())
         else:
             resolved = os.environ.get(name)
         if not isinstance(resolved, str) or not resolved.strip():
@@ -91,6 +123,16 @@ def _setting(config):
     return _MISSING
 
 
+def _overlay_config(user: dict, managed: dict) -> dict:
+    # Preserve the winning *raw* leaf, before native process expansion. A
+    # shadowed user template is not the provenance of a managed literal.
+    result = dict(user)
+    for key, value in managed.items():
+        result[key] = (_overlay_config(result[key], value)
+                       if isinstance(result.get(key), dict) and isinstance(value, dict) else value)
+    return result
+
+
 def _configured_home(home: Path):
     config = import_module("hermes_cli.config")
     # This host validator only reads. The normal behavioral loader deliberately
@@ -100,7 +142,7 @@ def _configured_home(home: Path):
         raw = config.require_readable_config_before_write(home / "config.yaml")
     except (RuntimeError, OSError, ValueError) as exc:
         raise RuntimeBindingError("OMH profile configuration is unreadable or invalid") from exc
-    original = _setting(raw)
+    original = _setting(_overlay_config(raw, import_module("hermes_cli.managed_scope").load_managed_config()))
     if original is not _MISSING:
         original_path = expand_path(original, hermes_home=home, relative_to=home)
     effective = _setting(config.load_config_readonly())
@@ -144,9 +186,7 @@ def resolve_homes(omh_home: str | Path | None = None, hermes_home: str | Path | 
     # secret scope must not inherit env even when multiplex is not yet active.
     if home != launch_home and scope is None:
         raise RuntimeBindingError("OMH home is not configured for this profile")
-    value = secrets.get_secret("OMH_HOME")
-    if scope is not None and home != launch_home and "OMH_HOME" not in scope:
-        value = None
+    value = _profile_variable("OMH_HOME", home)
     if value is not None:
         return expand_path(value, hermes_home=home, relative_to=home if multiplex or home != launch_home else None), home
     if multiplex or home != launch_home:

--- a/src/plugin_bundle/omh/runtime_paths.py
+++ b/src/plugin_bundle/omh/runtime_paths.py
@@ -128,6 +128,9 @@ def _overlay_config(user: dict, managed: dict) -> dict:
     # shadowed user template is not the provenance of a managed literal.
     result = dict(user)
     for key, value in managed.items():
+        # Native merging treats empty YAML sections as absent, not removals.
+        if isinstance(result.get(key), dict) and value is None:
+            continue
         result[key] = (_overlay_config(result[key], value)
                        if isinstance(result.get(key), dict) and isinstance(value, dict) else value)
     return result

--- a/src/plugin_bundle/omh/runtime_paths.py
+++ b/src/plugin_bundle/omh/runtime_paths.py
@@ -11,6 +11,7 @@ from importlib import import_module
 import os
 from pathlib import Path
 import re
+import sys
 
 
 class RuntimeBindingError(ValueError):
@@ -19,21 +20,108 @@ class RuntimeBindingError(ValueError):
 
 _VARIABLE = re.compile(r"\$(?:\{(?:env:)?([A-Za-z_][A-Za-z_0-9]*)\}|([A-Za-z_][A-Za-z_0-9]*))|%([A-Za-z_][A-Za-z_0-9]*)%")
 _MISSING = object()
+# Lifecycle marker only, never a current-profile/home/secret cache. Native
+# single-owner callbacks and the memory collector may run without task scopes.
+_NATIVE_REGISTERED = False
+
+
+def note_host_registration(ctx) -> None:
+    """Recognize actual native registration, not an importable installation.
+
+    Inspect already-loaded host types only. Standalone fake/operator contexts
+    neither import Hermes nor activate the native lane. Both supported native
+    loaders retain their normal lifecycle; no wrappers or host scopes are set.
+    """
+    global _NATIVE_REGISTERED
+    for module, name in (("hermes_cli.plugins", "PluginContext"),
+                         ("plugins.memory", "_ProviderCollector")):
+        native_type = getattr(sys.modules.get(module), name, None)
+        if isinstance(native_type, type) and isinstance(ctx, native_type):
+            _NATIVE_REGISTERED = True
+            return
+
+
+def _optional_module(name):
+    try:
+        return import_module(name)
+    except ModuleNotFoundError as exc:
+        if exc.name != name and not name.startswith(str(exc.name) + "."):
+            raise
+        return None
+
+
+def _require_api(module, *names):
+    if any(not callable(getattr(module, name, None)) for name in names):
+        raise RuntimeBindingError("OMH native runtime binding APIs are unavailable")
+    return module
 
 
 def _host():
-    try:
-        return import_module("hermes_constants")
-    except ModuleNotFoundError as exc:
-        if exc.name != "hermes_constants":
-            raise
+    host = _optional_module("hermes_constants")
+    if host is None:
+        # A partially missing native installation is not standalone while an
+        # already-loaded scope still says a profile/multiplexer is active.
+        secrets = sys.modules.get("agent.secret_scope")
+        scoped = getattr(secrets, "current_secret_scope", None)
+        multiplex = getattr(secrets, "is_multiplex_active", None)
+        if (_NATIVE_REGISTERED or (callable(scoped) and scoped() is not None)
+                or (callable(multiplex) and multiplex())):
+            raise RuntimeBindingError("OMH native runtime binding APIs are unavailable")
         return None
+    # Importability alone is not a native lifecycle. A colocated OMH CLI has
+    # neither a home override nor a secret scope/multiplexer. Probe these
+    # read-only signals first; an unprobeable host is ambiguous, not standalone.
+    _require_api(host, "get_hermes_home_override")
+    secrets = _require_api(_optional_module("agent.secret_scope"),
+                           "current_secret_scope", "is_multiplex_active")
+    if (not _NATIVE_REGISTERED and host.get_hermes_home_override() is None
+            and secrets.current_secret_scope() is None and not secrets.is_multiplex_active()):
+        return None
+    _require_api(host, "get_hermes_home")
+    _require_api(secrets, "get_secret", "build_profile_secret_scope")
+    _require_api(_optional_module("agent.runtime_cwd"), "resolve_context_cwd", "resolve_agent_cwd")
+    _require_api(_optional_module("hermes_cli.managed_scope"), "load_managed_config")
+    _require_api(_optional_module("hermes_cli.config"),
+                 "require_readable_config_before_write", "load_config_readonly")
+    return host
+
+
+def _canonical_path(value, *, relative_to=None):
+    try:
+        path = Path(value).expanduser()
+        if relative_to is not None and not path.is_absolute():
+            path = relative_to / path
+        return path.resolve()
+    except (OSError, RuntimeError):
+        raise RuntimeBindingError("OMH runtime path could not be resolved") from None
+
+
+def profile_is_routed() -> bool:
+    """Only routed profiles pin inferred project artifacts to their own store."""
+    if _host() is None:
+        return False
+    return (import_module("agent.secret_scope").is_multiplex_active()
+            or default_hermes_home() != _canonical_path(os.environ.get("HERMES_HOME") or "~/.hermes"))
+
+
+def tool_home_error(args) -> dict | None:
+    """Reject legacy model overrides before observers or tool readers do I/O.
+
+    Standalone operator callers retain their explicit API. Native callbacks
+    bind from the host, never from these fields (even an equal/blank value).
+    """
+    try:
+        if _host() is not None and any(key in args for key in ("omh_home", "hermes_home")):
+            return {"status": "error", "error": "OMH native tools do not accept runtime home overrides"}
+    except RuntimeBindingError:
+        return {"status": "error", "error": "OMH native runtime home binding is unavailable"}
+    return None
 
 
 def _profile_variable(name: str, home: Path):
     secrets = import_module("agent.secret_scope")
     scope = secrets.current_secret_scope()
-    launch_home = Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve()
+    launch_home = _canonical_path(os.environ.get("HERMES_HOME") or "~/.hermes")
     if scope is None:
         if secrets.is_multiplex_active() or home != launch_home:
             raise RuntimeBindingError("OMH requires an owned profile variable binding")
@@ -57,6 +145,8 @@ def expand_input_path(value: str | Path) -> Path:
     """Observation/model paths are not a credential or environment lookup API."""
     if _VARIABLE.search(str(value)) or "${" in str(value):
         raise RuntimeBindingError("OMH input paths do not support variable references")
+    if str(value).startswith("~") and str(value) != "~" and not str(value).startswith("~/"):
+        raise RuntimeBindingError("OMH input paths do not support named-user expansion")
     return expand_path(value)
 
 
@@ -82,10 +172,7 @@ def expand_path(value: str | Path, *, hermes_home: Path | None = None, relative_
     expanded = _VARIABLE.sub(replace, str(value))
     if _VARIABLE.search(expanded) or "${" in expanded:
         raise RuntimeBindingError("OMH runtime path contains an unresolved variable")
-    path = Path(expanded).expanduser()
-    if relative_to is not None and not path.is_absolute():
-        path = relative_to / path
-    return path.resolve()
+    return _canonical_path(expanded, relative_to=relative_to)
 
 
 def default_hermes_home() -> Path:
@@ -99,7 +186,7 @@ def default_hermes_home() -> Path:
     # environment lookup which could recursively select the launch profile.
     if not isinstance(value, (str, Path)) or not str(value).strip() or "\0" in str(value):
         raise RuntimeBindingError("Hermes runtime home is invalid")
-    return Path(value).expanduser().resolve()
+    return _canonical_path(value)
 
 
 def _setting(config):
@@ -149,13 +236,15 @@ def _configured_home(home: Path):
     if original is not _MISSING:
         original_path = expand_path(original, hermes_home=home, relative_to=home)
     effective = _setting(config.load_config_readonly())
+    if (original is _MISSING) != (effective is _MISSING):
+        raise RuntimeBindingError("OMH home configuration disagrees with the active profile")
     if effective is _MISSING:
         return _MISSING
     path = expand_path(effective, hermes_home=home, relative_to=home)
     # Native config currently expands ${HERMES_HOME} through the process env.
     # Reject an expansion that changed owner; bare $HERMES_HOME is expanded here
     # against the profile. Do not silently bypass managed/effective config.
-    if original is not _MISSING and _VARIABLE.search(str(original)) and path != original_path:
+    if original is not _MISSING and path != original_path:
         raise RuntimeBindingError("OMH home expansion disagrees with the active profile; use an absolute path")
     return path
 
@@ -184,7 +273,7 @@ def resolve_homes(omh_home: str | Path | None = None, hermes_home: str | Path | 
     if configured is not _MISSING:
         return configured, home
     scope = secrets.current_secret_scope()
-    launch_home = Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve()
+    launch_home = _canonical_path(os.environ.get("HERMES_HOME") or "~/.hermes")
     # Registration can carry only a home override. A foreign home with no
     # secret scope must not inherit env even when multiplex is not yet active.
     if home != launch_home and scope is None:
@@ -214,11 +303,13 @@ def plugin_home(value: object = None, *, hermes: bool = False) -> Path:
 
 def runtime_cwd() -> Path | None:
     """Use host context discovery; never fall back to a foreign launch repo."""
-    if _host() is None:
-        return Path.cwd()
-    cwd = import_module("agent.runtime_cwd")
-    secrets = import_module("agent.secret_scope")
-    launch_home = Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve()
-    if secrets.is_multiplex_active() or default_hermes_home() != launch_home:
-        return cwd.resolve_context_cwd()
-    return cwd.resolve_agent_cwd()
+    host = _host()
+    try:
+        if host is None:
+            return Path.cwd()
+        cwd = import_module("agent.runtime_cwd")
+        if profile_is_routed():
+            return cwd.resolve_context_cwd()
+        return cwd.resolve_agent_cwd()
+    except (OSError, RuntimeError):
+        raise RuntimeBindingError("OMH logical working directory could not be resolved") from None

--- a/src/plugin_bundle/omh/runtime_paths.py
+++ b/src/plugin_bundle/omh/runtime_paths.py
@@ -225,7 +225,8 @@ def _overlay_config(user: dict, managed: dict) -> dict:
 
 def _configured_home(home: Path):
     config = import_module("hermes_cli.config")
-    # This host validator only reads. The normal behavioral loader deliberately
+    # This host validator preserves the source YAML (and may save a recovery
+    # copy when it is malformed). The normal behavioral loader deliberately
     # tolerates malformed/unreadable YAML and can reuse last-known-good data;
     # neither is safe for selecting a state owner. Validate before using it.
     try:

--- a/src/plugin_bundle/omh/runtime_reader.py
+++ b/src/plugin_bundle/omh/runtime_reader.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from . import runtime_paths
+
 import errno
 import heapq
 import json
@@ -265,11 +267,11 @@ def _widget_hud_bytes(payload: dict[str, Any]) -> int:
 
 
 def _default_omh_home() -> Path:
-    return _expand_path(os.environ.get("OMH_HOME", "~/.omh"))
+    return runtime_paths.default_omh_home()
 
 
 def _default_hermes_home() -> Path:
-    return _expand_path(os.environ.get("HERMES_HOME", "~/.hermes"))
+    return runtime_paths.default_hermes_home()
 
 
 def _read_json(path: Path) -> dict[str, Any]:

--- a/src/plugin_bundle/omh/status_board_reader.py
+++ b/src/plugin_bundle/omh/status_board_reader.py
@@ -47,6 +47,8 @@ Boundaries, in order of importance:
 
 from __future__ import annotations
 
+from . import runtime_paths
+
 import errno
 import hashlib
 import json
@@ -549,7 +551,7 @@ def _sort_key(unit: dict[str, Any]) -> tuple[int, str, str]:
 
 
 def _home_dir(omh_home: str | Path | None) -> Path:
-    return _expand_path(omh_home) if omh_home else _expand_path(os.environ.get("OMH_HOME", "~/.omh"))
+    return _expand_path(omh_home) if omh_home else runtime_paths.default_omh_home()
 
 
 def _expand_path(value: str | Path) -> Path:

--- a/src/plugin_bundle/omh/tool_bursts.py
+++ b/src/plugin_bundle/omh/tool_bursts.py
@@ -31,6 +31,8 @@ liveness signal exactly the same as this session's own calls.
 """
 from __future__ import annotations
 
+from . import runtime_paths
+
 import json
 import time
 from datetime import datetime, timezone
@@ -98,7 +100,7 @@ _MAX_ID_CHARS = 128
 
 
 def _runtime_dir(omh_home: str = "") -> Path:
-    root = Path(omh_home).expanduser() if omh_home else Path.home() / ".omh"
+    root = Path(omh_home).expanduser() if omh_home else runtime_paths.default_omh_home()
     return root / "runtime"
 
 

--- a/src/plugin_bundle/omh/toolcall_rules.py
+++ b/src/plugin_bundle/omh/toolcall_rules.py
@@ -28,8 +28,9 @@ execution, verification, review, CI, or merge evidence.
 
 from __future__ import annotations
 
+from . import runtime_paths
+
 import json
-import os
 import re
 import threading
 from dataclasses import dataclass
@@ -81,7 +82,7 @@ _rules_cache: dict[str, tuple[int, int, tuple[ToolcallRule, ...]]] = {}
 # In-process state is the point — one intervention per rule per session within
 # this host process, and a host restart naturally re-arms the rules.
 _fired_lock = threading.Lock()
-_fired: set[tuple[str, str]] = set()
+_fired: set[tuple[Path, Path, str, str]] = set()
 _MAX_FIRED_ENTRIES: Final = 1024
 _MAX_CACHED_RULE_FILES: Final = 8
 
@@ -89,7 +90,7 @@ _MAX_CACHED_RULE_FILES: Final = 8
 def toolcall_rules_path(omh_home: str = "") -> Path:
     # Same home resolution as session_hooks.py: an explicit kwarg wins, then
     # $OMH_HOME, then ~/.omh — so the documented rules path is the read path.
-    resolved = omh_home or os.environ.get("OMH_HOME", "") or "~/.omh"
+    resolved = omh_home or runtime_paths.default_omh_home()
     return Path(resolved).expanduser() / "rules" / TOOLCALL_RULES_FILE
 
 
@@ -178,7 +179,7 @@ def toolcall_rule_directive(
             continue
         if rule.pattern.search(match_text) is None:
             continue
-        if rule.repeat == "once" and not _claim_fire(session_id, rule.name):
+        if rule.repeat == "once" and not _claim_fire(path, session_id, rule.name):
             continue
         return {
             "action": "block",
@@ -271,8 +272,8 @@ def _match_text(tool_name: str, tool_input: object) -> str:
     return f"{tool_name}\n{args_text}"[:MAX_MATCH_TEXT_CHARS]
 
 
-def _claim_fire(session_id: str, rule_name: str) -> bool:
-    key = (str(session_id or ""), rule_name)
+def _claim_fire(path: Path, session_id: str, rule_name: str) -> bool:
+    key = (runtime_paths.default_hermes_home(), path.resolve(), str(session_id or ""), rule_name)
     with _fired_lock:
         if key in _fired:
             return False

--- a/src/plugin_bundle/omh/tools/chat_tool.py
+++ b/src/plugin_bundle/omh/tools/chat_tool.py
@@ -76,11 +76,11 @@ OMH_INTERACT_SCHEMA = {
             },
             "omh_home": {
                 "type": "string",
-                "description": "Optional OMH_HOME override. Defaults to $OMH_HOME or ~/.omh.",
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "hermes_home": {
                 "type": "string",
-                "description": "Optional HERMES_HOME override. Defaults to $HERMES_HOME or ~/.hermes.",
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "observation": OBSERVATION_SCHEMA,
         },
@@ -113,6 +113,8 @@ _SENSITIVE_VALUE_PATTERN = re.compile(
 
 
 def omh_interact_handler(args: dict, **kwargs) -> str:
+    if error := runtime_paths.tool_home_error(args):
+        return json.dumps(error, sort_keys=True)
     observation = observe_plugin_tool_call("omh_interact", args, kwargs)
     message = str(args.get("message") or "").strip()
     if not message:

--- a/src/plugin_bundle/omh/tools/chat_tool.py
+++ b/src/plugin_bundle/omh/tools/chat_tool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import hashlib
 import json
 import re
@@ -203,8 +205,8 @@ def _package_interaction(
     from omh.wrapper.sessions import create_or_resume_wrapper_session
 
     paths = resolve_paths(
-        omh_home=_optional_path_arg(args.get("omh_home")),
-        hermes_home=_optional_path_arg(args.get("hermes_home")),
+        omh_home=runtime_paths.plugin_home(args.get("omh_home")),
+        hermes_home=runtime_paths.plugin_home(args.get("hermes_home"), hermes=True),
     )
     source = _source(args)
     mode = _mode(args)

--- a/src/plugin_bundle/omh/tools/decision_gate_tool.py
+++ b/src/plugin_bundle/omh/tools/decision_gate_tool.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import json
-import os
 from collections.abc import Mapping
-from pathlib import Path
 from typing import Any
 
 from ..host_observation import OBSERVATION_SCHEMA, attach_public_observation, observe_plugin_tool_call
@@ -76,7 +76,7 @@ def omh_decision_gate_handler(
 
     paths = resolve_paths(
         omh_home=default_omh_home(),
-        hermes_home=Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser(),
+        hermes_home=runtime_paths.default_hermes_home(),
     )
     result = apply_connector_decision_answer(paths, **parsed_payload)
     return json.dumps(attach_public_observation(result, observation), sort_keys=True)

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import json
 import time
 from typing import Any
@@ -157,8 +159,8 @@ OMH_DELEGATE_ROUTE_SCHEMA = {
 def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
     observation = observe_plugin_tool_call("omh_delegate_route", args, kwargs)
     action = str(args.get("action", "") or "set").strip().lower()
-    hermes_home = str(args.get("hermes_home", "") or "") or None
-    omh_home = str(args.get("omh_home", "") or "") or None
+    hermes_home = runtime_paths.plugin_home(args.get("hermes_home"), hermes=True)
+    omh_home = runtime_paths.plugin_home(args.get("omh_home"))
     # Every chain read below honors the user's routing/model-chains.json
     # overrides and the provider-entitlement reorder (routing/providers.json);
     # the category vocabulary itself stays the shipped closed set. One

--- a/src/plugin_bundle/omh/tools/delegate_route_tool.py
+++ b/src/plugin_bundle/omh/tools/delegate_route_tool.py
@@ -141,14 +141,11 @@ OMH_DELEGATE_ROUTE_SCHEMA = {
             },
             "hermes_home": {
                 "type": "string",
-                "description": "Optional Hermes home override. Defaults to the active Hermes home, or $HERMES_HOME / ~/.hermes without Hermes.",
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "omh_home": {
                 "type": "string",
-                "description": (
-                    "Optional OMH home override for model-chains.json and "
-                    "model-providers.json. Defaults to ~/.omh."
-                ),
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "observation": OBSERVATION_SCHEMA,
         },
@@ -157,6 +154,8 @@ OMH_DELEGATE_ROUTE_SCHEMA = {
 
 
 def omh_delegate_route_handler(args: dict[str, Any], **kwargs) -> str:
+    if error := runtime_paths.tool_home_error(args):
+        return json.dumps(error, sort_keys=True)
     observation = observe_plugin_tool_call("omh_delegate_route", args, kwargs)
     action = str(args.get("action", "") or "set").strip().lower()
     hermes_home = runtime_paths.plugin_home(args.get("hermes_home"), hermes=True)

--- a/src/plugin_bundle/omh/tools/evidence_tool.py
+++ b/src/plugin_bundle/omh/tools/evidence_tool.py
@@ -91,7 +91,11 @@ def omh_evidence_handler(args: dict, **kwargs) -> str:
     if len(commands) > _MAX_COMMANDS:
         return _json(_with_observation({"error": f"too many commands: {len(commands)} > {_MAX_COMMANDS}"}, observation))
 
-    project_root = _project_root(args, kwargs)
+    try:
+        project_root = _project_root(args, kwargs)
+        workdir = _workdir(args, project_root)
+    except runtime_paths.RuntimeBindingError as exc:
+        return _json(_with_observation({"error": str(exc)}, observation))
     if not project_root.is_dir():
         return _json(
             _with_observation(
@@ -99,7 +103,6 @@ def omh_evidence_handler(args: dict, **kwargs) -> str:
                 observation,
             )
         )
-    workdir = _workdir(args, project_root)
     if isinstance(workdir, dict):
         return _json(_with_observation(workdir, observation))
 
@@ -157,12 +160,12 @@ def _project_root(args: dict, kwargs: dict) -> Path:
     value = args.get("project_root") or kwargs.get("project_root") or runtime_paths.runtime_cwd()
     if value is None:
         raise runtime_paths.RuntimeBindingError("OMH evidence requires a logical project root")
-    return runtime_paths.expand_path(value)
+    return runtime_paths.expand_input_path(value)
 
 
 def _workdir(args: dict, project_root: Path) -> Path | dict[str, str]:
     value = str(args.get("workdir") or project_root)
-    workdir = runtime_paths.expand_path(value)
+    workdir = runtime_paths.expand_input_path(value)
     try:
         workdir.relative_to(project_root)
     except ValueError:

--- a/src/plugin_bundle/omh/tools/evidence_tool.py
+++ b/src/plugin_bundle/omh/tools/evidence_tool.py
@@ -130,8 +130,11 @@ def omh_evidence_handler(args: dict, **kwargs) -> str:
         parsed.append((command_text, tokens))
 
     results = [_rejected_result(item["command"], item["reason"]) for item in rejected]
-    for command_text, tokens in parsed:
-        results.append(_run_command(command_text, tokens, workdir=workdir, timeout=timeout, truncate=truncate))
+    try:
+        for command_text, tokens in parsed:
+            results.append(_run_command(command_text, tokens, workdir=workdir, timeout=timeout, truncate=truncate))
+    except runtime_paths.RuntimeBindingError:
+        return _json(_with_observation({"error": "OMH evidence runtime home binding is unavailable"}, observation))
 
     passed_count = sum(1 for result in results if result.get("passed"))
     payload = {

--- a/src/plugin_bundle/omh/tools/evidence_tool.py
+++ b/src/plugin_bundle/omh/tools/evidence_tool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 from datetime import datetime, timezone
 import json
 import os
@@ -152,13 +154,15 @@ def _with_observation(payload: dict[str, Any], observation: dict[str, Any] | Non
 
 
 def _project_root(args: dict, kwargs: dict) -> Path:
-    value = str(args.get("project_root") or kwargs.get("project_root") or os.getcwd())
-    return Path(os.path.expandvars(value)).expanduser().resolve()
+    value = args.get("project_root") or kwargs.get("project_root") or runtime_paths.runtime_cwd()
+    if value is None:
+        raise runtime_paths.RuntimeBindingError("OMH evidence requires a logical project root")
+    return runtime_paths.expand_path(value)
 
 
 def _workdir(args: dict, project_root: Path) -> Path | dict[str, str]:
     value = str(args.get("workdir") or project_root)
-    workdir = Path(os.path.expandvars(value)).expanduser().resolve()
+    workdir = runtime_paths.expand_path(value)
     try:
         workdir.relative_to(project_root)
     except ValueError:
@@ -256,6 +260,8 @@ def _minimal_child_environment(pycache_dir: str) -> dict[str, str]:
 
     return {
         "HOME": str(Path.home()),
+        "OMH_HOME": str(runtime_paths.default_omh_home()),
+        "HERMES_HOME": str(runtime_paths.default_hermes_home()),
         "LANG": os.environ.get("LANG", "C.UTF-8"),
         "LC_ALL": os.environ.get("LC_ALL", os.environ.get("LANG", "C.UTF-8")),
         "PATH": os.environ.get("PATH", os.defpath),

--- a/src/plugin_bundle/omh/tools/hud_tool.py
+++ b/src/plugin_bundle/omh/tools/hud_tool.py
@@ -24,11 +24,11 @@ OMH_HUD_SCHEMA = {
         "properties": {
             "omh_home": {
                 "type": "string",
-                "description": "Optional OMH_HOME override. Defaults to $OMH_HOME or ~/.omh.",
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "hermes_home": {
                 "type": "string",
-                "description": "Optional HERMES_HOME override. Defaults to $HERMES_HOME or ~/.hermes.",
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "preset": {
                 "type": "string",
@@ -66,6 +66,8 @@ OMH_HUD_SCHEMA = {
 
 
 def omh_hud_handler(args: dict[str, Any], **kwargs) -> str:
+    if error := runtime_paths.tool_home_error(args):
+        return json.dumps(error, sort_keys=True)
     observation = observe_plugin_tool_call("omh_hud", args, kwargs)
     token_metadata = {
         key: args.get(key)

--- a/src/plugin_bundle/omh/tools/hud_tool.py
+++ b/src/plugin_bundle/omh/tools/hud_tool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import json
 from typing import Any
 
@@ -77,8 +79,8 @@ def omh_hud_handler(args: dict[str, Any], **kwargs) -> str:
         if args.get(key) is not None
     }
     payload = read_omh_hud(
-        omh_home=str(args.get("omh_home", "") or "") or None,
-        hermes_home=str(args.get("hermes_home", "") or "") or None,
+        omh_home=runtime_paths.plugin_home(args.get("omh_home")),
+        hermes_home=runtime_paths.plugin_home(args.get("hermes_home"), hermes=True),
         preset=str(args.get("preset", "focused") or "focused"),
         limit=args.get("limit") or 3,
         token_metadata=token_metadata,

--- a/src/plugin_bundle/omh/tools/memory_tool.py
+++ b/src/plugin_bundle/omh/tools/memory_tool.py
@@ -26,8 +26,9 @@ model is what edits it.
 
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import json
-import os
 
 from ..degradation import safe_error_type as _safe_error_type
 from ..hermes_memory import build_hermes_memory_bridge
@@ -213,7 +214,7 @@ def _unknown_action(action: str) -> dict[str, object]:
 
 
 def _home(variable: str, default: str) -> str:
-    return os.path.expandvars(os.environ.get(variable, "") or default)
+    return str(runtime_paths.default_omh_home() if variable == "OMH_HOME" else runtime_paths.default_hermes_home())
 
 
 def _unavailable(reason: str) -> dict[str, object]:

--- a/src/plugin_bundle/omh/tools/probe_tool.py
+++ b/src/plugin_bundle/omh/tools/probe_tool.py
@@ -47,10 +47,10 @@ OMH_PROBE_SCHEMA = {
 def omh_probe_handler(args: dict, **kwargs) -> str:
     include_parity = bool(args.get("include_parity", False))
     include_roadmap = bool(args.get("include_roadmap", False))
-    omh_home = runtime_paths.plugin_home(args.get("omh_home"))
-    hermes_home = runtime_paths.plugin_home(args.get("hermes_home"), hermes=True)
     if error := runtime_paths.tool_home_error(args):
         return json.dumps(error, sort_keys=True)
+    omh_home = runtime_paths.plugin_home(args.get("omh_home"))
+    hermes_home = runtime_paths.plugin_home(args.get("hermes_home"), hermes=True)
     observation = observe_plugin_tool_call("omh_probe", args, kwargs)
     try:
         payload = _package_probe(

--- a/src/plugin_bundle/omh/tools/probe_tool.py
+++ b/src/plugin_bundle/omh/tools/probe_tool.py
@@ -24,11 +24,11 @@ OMH_PROBE_SCHEMA = {
         "properties": {
             "omh_home": {
                 "type": "string",
-                "description": "Optional OMH_HOME override. Defaults to $OMH_HOME or ~/.omh.",
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "hermes_home": {
                 "type": "string",
-                "description": "Optional HERMES_HOME override. Defaults to $HERMES_HOME or ~/.hermes.",
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "include_parity": {
                 "type": "boolean",
@@ -49,6 +49,8 @@ def omh_probe_handler(args: dict, **kwargs) -> str:
     include_roadmap = bool(args.get("include_roadmap", False))
     omh_home = runtime_paths.plugin_home(args.get("omh_home"))
     hermes_home = runtime_paths.plugin_home(args.get("hermes_home"), hermes=True)
+    if error := runtime_paths.tool_home_error(args):
+        return json.dumps(error, sort_keys=True)
     observation = observe_plugin_tool_call("omh_probe", args, kwargs)
     try:
         payload = _package_probe(

--- a/src/plugin_bundle/omh/tools/probe_tool.py
+++ b/src/plugin_bundle/omh/tools/probe_tool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import json
 from json import JSONDecodeError
 import os
@@ -45,8 +47,8 @@ OMH_PROBE_SCHEMA = {
 def omh_probe_handler(args: dict, **kwargs) -> str:
     include_parity = bool(args.get("include_parity", False))
     include_roadmap = bool(args.get("include_roadmap", False))
-    omh_home = _optional_path_arg(args.get("omh_home"))
-    hermes_home = _optional_path_arg(args.get("hermes_home"))
+    omh_home = runtime_paths.plugin_home(args.get("omh_home"))
+    hermes_home = runtime_paths.plugin_home(args.get("hermes_home"), hermes=True)
     observation = observe_plugin_tool_call("omh_probe", args, kwargs)
     try:
         payload = _package_probe(
@@ -95,8 +97,7 @@ def _standalone_probe(
 ) -> dict[str, Any]:
     # Keep this fallback deliberately smaller than omh.probe: copied plugin bundles
     # must answer setup/status questions without importing the installed package.
-    home = _expand_path(omh_home or os.environ.get("OMH_HOME", "~/.omh"))
-    hermes = _expand_path(hermes_home or os.environ.get("HERMES_HOME", "~/.hermes"))
+    home, hermes = runtime_paths.resolve_homes(omh_home, hermes_home)
     status = read_omh_status(omh_home=home, limit=3)
     hud = read_omh_hud(omh_home=home, hermes_home=hermes, preset="focused", limit=1)
     plugin_observation = _latest_plugin_observation(home)

--- a/src/plugin_bundle/omh/tools/run_summary_tool.py
+++ b/src/plugin_bundle/omh/tools/run_summary_tool.py
@@ -14,8 +14,9 @@ read-only, and renders the lines in the requested language.
 """
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import json
-import os
 import sqlite3
 import time
 from pathlib import Path
@@ -85,7 +86,7 @@ OMH_RUN_SUMMARY_SCHEMA = {
 
 
 def _default_hermes_home() -> Path:
-    return Path(os.environ.get("HERMES_HOME", "") or (Path.home() / ".hermes"))
+    return runtime_paths.default_hermes_home()
 
 
 def _rows(
@@ -166,7 +167,7 @@ def omh_run_summary_handler(args: dict[str, Any], **kwargs) -> str:
     if language not in _SUMMARY_LABELS:
         language = "en"
     session_id = str(args.get("session_id", "") or "") or str(kwargs.get("session_id", "") or "")
-    home = Path(str(args.get("hermes_home", "") or "")).expanduser() if args.get("hermes_home") else _default_hermes_home()
+    home = runtime_paths.plugin_home(args.get("hermes_home"), hermes=True)
 
     payload: dict[str, Any] = {
         "schema_version": "omh_run_summary/v1",

--- a/src/plugin_bundle/omh/tools/run_summary_tool.py
+++ b/src/plugin_bundle/omh/tools/run_summary_tool.py
@@ -77,7 +77,7 @@ OMH_RUN_SUMMARY_SCHEMA = {
             },
             "hermes_home": {
                 "type": "string",
-                "description": "Optional HERMES_HOME override. Defaults to ~/.hermes.",
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "observation": OBSERVATION_SCHEMA,
         },
@@ -162,6 +162,8 @@ def _optional_number(value: Any) -> float | None:
 
 
 def omh_run_summary_handler(args: dict[str, Any], **kwargs) -> str:
+    if error := runtime_paths.tool_home_error(args):
+        return json.dumps(error, sort_keys=True)
     observation = observe_plugin_tool_call("omh_run_summary", args, kwargs)
     language = str(args.get("language", "") or "en").strip().lower()
     if language not in _SUMMARY_LABELS:

--- a/src/plugin_bundle/omh/tools/status_tool.py
+++ b/src/plugin_bundle/omh/tools/status_tool.py
@@ -20,7 +20,7 @@ OMH_STATUS_SCHEMA = {
         "properties": {
             "omh_home": {
                 "type": "string",
-                "description": "Optional OMH_HOME override. Defaults to $OMH_HOME or ~/.omh.",
+                "description": "Standalone operator override only. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "limit": {
                 "type": "integer",
@@ -34,6 +34,8 @@ OMH_STATUS_SCHEMA = {
 
 def omh_status_handler(args: dict, *, group_activity_enabled: bool = False,
                        group_activity_observer: Callable[[], dict[str, str | int]] | None = None, **kwargs) -> str:
+    if error := runtime_paths.tool_home_error(args):
+        return json.dumps(error, sort_keys=True)
     observation = observe_plugin_tool_call("omh_status", args, kwargs)
     payload = read_omh_status(
         omh_home=runtime_paths.plugin_home(args.get("omh_home")),

--- a/src/plugin_bundle/omh/tools/status_tool.py
+++ b/src/plugin_bundle/omh/tools/status_tool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import json
 from collections.abc import Callable
 
@@ -34,7 +36,7 @@ def omh_status_handler(args: dict, *, group_activity_enabled: bool = False,
                        group_activity_observer: Callable[[], dict[str, str | int]] | None = None, **kwargs) -> str:
     observation = observe_plugin_tool_call("omh_status", args, kwargs)
     payload = read_omh_status(
-        omh_home=str(args.get("omh_home", "") or "") or None,
+        omh_home=runtime_paths.plugin_home(args.get("omh_home")),
         limit=int(args.get("limit") or 5),
     )
     payload["group_chat_activity"] = (group_activity_observer() if group_activity_observer is not None

--- a/src/plugin_bundle/omh/tools/todo_tool.py
+++ b/src/plugin_bundle/omh/tools/todo_tool.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .. import runtime_paths
+
 import json
 from typing import Any
 
@@ -143,5 +145,5 @@ def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
     else:
         payload["status"] = "invalid_action"
         payload["error"] = "action must be set, clear, or show"
-    payload["todo"] = read_omh_todo(home_arg or None, session_ref=session_ref)
+    payload["todo"] = read_omh_todo(runtime_paths.plugin_home(home_arg), session_ref=session_ref)
     return json.dumps(attach_public_observation(payload, observation), sort_keys=True)

--- a/src/plugin_bundle/omh/tools/todo_tool.py
+++ b/src/plugin_bundle/omh/tools/todo_tool.py
@@ -85,10 +85,7 @@ OMH_TODO_SCHEMA = {
             },
             "omh_home": {
                 "type": "string",
-                "description": (
-                    "Optional OMH_HOME override for action=show only. "
-                    "set and clear always use the configured OMH home."
-                ),
+                "description": "Standalone operator override for action=show only; set/clear reject overrides. Native Hermes calls reject this field; omit it to use the active profile.",
             },
             "observation": OBSERVATION_SCHEMA,
         },
@@ -98,6 +95,8 @@ OMH_TODO_SCHEMA = {
 
 
 def omh_todo_handler(args: dict[str, Any], **kwargs) -> str:
+    if error := runtime_paths.tool_home_error(args):
+        return json.dumps(error, sort_keys=True)
     observation = observe_plugin_tool_call("omh_todo", args, kwargs)
     # Hermes passes its stable session/thread id as a keyword on every tool
     # call, so a plan declared in chat is stored for, and read back for, the

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from omh.plugin_bundle.omh import runtime_paths
+
 import os
 import re
 import tempfile
@@ -480,11 +482,11 @@ def expand_path(value: str | Path) -> Path:
 
 
 def default_omh_home() -> Path:
-    return expand_path(os.environ.get("OMH_HOME", "~/.omh"))
+    return runtime_paths.default_omh_home()
 
 
 def default_hermes_home() -> Path:
-    return expand_path(os.environ.get("HERMES_HOME", "~/.hermes"))
+    return runtime_paths.default_hermes_home()
 
 
 def _is_windows() -> bool:
@@ -746,7 +748,12 @@ def _project_anchor(cwd: str | Path | None = None) -> Path:
     # store into `src/whatever/.omh` while repository-scoped artifacts resolved
     # to the root -- one `--scope project` run, two homes.
     root = find_project_root(cwd)
-    return root if root is not None else expand_path(cwd or Path.cwd())
+    if root is not None:
+        return root
+    anchor = cwd if cwd is not None else runtime_paths.runtime_cwd()
+    if anchor is None:
+        raise runtime_paths.RuntimeBindingError("OMH project scope requires a logical working directory")
+    return expand_path(anchor)
 
 
 def find_project_root(cwd: str | Path | None = None) -> Path | None:
@@ -754,7 +761,10 @@ def find_project_root(cwd: str | Path | None = None) -> Path | None:
     # Filesystem-only: `git rev-parse` would be a subprocess in a core that makes
     # no external calls. `.git` is a directory in a checkout and a file in a
     # linked worktree, so both shapes count.
-    start = expand_path(cwd or Path.cwd())
+    anchor = cwd if cwd is not None else runtime_paths.runtime_cwd()
+    if anchor is None:
+        return None
+    start = expand_path(anchor)
     for candidate in (start, *start.parents):
         git_entry = candidate / ".git"
         # Empty `.git` directories are intentionally supported as lightweight
@@ -814,14 +824,17 @@ def resolve_paths(
     normalized_scope = str(scope or "user").strip().lower()
     if normalized_scope not in {"user", "project"}:
         normalized_scope = "user"
-    default_omh = project_omh_home() if normalized_scope == "project" else default_omh_home()
-    default_hermes = project_hermes_home() if normalized_scope == "project" else default_hermes_home()
+    if normalized_scope == "project":
+        resolved_omh = expand_path(omh_home) if omh_home is not None else project_omh_home()
+        resolved_hermes = expand_path(hermes_home) if hermes_home is not None else project_hermes_home()
+    else:
+        resolved_omh, resolved_hermes = runtime_paths.resolve_homes(omh_home, hermes_home)
     return OmhPaths(
-        omh_home=expand_path(omh_home) if omh_home else default_omh,
-        hermes_home=expand_path(hermes_home) if hermes_home else default_hermes,
+        omh_home=resolved_omh,
+        hermes_home=resolved_hermes,
         # Recorded here, while the caller's intent is still known: comparing the
         # resolved home against the default later cannot tell a named home from
         # an unnamed one that happens to match it.
-        omh_home_named=omh_home is not None,
+        omh_home_named=omh_home is not None or (normalized_scope == "user" and runtime_paths._host() is not None),
         managed_skills_dir=managed_workflow_pack_dir() if normalized_scope == "user" else None,
     )

--- a/src/system/paths.py
+++ b/src/system/paths.py
@@ -825,8 +825,8 @@ def resolve_paths(
     if normalized_scope not in {"user", "project"}:
         normalized_scope = "user"
     if normalized_scope == "project":
-        resolved_omh = expand_path(omh_home) if omh_home is not None else project_omh_home()
-        resolved_hermes = expand_path(hermes_home) if hermes_home is not None else project_hermes_home()
+        resolved_omh = runtime_paths.expand_path(omh_home) if omh_home is not None else project_omh_home()
+        resolved_hermes = runtime_paths.expand_path(hermes_home) if hermes_home is not None else project_hermes_home()
     else:
         resolved_omh, resolved_hermes = runtime_paths.resolve_homes(omh_home, hermes_home)
     return OmhPaths(
@@ -835,6 +835,6 @@ def resolve_paths(
         # Recorded here, while the caller's intent is still known: comparing the
         # resolved home against the default later cannot tell a named home from
         # an unnamed one that happens to match it.
-        omh_home_named=omh_home is not None or (normalized_scope == "user" and runtime_paths._host() is not None),
+        omh_home_named=omh_home is not None or (normalized_scope == "user" and runtime_paths.profile_is_routed()),
         managed_skills_dir=managed_workflow_pack_dir() if normalized_scope == "user" else None,
     )

--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -14,6 +14,6 @@ def pytest_configure(config):
 
 
 def pytest_ignore_collect(collection_path, config):
-    if collection_path.name == "test_profile_runtime.py" and not config.getoption("--native-source"):
+    if collection_path.name in {"test_profile_runtime.py", "test_review_native.py"} and not config.getoption("--native-source"):
         return True
     return None

--- a/tests/native/conftest.py
+++ b/tests/native/conftest.py
@@ -1,0 +1,19 @@
+"""Opt-in real-host integration; OMH's standalone unittest suite has no host dependency."""
+import sys
+from pathlib import Path
+
+
+def pytest_addoption(parser):
+    parser.addoption("--native-source", help="Hermes source checkout (use its scripts/run_tests.sh)")
+
+
+def pytest_configure(config):
+    source = config.getoption("--native-source")
+    if source:
+        sys.path.insert(0, str(Path(source).resolve()))
+
+
+def pytest_ignore_collect(collection_path, config):
+    if collection_path.name == "test_profile_runtime.py" and not config.getoption("--native-source"):
+        return True
+    return None

--- a/tests/native/test_profile_runtime.py
+++ b/tests/native/test_profile_runtime.py
@@ -1,0 +1,440 @@
+"""Synthetic-only current OMH source probes; assertions express desired isolation."""
+import asyncio
+import hashlib
+import importlib
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+# Run with the native scripts/run_tests.sh; no native dependency in OMH CI.
+BUNDLE = REPO / 'src/plugin_bundle/omh'
+MARKER = 'SYNTHETIC_PRIVATE_CONSOLIDATION_ONLY'
+
+
+def record(row):
+    print('OBSERVED=' + json.dumps(row, sort_keys=True))
+
+
+@pytest.fixture
+def fixture(tmp_path, monkeypatch):
+    tmp_path = tmp_path.resolve()
+    root = tmp_path / '.hermes'
+    public = root / 'profiles' / 'public'
+    private_store, public_store = tmp_path / 'private-store', tmp_path / 'public-store'
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setenv('HERMES_HOME', str(root))
+    monkeypatch.setenv('OMH_HOME', str(private_store))
+    monkeypatch.setattr(Path, 'home', lambda: tmp_path)
+    monkeypatch.setenv('PYTHONDONTWRITEBYTECODE', '1')
+    for home, store in ((root, private_store), (public, public_store)):
+        home.mkdir(parents=True, exist_ok=True)
+        (home / 'config.yaml').write_text(
+            'memory:\n  provider: omh\nplugins:\n  enabled: [omh]\n'
+            '  entries:\n    omh:\n      settings:\n        omh_home: ' + str(store) + '\n'
+            'terminal:\n  backend: local\n')
+        (home / '.env').write_text(f'OMH_HOME={store}\n')
+        shutil.copytree(BUNDLE, home / 'plugins/omh', ignore=shutil.ignore_patterns('__pycache__'))
+        # Preserve bundled config bytes: no integrity bypass or implementation edit.
+        (store / 'memory').mkdir(parents=True)
+        (store / 'runtime').mkdir()
+        (store / 'runtime/state.json').write_text(json.dumps({'last_run_id': 'synthetic-' + store.name}))
+    from agent.secret_scope import set_multiplex_active
+    from hermes_cli.plugins import _reset_plugin_managers_for_tests, PluginManager
+    import hermes_cli.plugins as hp
+    # Only discover the two synthetic OMH copies, never other installed plugin code.
+    monkeypatch.setattr(hp, 'get_bundled_plugins_dir', lambda: tmp_path / 'no-bundled')
+    monkeypatch.setattr(PluginManager, '_scan_entry_points', lambda self: [])
+    _reset_plugin_managers_for_tests()
+    set_multiplex_active(True)
+    yield root, public, private_store, public_store
+    set_multiplex_active(False)
+    _reset_plugin_managers_for_tests()
+
+
+def load(home, order):
+    from gateway.run import _profile_runtime_scope
+    from plugins.memory import load_memory_provider
+    from hermes_cli.plugins import get_plugin_manager
+    with _profile_runtime_scope(home):
+        manager = get_plugin_manager()
+        if order == 'general-first':
+            manager.discover_and_load()
+        provider = load_memory_provider('omh', register_skills=False)
+        assert provider is not None
+        if order == 'memory-first':
+            manager.discover_and_load()
+        return provider, manager
+
+
+def snapshot(store):
+    return {str(path.relative_to(store)): hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in store.rglob("*") if path.is_file()}
+
+
+def seed(store, provider):
+    mod = importlib.import_module(type(provider).__module__.rsplit('.', 1)[0] + '.memory_dreaming')
+    (store / 'memory/consolidation.json').write_text(json.dumps({
+        'schema_version': mod.DREAMING_HANDOFF_SCHEMA_VERSION, 'due': True,
+        'trigger': 'synthetic-session', 'reasons': [MARKER], 'session_id': 'synthetic-private',
+        'requested_of_executor': []}))
+
+
+def exercise(home, provider, manager):
+    from gateway.run import _profile_runtime_scope
+    from hermes_constants import get_hermes_home
+    from agent.secret_scope import get_secret
+    from tools.registry import registry
+    with _profile_runtime_scope(home):
+        provider.initialize('synthetic-public', hermes_home=str(home), platform='discord',
+                            active_profile='public', shared_surface=True, cwd=str(home))
+        pack = provider.prefetch(session_id='synthetic-public')
+        provider.on_turn_start(1, 'synthetic question')
+        memory_result = registry.get_entry('omh_memory').handler({'action': 'consolidation'}, session_id='synthetic-public')
+        todo_result = json.loads(registry.get_entry('omh_todo').handler(
+            {'action': 'set', 'title': 'synthetic public plan', 'items': [{'text': 'synthetic task', 'state': 'pending'}]},
+            session_id='synthetic-public'))
+        hook = manager._hooks['on_session_end'][0]
+        hook_result = hook(session_id='synthetic-public')
+        module = importlib.import_module(type(provider).__module__)
+        digest = hashlib.sha256(Path(module.__file__).read_bytes()).hexdigest()
+        return {'native_home': str(get_hermes_home()), 'scoped_omh_env': get_secret('OMH_HOME'),
+                'provider_home': str(provider._omh_home), 'provider_source': module.__file__,
+                'current_source_digest_matches': digest == hashlib.sha256((BUNDLE / 'memory_provider.py').read_bytes()).hexdigest(),
+                'provider_marker': MARKER in pack, 'tool_marker': MARKER in memory_result,
+                'todo_status': todo_result.get('status'), 'session_hook': hook_result,
+                'on_session_end_hook_count': len(manager._hooks['on_session_end'])}
+
+
+@pytest.mark.parametrize('order', ['general-first', 'memory-first'])
+@pytest.mark.parametrize('mode', ['standalone', 'multiplex'])
+def test_public_provider_tools_and_hooks(fixture, monkeypatch, order, mode):
+    root, public, private_store, public_store = fixture
+    if mode == 'standalone':
+        from agent.secret_scope import set_multiplex_active
+        set_multiplex_active(False)
+        monkeypatch.setenv('HERMES_HOME', str(public))
+        monkeypatch.setenv('OMH_HOME', str(public_store))
+    provider, manager = load(public, order)
+    seed(private_store, provider)
+    before = snapshot(private_store)
+    observed = exercise(public, provider, manager)
+    assert snapshot(private_store) == before
+    observed.update({'case': mode, 'order': order,
+        'private_dreaming_written': (private_store / 'memory/dreaming.json').exists(),
+        'public_dreaming_written': (public_store / 'memory/dreaming.json').exists(),
+        'private_files': sorted(str(p.relative_to(private_store)) for p in private_store.rglob('*') if p.is_file()),
+        'public_files': sorted(str(p.relative_to(public_store)) for p in public_store.rglob('*') if p.is_file())})
+    record(observed)
+    assert observed['current_source_digest_matches']
+    assert not observed['provider_marker'] and not observed['tool_marker']
+    assert observed['provider_home'] == str(public_store)
+    assert observed['public_dreaming_written'] and not observed['private_dreaming_written']
+    assert observed['on_session_end_hook_count'] == 1
+    assert observed['todo_status'] == 'written'
+    assert observed['session_hook']['path'].startswith(str(public_store))
+
+
+@pytest.mark.parametrize('profile_order', ['private-first', 'public-first'])
+def test_interleaved_tasks(fixture, profile_order):
+    root, public, private_store, public_store = fixture
+    order = (root, public) if profile_order == 'private-first' else (public, root)
+    loaded = {home: load(home, 'memory-first') for home in order}
+    seed(private_store, loaded[public][0])
+    from gateway.run import _profile_runtime_scope
+    from hermes_constants import get_hermes_home
+    from agent.secret_scope import get_secret
+    async def run(home):
+        with _profile_runtime_scope(home):
+            await asyncio.sleep(0)
+            provider, manager = loaded[home]
+            module = importlib.import_module(type(provider).__module__.rsplit('.', 1)[0] + '.runtime_reader')
+            return {'hermes_home': str(get_hermes_home()), 'scoped_env': get_secret('OMH_HOME'),
+                    'provider_home': str(provider._omh_home),
+                    'reader_home': str(module._default_omh_home()),
+                    'reader_hermes_home': str(module._default_hermes_home()),
+                    'module': type(provider).__module__, 'manager_scope': manager.scope_key}
+    async def tasks():
+        return await asyncio.gather(run(root), run(public))
+    rows = asyncio.run(tasks())
+    record({'case': 'interleaved', 'profile_order': profile_order, 'rows': rows,
+            'process_omh_home_unchanged': os.environ['OMH_HOME'] == str(private_store)})
+    assert rows[0]['module'] != rows[1]['module']
+    assert rows[0]['manager_scope'] != rows[1]['manager_scope']
+    assert rows[1]['scoped_env'] == str(public_store)
+    assert rows[1]['provider_home'] == rows[1]['reader_home'] == str(public_store)
+    assert rows[1]['reader_hermes_home'] == str(public)
+
+
+@pytest.mark.parametrize('core_available', [False, True], ids=['bundle-fallback', 'current-core'])
+def test_remaining_binding_seams(fixture, core_available, monkeypatch):
+    root, public, private_store, public_store = fixture
+    if core_available:
+        sys.path.insert(0, str(REPO / 'src'))
+        import omh
+        assert Path(omh.__file__).resolve().is_relative_to(REPO)
+    else:
+        # Pytest may add the checkout shim to sys.path. Force the genuinely
+        # package-absent copied-bundle path, independent of collection order.
+        class WithoutCore:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == 'omh' or fullname.startswith('omh.'):
+                    raise ModuleNotFoundError('OMH core intentionally absent', name='omh')
+                return None
+        for name in list(sys.modules):
+            if name == 'omh' or name.startswith('omh.'):
+                monkeypatch.delitem(sys.modules, name)
+        monkeypatch.setattr(sys, 'meta_path', [WithoutCore(), *sys.meta_path])
+    provider, manager = load(public, 'memory-first')
+    from gateway.run import _profile_runtime_scope
+    from hermes_cli.plugins import PluginContext, PluginManifest
+    from plugins.memory import _ProviderCollector
+    with _profile_runtime_scope(public):
+        context = PluginContext(PluginManifest(name='omh', key='omh'), manager)
+        base = type(provider).__module__.rsplit('.', 1)[0]
+        observer = importlib.import_module(base + '.host_observation')
+        journal = observer.observe_plugin_hook_call('pre_llm_call',
+                    {'session_id': 'synthetic-public', 'host': 'synthetic-host'})
+        evidence = importlib.import_module(base + '.tools.evidence_tool')
+        env = evidence._minimal_child_environment(str(public / 'pycache'))
+        import subprocess
+        code = ('import sys,json; sys.path.insert(0,' + repr(str(REPO / 'src')) + '); '
+                'from omh.paths import default_omh_home, default_hermes_home; '
+                'print(json.dumps([str(default_omh_home()),str(default_hermes_home())]))')
+        child = subprocess.run([sys.executable, '-c', code], env=env, capture_output=True, text=True, check=True)
+        row = {'case': 'remaining-seams', 'core_available': core_available,
+               'host_get_config_correct': context.get_config('omh_home') == str(public_store),
+               'collector_has_get_config': hasattr(_ProviderCollector('omh'), 'get_config'),
+               'provider_home_correct': provider._omh_home == public_store,
+               'journal_result': journal,
+               'private_journal_files': sorted(str(p.relative_to(private_store)) for p in private_store.rglob('*') if p.is_file()),
+               'public_journal_files': sorted(str(p.relative_to(public_store)) for p in public_store.rglob('*') if p.is_file()),
+               'child_resolved_homes': json.loads(child.stdout),
+               'child_has_home_overrides': 'HERMES_HOME' in env or 'OMH_HOME' in env}
+        if core_available:
+            from omh.paths import resolve_paths
+            row['core_default_homes'] = [str(resolve_paths().omh_home), str(resolve_paths().hermes_home)]
+            row['core_explicit_homes'] = [str(resolve_paths(public_store, public).omh_home), str(resolve_paths(public_store, public).hermes_home)]
+        record(row)
+        assert row['host_get_config_correct']
+        assert row['provider_home_correct']
+        assert not (private_store / 'runtime/plugin-host-observations.jsonl').exists()
+        assert row['child_resolved_homes'] == [str(public_store), str(public)]
+        assert row['child_has_home_overrides']
+
+
+def test_tool_hook_third_home(fixture):
+    root, public, private_store, public_store = fixture
+    provider, manager = load(public, 'general-first')
+    from gateway.run import _profile_runtime_scope
+    with _profile_runtime_scope(public):
+        manager._hooks['pre_tool_call'][0](tool_name='read_file', args={'path': 'synthetic.txt'},
+            session_id='synthetic-public', tool_call_id='synthetic-call', turn_id='synthetic-turn')
+        manager._hooks['post_tool_call'][0](tool_name='read_file', session_id='synthetic-public',
+            tool_call_id='synthetic-call')
+    third_home = root.parent / '.omh'
+    row = {'case': 'tool-hook-third-home',
+           'public_burst_written': (public_store / 'runtime/tool-bursts.json').exists(),
+           'third_home_files': sorted(str(p.relative_to(third_home)) for p in third_home.rglob('*') if p.is_file())}
+    record(row)
+    assert row['public_burst_written']
+    assert not row['third_home_files']
+
+
+def test_real_host_turn_order(fixture, monkeypatch):
+    root, public, private_store, public_store = fixture
+    provider, manager = load(public, 'memory-first')
+    seed(private_store, provider)
+    monkeypatch.chdir(public)
+    from gateway.run import _profile_runtime_scope
+    from agent.memory_manager import MemoryManager
+    from agent.turn_context import _memory_turn_start_and_prefetch
+    from types import SimpleNamespace
+    with _profile_runtime_scope(public):
+        memory = MemoryManager()
+        memory.add_provider(provider)
+        memory.initialize_all('synthetic-public', platform='discord', agent_context='primary')
+        initialized_pack = provider.prefetch(session_id='synthetic-public')
+        agent = SimpleNamespace(_memory_manager=memory, _user_turn_count=1,
+                                session_id='synthetic-public', _emit_status=lambda message: None)
+        actual_pack = _memory_turn_start_and_prefetch(agent, 'Explain this synthetic project isolation question')
+        row = {'case': 'real-host-turn-order', 'initialized_pack_marker': MARKER in initialized_pack,
+               'native_turn_pack_marker': MARKER in actual_pack, 'native_turn_pack_empty': not actual_pack,
+               'private_dreaming_written': (private_store / 'memory/dreaming.json').exists(),
+               'public_dreaming_written': (public_store / 'memory/dreaming.json').exists()}
+        record(row)
+        assert not row['native_turn_pack_marker']
+        assert not row['private_dreaming_written'] and row['public_dreaming_written']
+
+
+
+
+@pytest.mark.parametrize('binding', ['settings', 'legacy', 'scoped-env', 'shared', 'missing', 'blank', 'invalid', 'malformed', 'scoped-variable', 'ambiguous-variable', 'relative'])
+def test_native_binding_precedence_and_fail_closed(fixture, binding):
+    root, public, private_store, public_store = fixture
+    from gateway.run import _profile_runtime_scope
+    from hermes_constants import get_hermes_home
+    from agent.secret_scope import set_secret_scope, reset_secret_scope
+    sys.path.insert(0, str(REPO / 'src'))
+    from omh.plugin_bundle.omh.runtime_paths import RuntimeBindingError, resolve_homes
+    expected = public_store
+    entry = {'settings': {'omh_home': str(public_store)}}
+    env = {'OMH_HOME': str(private_store)}
+    if binding == 'legacy':
+        entry = {'config': {'omh_home': str(public_store)}}
+    elif binding == 'scoped-env':
+        entry, env = {}, {'OMH_HOME': str(public_store)}
+    elif binding == 'shared':
+        entry = {'settings': {'omh_home': str(private_store)}}
+        expected = private_store
+    elif binding == 'missing':
+        entry, env = {}, {}
+    elif binding == 'blank':
+        entry = {'settings': {'omh_home': '   '}}
+    elif binding == 'invalid':
+        entry = {'settings': {'omh_home': []}}
+    elif binding == 'scoped-variable':
+        entry = {'settings': {'omh_home': '$HERMES_HOME/state'}}
+        expected = public / 'state'
+    elif binding == 'relative':
+        entry = {'settings': {'omh_home': 'state'}}
+        expected = public / 'state'
+    elif binding == 'ambiguous-variable':
+        entry = {'settings': {'omh_home': '${HERMES_HOME}/state'}}
+    config = {'plugins': {'entries': {'omh': entry}}}
+    (public / 'config.yaml').write_text('invalid: [' if binding == 'malformed' else json.dumps(config))
+    with _profile_runtime_scope(public):
+        token = set_secret_scope(env)
+        try:
+            assert get_hermes_home() == public
+            if binding in {'missing', 'blank', 'invalid', 'malformed', 'ambiguous-variable'}:
+                with pytest.raises(RuntimeBindingError):
+                    resolve_homes()
+            else:
+                assert resolve_homes() == (expected, public)
+            # Complete operator pairs stay usable, even for offline/shared stores.
+            assert resolve_homes(private_store, root) == (private_store, root)
+            with pytest.raises(RuntimeBindingError):
+                resolve_homes(hermes_home=root)
+        finally:
+            reset_secret_scope(token)
+
+
+def test_unscoped_multiplexer_and_explicit_offline_pair(fixture):
+    root, public, private_store, public_store = fixture
+    sys.path.insert(0, str(REPO / 'src'))
+    from omh.plugin_bundle.omh.runtime_paths import RuntimeBindingError, resolve_homes, default_hermes_home
+    from agent.secret_scope import set_secret_scope, reset_secret_scope
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    home_token, secret_token = set_hermes_home_override(None), set_secret_scope(None)
+    try:
+        with pytest.raises(RuntimeBindingError):
+            resolve_homes()
+        with pytest.raises(RuntimeBindingError):
+            default_hermes_home()
+        assert resolve_homes(public_store, public) == (public_store, public)
+    finally:
+        reset_hermes_home_override(home_token)
+        reset_secret_scope(secret_token)
+
+
+def test_model_home_injection_and_bound_background_provider(fixture, monkeypatch):
+    root, public, private_store, public_store = fixture
+    provider, manager = load(public, 'general-first')
+    from gateway.run import _profile_runtime_scope
+    from tools.registry import registry
+    base = type(provider).__module__.rsplit('.', 1)[0]
+    observer = importlib.import_module(base + '.host_observation')
+    evidence = importlib.import_module(base + '.tools.evidence_tool')
+    monkeypatch.setenv('SYNTHETIC_ACCESS_TOKEN', 'never-pass-to-child')
+    with _profile_runtime_scope(public):
+        provider.initialize('same-session', hermes_home=public, cwd=public, platform='cli')
+        # The home-looking fields are observations/model text, not authority.
+        injection = {'host': 'synthetic-host', 'session_id': 'same-session',
+                     'omh_home': str(private_store), 'hermes_home': str(root)}
+        record = observer.observe_plugin_tool_call('omh_memory', {'observation': injection}, injection)
+        assert record and record['status'] == 'observed'
+        manager._hooks['pre_tool_call'][0](tool_name='read_file', args={'path': 'nothing'}, **injection)
+        registry.get_entry('omh_todo').handler({'action': 'show', 'omh_home': str(private_store)})
+        env = evidence._minimal_child_environment(str(public / 'cache'))
+        assert env['OMH_HOME'] == str(public_store) and env['HERMES_HOME'] == str(public)
+        assert 'SYNTHETIC_ACCESS_TOKEN' not in env
+        from contextvars import copy_context
+        work = copy_context()
+    with _profile_runtime_scope(root):
+        # Provider work remains attached to its instance even after scope exit.
+        work.run(provider.on_turn_start, 1, 'A synthetic queued turn')
+        with pytest.raises(ValueError, match='another profile'):
+            provider.initialize('different-session', hermes_home=root)
+    assert not (private_store / 'memory/dreaming.json').exists()
+    assert not (private_store / 'runtime/tool-bursts.json').exists()
+    assert (public_store / 'memory/dreaming.json').exists()
+    assert (public_store / 'runtime/tool-bursts.json').exists()
+
+
+def test_positive_recall_after_real_turn_and_native_queue(fixture):
+    root, public, private_store, public_store = fixture
+    provider, _ = load(public, 'memory-first')
+    from gateway.run import _profile_runtime_scope
+    from agent.memory_manager import MemoryManager
+    from agent.turn_context import _memory_turn_start_and_prefetch
+    from types import SimpleNamespace
+    blocks = importlib.import_module(type(provider).__module__.rsplit('.', 1)[0] + '.memory_blocks')
+    block = blocks.build_memory_block(label='profile-preference', value='SYNTHETIC_PUBLIC_RECALL',
+                                      description='Synthetic profile preference', tier='system')
+    blocks.write_memory_block(public_store, blocks.approve_memory_block(block, reviewer_claim='user'))
+    with _profile_runtime_scope(public):
+        memory = MemoryManager()
+        memory.add_provider(provider)
+        memory.initialize_all('synthetic-public', hermes_home=public, platform='cli', agent_context='primary')
+        agent = SimpleNamespace(_memory_manager=memory, _user_turn_count=1,
+                                session_id='synthetic-public', _emit_status=lambda message: None)
+        actual_pack = _memory_turn_start_and_prefetch(agent, 'Explain the synthetic profile preference')
+        # Existing upstream on_turn_start invalidates the pack. Do not repair or
+        # conceal that separate lifecycle behavior in a root-binding change.
+        assert MARKER not in actual_pack
+        memory.queue_prefetch_all('synthetic preference', session_id='synthetic-public')
+        assert memory.flush_pending(timeout=10)
+        positive = memory.prefetch_all('synthetic preference', session_id='synthetic-public')
+        assert 'SYNTHETIC_PUBLIC_RECALL' in positive
+        assert MARKER not in positive
+        assert memory.describe_recall()
+        memory.shutdown_all()
+    assert not (private_store / 'memory/dreaming.json').exists()
+    assert (public_store / 'memory/dreaming.json').exists()
+
+
+def test_project_home_uses_host_logical_cwd(fixture, monkeypatch):
+    root, public, private_store, public_store = fixture
+    private_project, public_project = root.parent / 'private-project', root.parent / 'public-project'
+    for project in (private_project, public_project):
+        (project / '.git').mkdir(parents=True)
+        (project / '.omh/memory').mkdir(parents=True)
+    monkeypatch.chdir(private_project)
+    provider, _ = load(public, 'memory-first')
+    from gateway.run import _profile_runtime_scope
+    from agent.runtime_cwd import set_session_cwd, _SESSION_CWD, resolve_agent_cwd
+    from agent.memory_manager import MemoryManager
+    with _profile_runtime_scope(public):
+        token = set_session_cwd(str(public_project))
+        try:
+            # Explicit user-store control isolates the independent project-store binding.
+            correctly_bound = type(provider)(public_store)
+            memory = MemoryManager()
+            memory.add_provider(correctly_bound)
+            memory.initialize_all('synthetic-public', platform='discord', agent_context='primary')
+            row = {'case': 'project-home', 'host_logical_cwd_correct': resolve_agent_cwd() == public_project,
+                   'user_store_correct': correctly_bound._omh_home == public_store,
+                   'project_store_correct': correctly_bound._project_home == public_project / '.omh',
+                   'project_store_follows_process_cwd': correctly_bound._project_home == private_project / '.omh'}
+            record(row)
+            assert row['host_logical_cwd_correct'] and row['user_store_correct']
+            assert row['project_store_correct']
+            evidence = importlib.import_module(type(provider).__module__.rsplit('.', 1)[0] + '.tools.evidence_tool')
+            assert evidence._project_root({}, {}) == public_project
+        finally:
+            _SESSION_CWD.reset(token)

--- a/tests/native/test_profile_runtime.py
+++ b/tests/native/test_profile_runtime.py
@@ -408,6 +408,82 @@ def test_positive_recall_after_real_turn_and_native_queue(fixture):
     assert (public_store / 'memory/dreaming.json').exists()
 
 
+@pytest.mark.parametrize('identity_source', ['explicit', 'remote', 'missing', 'absent-cwd'])
+def test_project_identity_stays_bound_across_profile_scopes(fixture, monkeypatch, identity_source):
+    root, public, private_store, public_store = fixture
+    private_project = root.parent / 'private' / 'same-name'
+    public_project = root.parent / 'public' / 'same-name'
+    private_identity = 'prj:' + 'b' * 64
+    public_identity = 'prj:' + 'a' * 64
+    for project, identity in ((private_project, private_identity), (public_project, public_identity)):
+        (project / '.omh').mkdir(parents=True)
+        (project / '.omh/project-identity.json').write_text(json.dumps({
+            'schema_version': 'project_identity_file/v1', 'identity': identity,
+            'created_at': '2026-01-01T00:00:00Z', 'resolver_version': 'project_identity/v2'}))
+    if identity_source in {'remote', 'missing'}:
+        (public_project / '.omh/project-identity.json').unlink()
+        (public_project / '.git').mkdir()
+        (public_project / '.git/config').write_text(
+            '[remote "origin"]\n url = git@EXAMPLE.test:team/public.git\n'
+            if identity_source == 'remote' else '[core]\n bare = false\n')
+        public_identity = ('repo:' + hashlib.sha256(b'example.test/team/public').hexdigest()[:32]
+                           if identity_source == 'remote' else '')
+    if identity_source == 'absent-cwd':
+        public_identity = ''
+    monkeypatch.chdir(private_project)
+    provider, _ = load(public, 'memory-first')
+    from gateway.run import _profile_runtime_scope
+    from agent.runtime_cwd import set_session_cwd, _SESSION_CWD, resolve_context_cwd
+    from agent.memory_manager import MemoryManager
+    sys.path.insert(0, str(REPO / 'src'))
+    from omh.paths import resolve_paths
+    from omh.workflows import memory as memory_api
+    with _profile_runtime_scope(public):
+        paths = resolve_paths(public_store, public)
+        records = {}
+        for label, identity in (('public', public_identity or 'prj:' + 'a' * 64), ('private', private_identity)):
+            candidate = memory_api.capture_project_memory_candidate(paths,
+                'Synthetic ' + label + ' project sentinel', scope_ref=identity, retention_class='durable')['candidate']
+            records[label] = memory_api.approve_project_memory_candidate(paths, candidate['candidate_id'])['record']['record_id']
+        from tools.terminal_scope import set_terminal_scope, reset_terminal_scope
+        terminal_token = set_terminal_scope({})
+        token = set_session_cwd(None if identity_source == 'absent-cwd' else str(public_project))
+        try:
+            assert resolve_context_cwd() == (None if identity_source == 'absent-cwd' else public_project)
+            before = snapshot(private_store), snapshot(private_project)
+            memory = MemoryManager()
+            memory.add_provider(provider)
+            memory.initialize_all('synthetic-identity', platform='cli', agent_context='primary')
+        finally:
+            _SESSION_CWD.reset(token)
+            reset_terminal_scope(terminal_token)
+    with _profile_runtime_scope(root):
+        token = set_session_cwd(str(private_project))
+        try:
+            # Both direct re-render and queued work must keep the initialized cwd;
+            # a genuinely absent public cwd must not re-resolve this foreign one.
+            pack = provider.render_pack()
+            provider.queue_prefetch()
+            pack += provider.prefetch()
+            receipt = provider.latest_prefetch_receipt()
+            assert receipt is not None
+            assert receipt['schema_version'] == 'omh_memory_prefetch_receipt/v3'
+            assert receipt['resolver_version'] == 'project_identity/v2'
+            assert receipt['project_identity'] == public_identity
+            assert records['private'] not in pack
+            if public_identity:
+                assert records['public'] in pack
+            else:
+                assert records['public'] not in pack
+                assert receipt['lens']['scope_allowlist'] == []
+            assert provider._project_home == (None if identity_source == 'absent-cwd' else public_project / '.omh')
+            assert provider._omh_home == public_store
+            assert (snapshot(private_store), snapshot(private_project)) == before
+        finally:
+            _SESSION_CWD.reset(token)
+            memory.shutdown_all()
+
+
 def test_project_home_uses_host_logical_cwd(fixture, monkeypatch):
     root, public, private_store, public_store = fixture
     private_project, public_project = root.parent / 'private-project', root.parent / 'public-project'

--- a/tests/native/test_review_native.py
+++ b/tests/native/test_review_native.py
@@ -51,6 +51,117 @@ def test_managed_null_section_preserves_native_winner(fixture, monkeypatch, leve
     assert provider._omh_home == public_store
 
 
+@pytest.mark.parametrize('order', ['general-first', 'memory-first'])
+def test_review_single_owner_native_lifecycle_without_task_scope(fixture, monkeypatch, order):
+    root, public, private_store, public_store = fixture
+    from agent.secret_scope import set_multiplex_active, current_secret_scope
+    from hermes_constants import get_hermes_home_override
+    from hermes_cli.plugins import get_plugin_manager
+    from plugins.memory import load_memory_provider
+    from tools.registry import registry
+    set_multiplex_active(False)
+    # Ordinary single-owner Hermes has no task override/secret scope. Its
+    # explicit plugin setting must still win, including on the memory-first path.
+    assert current_secret_scope() is None
+    assert get_hermes_home_override() is None
+    settings(root, {'omh_home': str(public_store)})
+    manager = get_plugin_manager()
+    if order == 'general-first':
+        manager.discover_and_load()
+    provider = load_memory_provider('omh', register_skills=False)
+    assert provider is not None
+    if order == 'memory-first':
+        manager.discover_and_load()
+    assert provider._omh_home == public_store
+    before = baseline.snapshot(private_store)
+    result = json.loads(registry.get_entry('omh_todo').handler(
+        {'action': 'set', 'title': 'Single owner plan', 'items': [{'text': 'Check', 'state': 'pending'}]},
+        session_id='review-single'))
+    assert result['status'] == 'written'
+    assert baseline.snapshot(private_store) == before
+    hooks = manager.invoke_hook('pre_llm_call', user_message='unrelated',
+                                include_omh_awareness=False, session_id='review-single')
+    assert all(not row.get('omh_degradation') for row in hooks if isinstance(row, dict))
+    rejected = json.loads(registry.get_entry('omh_todo').handler(
+        {'action': 'show', 'omh_home': str(private_store)}))
+    assert 'error' in rejected
+    assert baseline.snapshot(private_store) == before
+
+
+def test_review_colocated_cli_uses_process_environment(fixture):
+    root, public, private_store, public_store = fixture
+    core()
+    from agent.secret_scope import set_multiplex_active, current_secret_scope
+    from hermes_constants import get_hermes_home_override
+    from omh.plugin_bundle.omh.runtime_paths import resolve_homes, _host
+    set_multiplex_active(False)
+    settings(root, {'omh_home': str(public_store)})
+    assert current_secret_scope() is None and get_hermes_home_override() is None
+    assert _host() is None
+    assert resolve_homes() == (private_store, root)
+
+
+@pytest.mark.parametrize('mode', ['standalone', 'single', 'routed', 'explicit', 'absent-cwd'])
+def test_review_native_project_artifact_contract(fixture, monkeypatch, mode):
+    from contextlib import ExitStack
+    from gateway.run import _profile_runtime_scope
+    from agent.secret_scope import set_multiplex_active
+    from agent.runtime_cwd import set_session_cwd, _SESSION_CWD
+    from tools.terminal_scope import set_terminal_scope, reset_terminal_scope
+    root, public, private_store, public_store = fixture
+    core()
+    from omh.paths import resolve_paths, project_artifact_dir
+    from omh.plugin_bundle.omh.runtime_paths import runtime_cwd
+    project = root.parent / 'project'
+    (project / '.git').mkdir(parents=True)
+    monkeypatch.chdir(project)
+    single = mode in {'standalone', 'single'}
+    set_multiplex_active(not single)
+    with ExitStack() as stack:
+        if mode != 'standalone':
+            stack.enter_context(_profile_runtime_scope(root if single else public))
+        terminal_token = set_terminal_scope({})
+        cwd_token = set_session_cwd(None if mode == 'absent-cwd' else str(project))
+        try:
+            paths = resolve_paths(private_store, root) if mode == 'explicit' else resolve_paths()
+            assert paths.omh_home_named is (not single)
+            assert runtime_cwd() == (None if mode == 'absent-cwd' else project)
+            expected = project / '.omh' if single else private_store if mode == 'explicit' else public_store
+            assert project_artifact_dir(paths, 'goals') == expected / 'goals'
+        finally:
+            _SESSION_CWD.reset(cwd_token)
+            reset_terminal_scope(terminal_token)
+
+
+def test_review_native_delegate_tool_cycle_and_override_refusal(fixture):
+    root, public, private_store, public_store = fixture
+    config = public / 'config.yaml'
+    config.write_text(config.read_text() + '# Keep unmanaged delegation settings.\ndelegation:\n  max_concurrent_children: 4\n')
+    provider, manager = baseline.load(public, 'general-first')
+    from gateway.run import _profile_runtime_scope
+    from tools.registry import registry
+    config = public / 'config.yaml'
+    original = config.read_bytes()
+    before = baseline.snapshot(private_store), (root / 'config.yaml').read_bytes()
+    with _profile_runtime_scope(public):
+        handler = registry.get_entry('omh_delegate_route').handler
+        assert json.loads(handler({'action': 'status'}))['route'] == {}
+        assert json.loads(handler({'action': 'set', 'model': 'test-child', 'reasoning_effort': 'high'}))['status'] == 'routed'
+        assert json.loads(handler({'action': 'status'}))['route']['model'] == 'test-child'
+        assert json.loads(handler({'action': 'clear'}))['status'] == 'cleared'
+        assert json.loads(handler({'action': 'status'}))['route'] == {}
+        after_cycle = baseline.snapshot(public_store)
+        rejected = handler({'action': 'set', 'model': 'test-child', 'hermes_home': str(root),
+            'observation': {'host': 'review-host', 'session_id': 'review-session'}})
+        assert 'error' in json.loads(rejected)
+        assert str(root) not in rejected
+        assert baseline.snapshot(public_store) == after_cycle
+    assert config.read_bytes() == original
+    # root contains public, so compare only its own config and launch store.
+    assert baseline.snapshot(private_store) == before[0]
+    assert (root / 'config.yaml').read_bytes() == before[1]
+
+
 def observed(**row):
     print('REVIEW_OBSERVED=' + json.dumps(row, sort_keys=True))
 

--- a/tests/native/test_review_native.py
+++ b/tests/native/test_review_native.py
@@ -459,3 +459,26 @@ def test_managed_winning_source_controls(fixture, monkeypatch, managed_kind):
                 resolve_homes()
         else:
             assert resolve_homes() == (public / 'state', public)
+
+
+@pytest.mark.parametrize('condition', ['invalid-config', 'missing-api'])
+def test_native_probe_override_rejects_before_binding_io(fixture, monkeypatch, condition):
+    root, public, private_store, public_store = fixture
+    baseline.load(public, 'general-first')
+    from gateway.run import _profile_runtime_scope
+    from tools.registry import registry
+    with _profile_runtime_scope(public):
+        if condition == 'invalid-config':
+            (public / 'config.yaml').write_text('invalid: [')
+        else:
+            import agent.runtime_cwd
+            monkeypatch.setattr(agent.runtime_cwd, 'resolve_context_cwd', None)
+        before = baseline.snapshot(public)
+        private_before = baseline.snapshot(private_store)
+        entry = registry.get_entry('omh_probe')
+        assert entry is not None
+        result = json.loads(entry.handler({'omh_home': str(private_store)}))
+        assert result['status'] == 'error'
+        assert str(private_store) not in json.dumps(result)
+        assert baseline.snapshot(public) == before
+        assert baseline.snapshot(private_store) == private_before

--- a/tests/native/test_review_native.py
+++ b/tests/native/test_review_native.py
@@ -28,6 +28,29 @@ def settings(home, values):
     path.write_text(json.dumps(config))
 
 
+@pytest.mark.parametrize('level', ['settings', 'entry'])
+def test_managed_null_section_preserves_native_winner(fixture, monkeypatch, level):
+    root, public, private_store, public_store = fixture
+    core()
+    settings(public, {'omh_home': str(public_store)})
+    entry = {'settings': None} if level == 'settings' else None
+    managed = root.parent / 'null-managed'
+    managed.mkdir()
+    (managed / 'config.yaml').write_text(json.dumps({'plugins': {'entries': {'omh': entry}}}))
+    monkeypatch.setenv('HERMES_MANAGED_DIR', str(managed))
+    from gateway.run import _profile_runtime_scope
+    from hermes_cli.config import load_config_readonly
+    from omh.plugin_bundle.omh.runtime_paths import resolve_homes
+    with _profile_runtime_scope(public):
+        effective = load_config_readonly()['plugins']['entries']['omh']['settings']['omh_home']
+        assert effective == str(public_store)
+        assert resolve_homes() == (public_store, public)
+    provider, manager = baseline.load(public, 'general-first')
+    assert manager._plugins['omh'].enabled
+    assert manager._plugins['omh'].error is None
+    assert provider._omh_home == public_store
+
+
 def observed(**row):
     print('REVIEW_OBSERVED=' + json.dumps(row, sort_keys=True))
 

--- a/tests/native/test_review_native.py
+++ b/tests/native/test_review_native.py
@@ -1,0 +1,327 @@
+"""Assertions express required safety; expected failures identify candidate gaps."""
+import importlib.util
+import importlib
+import json
+from pathlib import Path
+import shutil
+import sys
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location('review_baseline', REPO / 'tests/native/test_profile_runtime.py')
+baseline = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(baseline)
+fixture = baseline.fixture
+
+
+def core():
+    sys.path.insert(0, str(REPO / 'src'))
+    import omh
+    assert Path(omh.__file__).resolve().is_relative_to(REPO)
+
+
+def settings(home, values):
+    path = home / 'config.yaml'
+    config = {'memory': {'provider': 'omh'}, 'plugins': {'enabled': ['omh'],
+              'entries': {'omh': {'settings': values}}}, 'terminal': {'backend': 'local'}}
+    path.write_text(json.dumps(config))
+
+
+def observed(**row):
+    print('REVIEW_OBSERVED=' + json.dumps(row, sort_keys=True))
+
+
+@pytest.mark.parametrize('binding', ['relative', 'absolute'])
+def test_relative_observer_binding(fixture, monkeypatch, binding):
+    root, public, private_store, public_store = fixture
+    core()
+    launch = root.parent / 'private-project'
+    launch.mkdir()
+    monkeypatch.chdir(launch)
+    value = 'state' if binding == 'relative' else str(public_store)
+    settings(public, {'omh_home': value, 'group_chat_activity': {'enabled': True}})
+    provider, manager = baseline.load(public, 'general-first')
+    intended = public / 'state' if binding == 'relative' else public_store
+    wrong = launch / 'state'
+    observed(case='relative-observer', binding=binding, provider_home=str(provider._omh_home),
+             intended=str(intended),
+             foreign_files=[str(p.relative_to(wrong)) for p in wrong.rglob('*') if p.is_file()],
+             intended_files=[str(p.relative_to(intended)) for p in intended.rglob('*') if p.is_file()])
+    assert provider._omh_home == intended
+    assert not list(wrong.rglob('*.key')), 'observer keys must use the same configured root as the provider'
+    assert list((intended / 'runtime/group-activity-keys').glob('*.key'))
+
+
+def test_foreign_scope_manager_registration(fixture):
+    root, public, private_store, public_store = fixture
+    core()
+    settings(public, {'group_chat_activity': {'enabled': True}})  # legacy scoped .env remains present
+    from gateway.run import _profile_runtime_scope
+    from hermes_cli.plugins import get_plugin_manager
+    from hermes_constants import get_hermes_home
+    from agent.secret_scope import get_secret
+    with _profile_runtime_scope(public):
+        manager = get_plugin_manager()
+    with _profile_runtime_scope(root):
+        manager.discover_and_load()  # real manager supplies only its immutable home override
+        assert get_hermes_home() == root  # native token reset remains correct
+        assert get_secret('OMH_HOME') == str(private_store)
+    foreign_keys = list((private_store / 'runtime/group-activity-keys').glob('*.key'))
+    expected_keys = list((public_store / 'runtime/group-activity-keys').glob('*.key'))
+    observed(case='partial-manager-scope', manager_home=str(manager.home_path),
+             foreign_keys=[p.name for p in foreign_keys], public_keys=[p.name for p in expected_keys],
+             loaded=[{'key':k, 'enabled':v.enabled, 'error':v.error} for k,v in manager._plugins.items()])
+    assert not foreign_keys, 'public manager registration must not consume the caller profile secret scope'
+    if not expected_keys:
+        # An anonymous foreign scope may be refused instead of rebound. Either
+        # outcome must precede all observer IO and disable the failed plugin.
+        failed = manager._plugins['omh']
+        assert not failed.enabled and failed.error
+        assert not manager._hooks.get('on_room_member_activity')
+
+
+def test_untrusted_path_cannot_read_scoped_token(fixture, monkeypatch):
+    root, public, private_store, public_store = fixture
+    marker = 'SYNTHETIC_TOKEN_NOT_FOR_TOOL_OUTPUT'
+    monkeypatch.chdir(root.parent)
+    monkeypatch.delenv('REVIEW_ONLY_API_TOKEN', raising=False)
+    (public / '.env').write_text(f'OMH_HOME={public_store}\nREVIEW_ONLY_API_TOKEN={marker}\n')
+    provider, manager = baseline.load(public, 'general-first')
+    from gateway.run import _profile_runtime_scope
+    from tools.registry import registry
+    with _profile_runtime_scope(public):
+        result = registry.get_entry('omh_gather_evidence').handler(
+            {'commands': ['git diff --check'], 'project_root': '$REVIEW_ONLY_API_TOKEN'})
+    from agent.redact import redact_sensitive_text
+    scrubbed = redact_sensitive_text(result, force=True)
+    observed(case='untrusted-path-token', returned_marker=marker in result,
+             survives_native_redactor=marker in scrubbed, result=json.loads(result))
+    assert marker not in result, 'model path text must not become a credential-read API'
+
+
+@pytest.mark.parametrize('order', ['general-first', 'memory-first'])
+@pytest.mark.parametrize('profile_order', ['private-first', 'public-first'])
+def test_shared_source_reload_controls(fixture, monkeypatch, order, profile_order):
+    root, public, private_store, public_store = fixture
+    core()
+    shared = root.parent / 'shared-omh'
+    shutil.copytree(baseline.BUNDLE, shared, ignore=shutil.ignore_patterns('__pycache__'))
+    for home in (root, public):
+        shutil.rmtree(home / 'plugins/omh')
+        (home / 'plugins/omh').symlink_to(shared, target_is_directory=True)
+    homes = (root, public) if profile_order == 'private-first' else (public, root)
+    loaded = {home: baseline.load(home, order) for home in homes}
+    from gateway.run import _profile_runtime_scope
+    from tools.registry import registry
+    rows = []
+    for cycle in range(2):
+        for home, store in ((root, private_store), (public, public_store)):
+            with _profile_runtime_scope(home):
+                old_provider, manager = loaded[home]
+                assert old_provider._omh_home == store
+                if cycle:
+                    assert manager.unload('omh')
+                    manager.discover_and_load(force=True)
+                assert len(manager._hooks['on_session_end']) == 1
+                result = json.loads(registry.get_entry('omh_todo').handler(
+                    {'action': 'set', 'title': 'review-'+store.name,
+                     'items': [{'text': 'synthetic', 'state': 'pending'}]}, session_id='same-session'))
+                assert result['status'] == 'written'
+                rows.append({'cycle':cycle, 'home':str(home), 'provider_home':str(old_provider._omh_home),
+                             'session_hooks':len(manager._hooks['on_session_end'])})
+    observed(case='shared-source-reload', order=order, profile_order=profile_order, rows=rows)
+
+
+def test_native_single_owner_unscoped_startup(fixture, monkeypatch):
+    root, public, private_store, public_store = fixture
+    core()
+    from agent.secret_scope import set_multiplex_active, set_secret_scope, reset_secret_scope
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    from plugins.memory import load_memory_provider
+    from hermes_cli.plugins import get_plugin_manager
+    set_multiplex_active(False)
+    ht, st = set_hermes_home_override(None), set_secret_scope(None)
+    try:
+        manager = get_plugin_manager()
+        manager.discover_and_load()
+        provider = load_memory_provider('omh', register_skills=False)
+        assert provider is not None and provider._omh_home == private_store
+        from tools.registry import registry
+        result = json.loads(registry.get_entry('omh_todo').handler({'action':'show'}))
+        observed(case='single-owner-unscoped', provider_home=str(provider._omh_home), tool_returned=bool(result))
+    finally:
+        reset_secret_scope(st)
+        reset_hermes_home_override(ht)
+
+
+def test_bound_provider_work_under_foreign_scope(fixture):
+    root, public, private_store, public_store = fixture
+    provider, manager = baseline.load(public, 'memory-first')
+    blocks = importlib.import_module(type(provider).__module__.rsplit('.', 1)[0] + '.memory_blocks')
+    block = blocks.build_memory_block(label='review-positive', value='SYNTHETIC_PUBLIC_BOUND_RECALL',
+        description='Synthetic independent review control', tier='system')
+    blocks.write_memory_block(public_store, blocks.approve_memory_block(block, reviewer_claim='user'))
+    from gateway.run import _profile_runtime_scope
+    with _profile_runtime_scope(public):
+        provider.initialize('review-bound', hermes_home=public, cwd=public, platform='cli')
+    before = baseline.snapshot(private_store)
+    with _profile_runtime_scope(root):
+        provider.on_turn_start(1, 'Synthetic public queued work')
+        provider.queue_prefetch('Synthetic public queued work', session_id='review-bound')
+        text = provider.prefetch(session_id='review-bound')
+    assert 'SYNTHETIC_PUBLIC_BOUND_RECALL' in text
+    assert baseline.snapshot(private_store) == before
+    assert (public_store / 'memory/dreaming.json').exists()
+    observed(case='bound-provider-foreign-scope', positive_recall=True, foreign_store_unchanged=True)
+
+
+def test_managed_absolute_override_beats_user_template(fixture, monkeypatch):
+    root, public, private_store, public_store = fixture
+    core()
+    settings(public, {'omh_home': '$HERMES_HOME/user-state'})
+    managed = root.parent / 'admin-config'
+    managed.mkdir()
+    (managed / 'config.yaml').write_text(json.dumps({'plugins': {'entries': {'omh': {
+        'settings': {'omh_home': str(public_store)}}}}}))
+    monkeypatch.setenv('HERMES_MANAGED_DIR', str(managed))
+    from gateway.run import _profile_runtime_scope
+    from hermes_cli.config import load_config_readonly
+    from omh.plugin_bundle.omh.runtime_paths import resolve_homes
+    with _profile_runtime_scope(public):
+        effective = load_config_readonly()['plugins']['entries']['omh']['settings']['omh_home']
+        assert effective == str(public_store)
+        try:
+            actual = resolve_homes()
+        except Exception as exc:
+            observed(case='managed-absolute-override', effective=effective, error_type=type(exc).__name__, error=str(exc))
+            raise
+        assert actual == (public_store, public)
+
+
+def test_missing_deleted_project_context_controls(fixture, monkeypatch):
+    root, public, private_store, public_store = fixture
+    core()
+    launch = root.parent / 'launch-project'
+    (launch / '.git').mkdir(parents=True)
+    monkeypatch.chdir(launch)
+    provider, _ = baseline.load(public, 'memory-first')
+    from gateway.run import _profile_runtime_scope
+    from agent.runtime_cwd import set_session_cwd, _SESSION_CWD
+    base = type(provider).__module__.rsplit('.', 1)[0]
+    paths = importlib.import_module(base + '.runtime_paths')
+    evidence = importlib.import_module(base + '.tools.evidence_tool')
+    from omh.paths import find_project_root
+    from tools.terminal_scope import set_terminal_scope, reset_terminal_scope
+    for value in ('', str(public / 'deleted-project')):
+        with _profile_runtime_scope(public):
+            token = set_session_cwd(value)
+            terminal_token = set_terminal_scope({'TERMINAL_CWD': ''})
+            try:
+                provider.initialize('review-project', hermes_home=public, platform='cli')
+                assert provider._project_home is None
+                assert find_project_root() is None
+                with pytest.raises(paths.RuntimeBindingError):
+                    evidence._project_root({}, {})
+            finally:
+                reset_terminal_scope(terminal_token)
+                _SESSION_CWD.reset(token)
+    observed(case='missing-deleted-project', provider_has_project=provider._project_home is not None)
+
+@pytest.mark.parametrize('field', ['project_root', 'workdir'])
+@pytest.mark.parametrize('reference', ['$REVIEW_ONLY_API_TOKEN', '${REVIEW_ONLY_API_TOKEN}', '${env:REVIEW_ONLY_API_TOKEN}', '%REVIEW_ONLY_API_TOKEN%'])
+def test_evidence_input_variables_refused_before_lookup(fixture, monkeypatch, field, reference):
+    root, public, private_store, public_store = fixture
+    provider, _ = baseline.load(public, 'general-first')
+    from gateway.run import _profile_runtime_scope
+    from tools.registry import registry
+    base = type(provider).__module__.rsplit('.', 1)[0]
+    paths = importlib.import_module(base + '.runtime_paths')
+    # Fail if the input crosses into credential resolution, even if redacted.
+    def forbidden(*args, **kwargs):
+        pytest.fail('untrusted input performed a credential lookup')
+    monkeypatch.setattr(paths, '_profile_variable', forbidden)
+    with _profile_runtime_scope(public):
+        result = json.loads(registry.get_entry('omh_gather_evidence').handler(
+            {'commands': ['git diff --check'], 'project_root': str(public), field: reference}))
+    assert result['error'] == 'OMH input paths do not support variable references'
+    assert 'results' not in result
+
+
+@pytest.mark.parametrize('feature', ['egress_attempts', 'browser_bridge'])
+@pytest.mark.parametrize('binding', ['scoped-env', 'foreign-scope', 'relative-setting', 'explicit-feature'])
+def test_optional_sibling_registration_owner(fixture, monkeypatch, feature, binding):
+    from inspect import getclosurevars
+    from gateway.run import _profile_runtime_scope
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    from hermes_cli.plugins import get_plugin_manager, PluginContext, PluginManifest
+    root, public, private_store, public_store = fixture
+    core()
+    settings(public, {'omh_home': 'state'} if binding == 'relative-setting' else {})
+    with _profile_runtime_scope(public):
+        manager = get_plugin_manager()
+        ctx = PluginContext(PluginManifest(name='omh', key='omh'), manager)
+    module = importlib.import_module('omh.plugin_bundle.omh.' + feature)
+    paths = importlib.import_module('omh.plugin_bundle.omh.runtime_paths')
+    config = {'omh_home': str(public_store / 'feature')} if binding == 'explicit-feature' else {}
+    expected = (public / 'state' if binding == 'relative-setting' else
+                public_store / 'feature' if binding == 'explicit-feature' else public_store)
+    before = baseline.snapshot(private_store)
+    with _profile_runtime_scope(root if binding == 'foreign-scope' else public):
+        token = set_hermes_home_override(str(public))  # native manager's home-only transition
+        try:
+            if binding == 'foreign-scope':
+                with pytest.raises(paths.RuntimeBindingError, match='ownership is unverified'):
+                    module.register(ctx, config)
+                assert not manager._hooks
+            elif feature == 'egress_attempts':
+                module.register(ctx, config)
+                assert manager._hooks['pre_tool_call'][0].__self__.home == expected
+            else:
+                module.register(ctx, config)
+                # Inspect the bound store, without pretending to authorize a
+                # browser task or providing a fake native admission identity.
+                end = manager._hooks['on_session_end'][0]
+                get_manager = getclosurevars(end).nonlocals['get_manager']
+                assert getclosurevars(get_manager).nonlocals['home'] == expected
+        finally:
+            reset_hermes_home_override(token)
+    assert baseline.snapshot(private_store) == before
+
+
+def test_native_launch_owner_empty_scope_overlay(fixture):
+    from gateway.run import _profile_runtime_scope
+    from agent.secret_scope import set_multiplex_active
+    root, public, private_store, public_store = fixture
+    core()
+    from omh.plugin_bundle.omh.runtime_paths import resolve_homes
+    settings(root, {})
+    (root / '.env').write_text('')
+    set_multiplex_active(False)
+    with _profile_runtime_scope(root):
+        assert resolve_homes() == (private_store, root)
+
+
+@pytest.mark.parametrize('managed_kind', ['unrelated-leaf', 'legacy-shadowed', 'ambiguous-winning'])
+def test_managed_winning_source_controls(fixture, monkeypatch, managed_kind):
+    from gateway.run import _profile_runtime_scope
+    root, public, private_store, public_store = fixture
+    core()
+    from omh.plugin_bundle.omh.runtime_paths import resolve_homes, RuntimeBindingError
+    settings(public, {'omh_home': '$HERMES_HOME/state'})
+    entry = {'settings': {'enabled': True}}
+    if managed_kind == 'legacy-shadowed':
+        entry = {'config': {'omh_home': str(private_store)}}
+    elif managed_kind == 'ambiguous-winning':
+        settings(public, {'omh_home': str(public_store)})
+        entry = {'settings': {'omh_home': '${HERMES_HOME}/state'}}
+    managed = root.parent / 'managed'
+    managed.mkdir()
+    (managed / 'config.yaml').write_text(json.dumps({'plugins': {'entries': {'omh': entry}}}))
+    monkeypatch.setenv('HERMES_MANAGED_DIR', str(managed))
+    with _profile_runtime_scope(public):
+        if managed_kind == 'ambiguous-winning':
+            with pytest.raises(RuntimeBindingError, match='expansion disagrees'):
+                resolve_homes()
+        else:
+            assert resolve_homes() == (public / 'state', public)

--- a/tests/test_capability_impact.py
+++ b/tests/test_capability_impact.py
@@ -203,7 +203,7 @@ class PreVerifyHookTests(unittest.TestCase):
         self.assertIn("omh_capabilities", context.tools)
 
     def test_pre_verify_persists_bounded_host_observation_without_paths_or_response(self) -> None:
-        with TemporaryDirectory() as tmp:
+        with TemporaryDirectory() as tmp, patch.dict("os.environ", {"OMH_HOME": tmp}):
             result = verify_hooks.pre_verify(
                 host="hermes-agent",
                 session_id="session-1",

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -103,7 +103,9 @@ class DelegationRouteHomeTest(unittest.TestCase):
             "hermes_constants": module,
             "agent.secret_scope": types.SimpleNamespace(is_multiplex_active=lambda: False,
                 current_secret_scope=lambda: {"OMH_HOME": str(self.omh_home)},
-                get_secret=lambda name: str(self.omh_home)),
+                get_secret=lambda name: str(self.omh_home),
+                build_profile_secret_scope=lambda home: {"OMH_HOME": str(self.omh_home)}),
+            "hermes_cli.managed_scope": types.SimpleNamespace(load_managed_config=lambda: {}),
             "hermes_cli.config": types.SimpleNamespace(require_readable_config_before_write=lambda path: {},
                 load_config_readonly=lambda: {}),
         }):

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -99,14 +99,24 @@ class DelegationRouteHomeTest(unittest.TestCase):
         native = self.root / "native"
         module = types.ModuleType("hermes_constants")
         module.get_hermes_home = lambda: native
-        with mock.patch.dict("sys.modules", {"hermes_constants": module}):
+        with mock.patch.dict("sys.modules", {
+            "hermes_constants": module,
+            "agent.secret_scope": types.SimpleNamespace(is_multiplex_active=lambda: False,
+                current_secret_scope=lambda: {"OMH_HOME": str(self.omh_home)},
+                get_secret=lambda name: str(self.omh_home)),
+            "hermes_cli.config": types.SimpleNamespace(require_readable_config_before_write=lambda path: {},
+                load_config_readonly=lambda: {}),
+        }):
             self._assert_tool_cycle(native)
 
     def test_explicit_home_does_not_consult_native_resolver(self):
         module = types.ModuleType("hermes_constants")
         module.get_hermes_home = mock.Mock(side_effect=AssertionError("must not resolve"))
         with mock.patch.dict("sys.modules", {"hermes_constants": module}):
-            self._assert_tool_cycle(self.root / "explicit", hermes_home="~/explicit")
+            # Explicit programmatic/CLI writes remain authoritative. A native
+            # model tool's home fields are no longer an offline-operation API.
+            write_delegation_route("~/explicit", model="test-child")
+            self.assertEqual(read_delegation_route("~/explicit"), {"model": "test-child"})
         module.get_hermes_home.assert_not_called()
 
 
@@ -395,7 +405,7 @@ class DelegateRouteToolTest(unittest.TestCase):
         self.assertEqual(result["provider_routes"], "absent")
         self.assertEqual(
             Path(result["provider_routes_path"]),
-            self.omh_home / "routing" / "model-providers.json",
+            self.omh_home.resolve() / "routing" / "model-providers.json",
         )
         self._write_overrides(
             {"deep": [{"model": "aliased-model", "reasoning_effort": "xhigh"}]}
@@ -590,7 +600,7 @@ class DelegateRouteToolTest(unittest.TestCase):
         self.assertEqual(result["chain_overrides"], "absent")
         self.assertEqual(
             Path(result["chain_overrides_path"]),
-            self.omh_home / "routing" / "model-chains.json",
+            self.omh_home.resolve() / "routing" / "model-chains.json",
         )
         self._write_overrides({"deep": [{"model": "gpt-5.6-terra", "reasoning_effort": "xhigh"}]})
         applied = self._call(action="status")

--- a/tests/test_delegate_route_tool.py
+++ b/tests/test_delegate_route_tool.py
@@ -42,7 +42,7 @@ class DelegationRouteHomeTest(unittest.TestCase):
         # Force the standalone boundary regardless of the developer's host.
         self.enterContext(mock.patch.dict("sys.modules", {"hermes_constants": None}))
 
-    def _assert_tool_cycle(self, target, **args):
+    def _assert_tool_cycle(self, target, *, native=False, **args):
         untouched = (
             "# keep this comment\nmodel:\n  provider: test-parent\n"
             "delegation:\n  max_concurrent_children: 4\n"
@@ -59,7 +59,7 @@ class DelegationRouteHomeTest(unittest.TestCase):
 
         def call(action, **values):
             return json.loads(omh_delegate_route_handler({
-                "action": action, "omh_home": str(self.omh_home), **args, **values,
+                "action": action, **({} if native else {"omh_home": str(self.omh_home)}), **args, **values,
             }))
 
         self.assertEqual(call("status")["route"], {})
@@ -99,8 +99,10 @@ class DelegationRouteHomeTest(unittest.TestCase):
         native = self.root / "native"
         module = types.ModuleType("hermes_constants")
         module.get_hermes_home = lambda: native
+        module.get_hermes_home_override = lambda: str(native)
         with mock.patch.dict("sys.modules", {
             "hermes_constants": module,
+            "agent.runtime_cwd": types.SimpleNamespace(resolve_context_cwd=lambda: None, resolve_agent_cwd=Path.cwd),
             "agent.secret_scope": types.SimpleNamespace(is_multiplex_active=lambda: False,
                 current_secret_scope=lambda: {"OMH_HOME": str(self.omh_home)},
                 get_secret=lambda name: str(self.omh_home),
@@ -109,7 +111,7 @@ class DelegationRouteHomeTest(unittest.TestCase):
             "hermes_cli.config": types.SimpleNamespace(require_readable_config_before_write=lambda path: {},
                 load_config_readonly=lambda: {}),
         }):
-            self._assert_tool_cycle(native)
+            self._assert_tool_cycle(native, native=True)
 
     def test_explicit_home_does_not_consult_native_resolver(self):
         module = types.ModuleType("hermes_constants")

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -188,9 +188,8 @@ class PluginCapabilitiesTests(unittest.TestCase):
             root = Path(tmp)
             omh_home = root / ".omh"
             hermes_home = root / ".hermes"
-            # Observation metadata is not store authority. Bind this synthetic
-            # standalone host before registration, like an actual owner process.
-            self.enterContext(patch.dict(os.environ, {"OMH_HOME": str(omh_home), "HERMES_HOME": str(hermes_home)}))
+            # These explicit standalone operator roots must outrank the
+            # environment; native observation metadata is tested separately.
             base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
             status, _, stderr = run_cli(base + ["setup", "--with-plugin"])
             self.assertEqual(status, 0, stderr)

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import textwrap
@@ -187,6 +188,9 @@ class PluginCapabilitiesTests(unittest.TestCase):
             root = Path(tmp)
             omh_home = root / ".omh"
             hermes_home = root / ".hermes"
+            # Observation metadata is not store authority. Bind this synthetic
+            # standalone host before registration, like an actual owner process.
+            self.enterContext(patch.dict(os.environ, {"OMH_HOME": str(omh_home), "HERMES_HOME": str(hermes_home)}))
             base = ["--omh-home", str(omh_home), "--hermes-home", str(hermes_home)]
             status, _, stderr = run_cli(base + ["setup", "--with-plugin"])
             self.assertEqual(status, 0, stderr)
@@ -607,6 +611,7 @@ merge_observed=false
 
             result = subprocess.run(
                 [sys.executable, "-S", "-c", script],
+                env={**os.environ, "OMH_HOME": str(omh_home), "HERMES_HOME": str(hermes_home)},
                 cwd=str(root),
                 text=True,
                 capture_output=True,

--- a/tests/test_plugin_distribution.py
+++ b/tests/test_plugin_distribution.py
@@ -1009,6 +1009,8 @@ print(json.dumps(observed, ensure_ascii=False))
             with mock.patch.dict(
                 os.environ,
                 {
+                    "OMH_HOME": str(omh_home),
+                    "HERMES_HOME": str(hermes_home),
                     "OPENAI_API_KEY": "model-secret-do-not-print",
                     "AWS_SECRET_ACCESS_KEY": "cloud-secret-do-not-print",
                     "BUZZ_PRIVATE_KEY": "buzz-secret-do-not-print",
@@ -1035,6 +1037,8 @@ print(json.dumps(observed, ensure_ascii=False))
                 set(child_env),
                 {
                     "HOME",
+                    "OMH_HOME",
+                    "HERMES_HOME",
                     "LANG",
                     "LC_ALL",
                     "PATH",
@@ -1043,6 +1047,8 @@ print(json.dumps(observed, ensure_ascii=False))
                     "TMPDIR",
                 },
             )
+            self.assertEqual(child_env["OMH_HOME"], str(omh_home.resolve()))
+            self.assertEqual(child_env["HERMES_HOME"], str(hermes_home.resolve()))
             self.assertNotIn("OPENAI_API_KEY", child_env)
             self.assertNotIn("AWS_SECRET_ACCESS_KEY", child_env)
             self.assertNotIn("BUZZ_PRIVATE_KEY", child_env)

--- a/tests/test_plugin_observations.py
+++ b/tests/test_plugin_observations.py
@@ -25,7 +25,7 @@ def _record_standalone_hooks(
     process_index, count, omh_home, start_barrier = work
     # The installed standalone bundle cannot import these core modules. Mask
     # them here so this regression cannot accidentally exercise the core path.
-    with mock.patch.dict(sys.modules, {"omh.paths": None, "omh.plugin_observations": None}):
+    with mock.patch.dict(sys.modules, {"omh.paths": None, "omh.plugin_observations": None}), mock.patch.dict(os.environ, {"OMH_HOME": omh_home}):
         start_barrier.wait(timeout=20)
         return [
             observe_plugin_hook_call(

--- a/tests/test_plugin_observer_native.py
+++ b/tests/test_plugin_observer_native.py
@@ -44,6 +44,7 @@ class NativeObserverTests(unittest.TestCase):
                             "hermes_constants": SimpleNamespace(get_hermes_home=lambda: paths.hermes_home),
                             "agent.secret_scope": SimpleNamespace(is_multiplex_active=lambda: False,
                                 current_secret_scope=lambda: None, get_secret=lambda name: str(paths.omh_home)),
+                            "hermes_cli.managed_scope": SimpleNamespace(load_managed_config=lambda: {}),
                             "hermes_cli.config": SimpleNamespace(
                                 require_readable_config_before_write=lambda path: {},
                                 load_config_readonly=lambda: {})}):

--- a/tests/test_plugin_observer_native.py
+++ b/tests/test_plugin_observer_native.py
@@ -41,7 +41,12 @@ class NativeObserverTests(unittest.TestCase):
         paths = OmhPaths(root / "omh", root / "hermes")
         with patch.dict("os.environ", {"OMH_HOME": str(paths.omh_home), "HERMES_HOME": str(paths.hermes_home)}), patch.dict(
             "sys.modules", {"hermes_cli.plugins": SimpleNamespace(VALID_HOOKS={"on_room_member_activity"}),
-                            "hermes_constants": SimpleNamespace(get_hermes_home=lambda: paths.hermes_home)}):
+                            "hermes_constants": SimpleNamespace(get_hermes_home=lambda: paths.hermes_home),
+                            "agent.secret_scope": SimpleNamespace(is_multiplex_active=lambda: False,
+                                current_secret_scope=lambda: None, get_secret=lambda name: str(paths.omh_home)),
+                            "hermes_cli.config": SimpleNamespace(
+                                require_readable_config_before_write=lambda path: {},
+                                load_config_readonly=lambda: {})}):
             try:
                 plugin.register(context)
                 callback = context.hooks.get("on_room_member_activity")

--- a/tests/test_plugin_observer_native.py
+++ b/tests/test_plugin_observer_native.py
@@ -41,9 +41,12 @@ class NativeObserverTests(unittest.TestCase):
         paths = OmhPaths(root / "omh", root / "hermes")
         with patch.dict("os.environ", {"OMH_HOME": str(paths.omh_home), "HERMES_HOME": str(paths.hermes_home)}), patch.dict(
             "sys.modules", {"hermes_cli.plugins": SimpleNamespace(VALID_HOOKS={"on_room_member_activity"}),
-                            "hermes_constants": SimpleNamespace(get_hermes_home=lambda: paths.hermes_home),
+                            "hermes_constants": SimpleNamespace(get_hermes_home=lambda: paths.hermes_home,
+                                get_hermes_home_override=lambda: str(paths.hermes_home)),
+                            "agent.runtime_cwd": SimpleNamespace(resolve_context_cwd=lambda: None, resolve_agent_cwd=Path.cwd),
                             "agent.secret_scope": SimpleNamespace(is_multiplex_active=lambda: False,
-                                current_secret_scope=lambda: None, get_secret=lambda name: str(paths.omh_home)),
+                                current_secret_scope=lambda: None, get_secret=lambda name: str(paths.omh_home),
+                                build_profile_secret_scope=lambda home: {"OMH_HOME": str(paths.omh_home)}),
                             "hermes_cli.managed_scope": SimpleNamespace(load_managed_config=lambda: {}),
                             "hermes_cli.config": SimpleNamespace(
                                 require_readable_config_before_write=lambda path: {},

--- a/tests/test_runtime_binding_review.py
+++ b/tests/test_runtime_binding_review.py
@@ -1,0 +1,313 @@
+"""Finite PR review regressions at the runtime ownership boundary."""
+import importlib
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.plugin_bundle.omh import runtime_paths as paths
+from omh.plugin_bundle.omh.hooks import llm_hooks, tool_hooks, session_hooks
+
+
+def native_modules(home, store, *, active=True, multiplex=False):
+    def config(value):
+        return {"plugins": {"entries": {"omh": {"settings": {"omh_home": str(value)}}}}}
+    return {
+        "hermes_constants": types.SimpleNamespace(get_hermes_home=lambda: home,
+            get_hermes_home_override=lambda: str(home) if active else None),
+        "agent.secret_scope": types.SimpleNamespace(is_multiplex_active=lambda: multiplex,
+            current_secret_scope=lambda: None, get_secret=Mock(return_value=str(store)),
+            build_profile_secret_scope=lambda home: {"OMH_HOME": str(store)}),
+        "hermes_cli.config": types.SimpleNamespace(require_readable_config_before_write=Mock(return_value=config(store)),
+            load_config_readonly=Mock(return_value=config(store))),
+        "hermes_cli.managed_scope": types.SimpleNamespace(load_managed_config=lambda: {}),
+        "agent.runtime_cwd": types.SimpleNamespace(resolve_context_cwd=lambda: None, resolve_agent_cwd=Path.cwd),
+    }
+
+
+class RuntimeBindingReviewTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name).resolve()
+        self.home, self.store = self.root / 'profile', self.root / 'state'
+        self.enterContext(patch.dict(os.environ, {"HOME": str(self.root), "USERPROFILE": str(self.root),
+            "HERMES_HOME": str(self.home), "OMH_HOME": str(self.store)}))
+        self.enterContext(patch.dict(sys.modules, {'hermes_constants': None}))
+
+    def test_colocated_imports_do_not_select_native_config_or_secrets(self):
+        modules = native_modules(self.home, self.root / 'native-state', active=False)
+        with patch.dict(sys.modules, modules):
+            self.assertEqual(paths.resolve_homes(), (self.store, self.home))
+            self.assertEqual(paths.expand_path('$OMH_HOME'), self.store)
+        modules['hermes_cli.config'].load_config_readonly.assert_not_called()
+        modules['agent.secret_scope'].get_secret.assert_not_called()
+
+    def test_active_host_missing_capabilities_is_bounded_before_config_io(self):
+        required = {
+            'hermes_constants': ['get_hermes_home', 'get_hermes_home_override'],
+            'agent.secret_scope': ['is_multiplex_active', 'current_secret_scope', 'get_secret', 'build_profile_secret_scope'],
+            'hermes_cli.config': ['require_readable_config_before_write', 'load_config_readonly'],
+            'hermes_cli.managed_scope': ['load_managed_config'],
+            'agent.runtime_cwd': ['resolve_context_cwd', 'resolve_agent_cwd'],
+        }
+        for module, names in required.items():
+            for name in [None, *names]:
+                with self.subTest(module=module, name=name):
+                    modules = native_modules(self.home, self.store)
+                    config = modules['hermes_cli.config']
+                    if name is None:
+                        modules[module] = None
+                    else:
+                        setattr(modules[module], name, None)
+                    # A wholly absent Hermes is the supported standalone lane.
+                    if module == 'hermes_constants' and name is None:
+                        continue
+                    with patch.dict(sys.modules, modules), self.assertRaises(paths.RuntimeBindingError) as caught:
+                        paths.resolve_homes()
+                    self.assertNotIn(str(self.root), str(caught.exception))
+                    if callable(config.load_config_readonly):
+                        config.load_config_readonly.assert_not_called()
+                    if callable(config.require_readable_config_before_write):
+                        config.require_readable_config_before_write.assert_not_called()
+
+    def test_missing_constants_does_not_downgrade_an_active_native_scope(self):
+        modules = native_modules(self.home, self.store, multiplex=True)
+        modules['hermes_constants'] = None
+        with patch.dict(sys.modules, modules), self.assertRaises(paths.RuntimeBindingError):
+            paths.resolve_homes()
+        with patch.object(paths, '_NATIVE_REGISTERED', True), self.assertRaises(paths.RuntimeBindingError):
+            paths.resolve_homes()
+
+    def test_unscoped_multiplexer_is_not_standalone(self):
+        modules = native_modules(self.home, self.store, active=False, multiplex=True)
+        with patch.dict(sys.modules, modules), self.assertRaises(paths.RuntimeBindingError):
+            paths.resolve_homes()
+        modules['hermes_cli.config'].load_config_readonly.assert_not_called()
+
+    def test_literal_active_config_disagreement_is_rejected(self):
+        modules = native_modules(self.home, self.store)
+        modules['hermes_cli.config'].load_config_readonly.return_value = {
+            'plugins': {'entries': {'omh': {'settings': {'omh_home': str(self.root / 'foreign')}}}}}
+        with patch.dict(sys.modules, modules), self.assertRaises(paths.RuntimeBindingError):
+            paths.resolve_homes()
+        self.assertFalse(self.store.exists())
+        self.assertFalse((self.root / 'foreign').exists())
+
+    def test_missing_winning_leaf_cannot_select_an_effective_foreign_home(self):
+        for missing in ('raw', 'effective'):
+            with self.subTest(missing=missing):
+                modules = native_modules(self.home, self.store)
+                config = modules['hermes_cli.config']
+                if missing == 'raw':
+                    config.require_readable_config_before_write.return_value = {}
+                else:
+                    config.load_config_readonly.return_value = {}
+                with patch.dict(sys.modules, modules), self.assertRaises(paths.RuntimeBindingError):
+                    paths.resolve_homes()
+
+    def test_filesystem_home_faults_are_typed_and_bounded(self):
+        for exc in (OSError('PRIVATE_PATH'), RuntimeError('PRIVATE_PATH')):
+            with self.subTest(error=type(exc).__name__), patch.object(Path, 'resolve', side_effect=exc):
+                for call in (lambda: paths.expand_path(self.home), paths.default_hermes_home, paths.resolve_homes):
+                    with self.assertRaises(paths.RuntimeBindingError) as caught:
+                        call()
+                    self.assertNotIn('PRIVATE_PATH', str(caught.exception))
+
+    def test_cwd_resolution_fault_is_a_bounded_binding_error(self):
+        modules = native_modules(self.home, self.store, multiplex=True)
+        modules['agent.runtime_cwd'].resolve_context_cwd = Mock(side_effect=RuntimeError('PRIVATE_PATH'))
+        for native in (False, True):
+            with self.subTest(native=native), patch.dict(sys.modules, modules if native else {'hermes_constants': None}), \
+                    patch.object(Path, 'cwd', side_effect=OSError('PRIVATE_PATH')):
+                with self.assertRaises(paths.RuntimeBindingError) as caught:
+                    paths.runtime_cwd()
+                self.assertNotIn('PRIVATE_PATH', str(caught.exception))
+
+    def test_binding_fault_precedes_hook_io_and_pre_tool_blocks(self):
+        for module, name in ((llm_hooks, 'pre_llm_call'), (tool_hooks, 'pre_tool_call'),
+                             (tool_hooks, 'post_tool_call'), (session_hooks, 'on_session_end')):
+            for home_key in ('omh_home', 'hermes_home'):
+                with self.subTest(hook=name, home=home_key):
+                    def bind(value=None, *, hermes=False):
+                        if hermes == (home_key == 'hermes_home'):
+                            raise paths.RuntimeBindingError('PRIVATE_PATH')
+                        return self.home if hermes else self.store
+                    with patch.object(paths, 'plugin_home', side_effect=bind), \
+                            patch.object(module, 'observe_plugin_hook_call') as observer:
+                        result = getattr(module, name)(tool_name='read_file', host='host', session_id='s')
+                    observer.assert_not_called()
+                    self.assertTrue(result['omh_degradation']['degraded'])
+                    self.assertNotIn('PRIVATE_PATH', json.dumps(result))
+                    if name == 'pre_tool_call':
+                        self.assertEqual(result['action'], 'block')
+
+    def test_tool_rule_failure_is_not_swallowed_by_binding_guard(self):
+        with patch.object(tool_hooks, 'toolcall_rule_directive', side_effect=RuntimeError('rule failure')):
+            with self.assertRaisesRegex(RuntimeError, 'rule failure'):
+                tool_hooks.pre_tool_call(tool_name='read_file')
+
+    def test_user_name_expansion_is_rejected_without_os_lookup(self):
+        for value in ('~root/file', '~some-user', '~another\\file'):
+            with self.subTest(value=value), patch.object(Path, 'expanduser', side_effect=AssertionError('OS lookup')):
+                with self.assertRaises(paths.RuntimeBindingError):
+                    paths.expand_input_path(value)
+        for value, expected in (('~/safe', self.root / 'safe'), (str(self.root / 'safe'), self.root / 'safe'),
+                                ('safe', Path.cwd() / 'safe')):
+            self.assertEqual(paths.expand_input_path(value), expected.resolve())
+
+    def test_evidence_child_binding_failure_is_json_and_never_spawns(self):
+        from omh.plugin_bundle.omh.tools import evidence_tool
+        for root in ('default_omh_home', 'default_hermes_home'):
+            with self.subTest(root=root), patch.object(paths, root, side_effect=paths.RuntimeBindingError('PRIVATE_PATH')), \
+                    patch.object(evidence_tool.subprocess, 'run') as child:
+                result = json.loads(evidence_tool.omh_evidence_handler({
+                    'commands': ['git diff --check'], 'project_root': str(self.root)}))
+            child.assert_not_called()
+            self.assertIn('error', result)
+            self.assertNotIn('PRIVATE_PATH', json.dumps(result))
+
+    def test_native_model_home_overrides_are_rejected_before_observation(self):
+        tools = {'delegate_route': ('omh_delegate_route', {'action': 'status'}),
+                 'probe': ('omh_probe', {}), 'status': ('omh_status', {}), 'hud': ('omh_hud', {}),
+                 'todo': ('omh_todo', {'action': 'show'}), 'chat': ('omh_interact', {'message': 'hello'}),
+                 'run_summary': ('omh_run_summary', {})}
+        with patch.dict(sys.modules, native_modules(self.home, self.store)):
+            for file, (name, args) in tools.items():
+                module = importlib.import_module('omh.plugin_bundle.omh.tools.' + file + '_tool')
+                for field in ('omh_home', 'hermes_home'):
+                    with self.subTest(tool=name, field=field), patch.object(module, 'observe_plugin_tool_call') as observer:
+                        result = json.loads(getattr(module, name + '_handler')({**args, field: 'PRIVATE_PATH'}))
+                    observer.assert_not_called()
+                    self.assertIn('error', result)
+                    self.assertNotIn('PRIVATE_PATH', json.dumps(result))
+        self.assertFalse(self.store.exists())
+
+    def test_project_artifact_routing_and_canonical_store_identity(self):
+        from omh.paths import resolve_paths, project_artifact_dir
+        project = self.root / 'project'
+        (project / '.git').mkdir(parents=True)
+        for native, routed in ((False, False), (True, False), (True, True)):
+            with self.subTest(native=native, routed=routed):
+                modules = native_modules(self.home, self.store, multiplex=routed) if native else {'hermes_constants': None}
+                with patch.dict(sys.modules, modules):
+                    selected = resolve_paths()
+                    self.assertEqual(selected.omh_home_named, routed)
+                    expected = self.store if routed else project / '.omh'
+                    self.assertEqual(project_artifact_dir(selected, 'goals', cwd=project), expected / 'goals')
+                    explicit = resolve_paths(self.store, self.home)
+                    self.assertTrue(explicit.omh_home_named)
+                    self.assertEqual(project_artifact_dir(explicit, 'goals', cwd=project), self.store / 'goals')
+                    with patch.object(paths, 'runtime_cwd', return_value=None):
+                        self.assertEqual(project_artifact_dir(selected, 'goals'), self.store / 'goals')
+        try:
+            (self.root / 'link').symlink_to(project, target_is_directory=True)
+        except OSError as exc:
+            self.skipTest(f'symlink unavailable: {type(exc).__name__}')
+        link = self.root / 'link'
+        with patch.object(paths, 'runtime_cwd', return_value=link):
+            scoped = resolve_paths(scope='project')
+            self.assertEqual(scoped.omh_home, project / '.omh')
+            self.assertEqual(scoped.hermes_home, project / '.hermes')
+            from omh.paths import find_project_root
+            self.assertEqual(paths.runtime_cwd(), link)
+            self.assertEqual(find_project_root(), project)
+        self.assertEqual(paths.resolve_homes(link / '.omh', link / '.hermes'),
+                         (scoped.omh_home, scoped.hermes_home))
+
+    def test_explicit_blank_homes_fail_closed_in_both_scopes(self):
+        from omh.paths import resolve_paths
+        for scope in ('user', 'project'):
+            for field in ('omh_home', 'hermes_home'):
+                with self.subTest(scope=scope, field=field), self.assertRaises(paths.RuntimeBindingError):
+                    resolve_paths(**{field: ''}, scope=scope)
+
+    def test_standalone_observer_honors_explicit_homes_not_environment(self):
+        from omh.plugin_bundle.omh.host_observation import observe_plugin_tool_call
+        target = self.root / 'explicit'
+        result = observe_plugin_tool_call('omh_status', {'omh_home': str(target),
+            'hermes_home': str(self.home), 'observation': {'host': 'test-host', 'session_id': 's'}}, {})
+        self.assertEqual(result['status'], 'observed')
+        self.assertTrue(list((target / 'runtime').glob('*observations.jsonl')))
+        self.assertFalse(self.store.exists())
+
+    def test_native_observer_ignores_untrusted_home_metadata(self):
+        from omh.plugin_bundle.omh.host_observation import observe_plugin_tool_call
+        with patch.dict(sys.modules, native_modules(self.home, self.store)):
+            result = observe_plugin_tool_call('omh_status', {'omh_home': str(self.root / 'foreign'),
+                'observation': {'host': 'test-host', 'session_id': 's', 'omh_home': str(self.root / 'foreign')}}, {})
+        self.assertEqual(result['status'], 'observed')
+        self.assertTrue(self.store.exists())
+        self.assertFalse((self.root / 'foreign').exists())
+
+    def test_bundle_only_observer_honors_explicit_pair(self):
+        import builtins
+        from omh.plugin_bundle.omh.host_observation import observe_plugin_hook_call
+        real_import = builtins.__import__
+        def without_core(name, *args, **kwargs):
+            if name == 'omh.paths':
+                raise ModuleNotFoundError('core unavailable', name='omh.paths')
+            return real_import(name, *args, **kwargs)
+        target = self.root / 'bundle-explicit'
+        with patch('builtins.__import__', side_effect=without_core):
+            result = observe_plugin_hook_call('pre_llm_call', {'omh_home': str(target),
+                'hermes_home': str(self.home), 'host': 'test-host', 'session_id': 's'})
+        self.assertEqual(result['status'], 'observed')
+        self.assertTrue((target / 'runtime/plugin_host_observations.jsonl').is_file())
+        self.assertFalse(self.store.exists())
+
+    def test_native_home_schema_descriptions_state_the_refusal(self):
+        for name in ('chat', 'delegate_route', 'hud', 'probe', 'run_summary', 'status', 'todo'):
+            module = importlib.import_module('omh.plugin_bundle.omh.tools.' + name + '_tool')
+            for symbol, schema in vars(module).items():
+                if not symbol.startswith('OMH_') or not symbol.endswith('_SCHEMA'):
+                    continue
+                for field, value in schema['parameters']['properties'].items():
+                    if field in ('omh_home', 'hermes_home'):
+                        self.assertIn('Native Hermes calls reject', value['description'])
+
+    def test_memory_module_missing_symbols_is_optional_but_internal_faults_propagate(self):
+        name = 'omh.plugin_bundle.omh._memory_import_review'
+        original = importlib.import_module('omh.plugin_bundle.omh.memory_provider')
+        def load():
+            spec = importlib.util.spec_from_file_location(name, original.__file__)
+            module = importlib.util.module_from_spec(spec)
+            with patch.dict(sys.modules, {name: module}):
+                spec.loader.exec_module(module)
+            return module
+        for module in (None, types.ModuleType('agent.memory_provider')):
+            with self.subTest(module=module), patch.dict(sys.modules, {'agent.memory_provider': module}):
+                loaded = load()
+                self.assertEqual(loaded.OmhMemoryProvider.__bases__, (object,))
+                self.assertEqual(loaded.RecallStatus('OMH', 2).count, 2)
+        class NativeBase:
+            pass
+        class NativeRecall:
+            pass
+        for base, recall in ((NativeBase, None), (None, NativeRecall), (NativeBase, NativeRecall)):
+            module = types.ModuleType('agent.memory_provider')
+            if base is not None:
+                module.MemoryProvider = base
+            if recall is not None:
+                module.RecallStatus = recall
+            with patch.dict(sys.modules, {'agent.memory_provider': module}):
+                loaded = load()
+                self.assertEqual(loaded.OmhMemoryProvider.__bases__, (base or object,))
+                if recall is not None:
+                    self.assertIs(loaded.RecallStatus, recall)
+        for failure in (ImportError('internal failure'), ModuleNotFoundError('internal failure', name='host_dependency')):
+            with patch.object(paths, 'import_module', side_effect=failure), self.assertRaises(type(failure)) as caught:
+                load()
+            self.assertIs(caught.exception, failure)
+        # The ordinary module and its class identities were never replaced.
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_runtime_binding_review.py
+++ b/tests/test_runtime_binding_review.py
@@ -183,8 +183,10 @@ class RuntimeBindingReviewTests(unittest.TestCase):
             for file, (name, args) in tools.items():
                 module = importlib.import_module('omh.plugin_bundle.omh.tools.' + file + '_tool')
                 for field in ('omh_home', 'hermes_home'):
-                    with self.subTest(tool=name, field=field), patch.object(module, 'observe_plugin_tool_call') as observer:
+                    with self.subTest(tool=name, field=field), patch.object(module, 'observe_plugin_tool_call') as observer, \
+                            patch.object(paths, 'plugin_home', side_effect=AssertionError('home lookup before rejection')) as resolver:
                         result = json.loads(getattr(module, name + '_handler')({**args, field: 'PRIVATE_PATH'}))
+                    resolver.assert_not_called()
                     observer.assert_not_called()
                     self.assertIn('error', result)
                     self.assertNotIn('PRIVATE_PATH', json.dumps(result))

--- a/tests/test_runtime_binding_review.py
+++ b/tests/test_runtime_binding_review.py
@@ -66,7 +66,7 @@ class RuntimeBindingReviewTests(unittest.TestCase):
                     if name is None:
                         modules[module] = None
                     else:
-                        setattr(modules[module], name, None)
+                        vars(modules[module])[name] = None
                     # A wholly absent Hermes is the supported standalone lane.
                     if module == 'hermes_constants' and name is None:
                         continue

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -28,11 +28,14 @@ class RuntimePathsTests(unittest.TestCase):
         secrets.get_secret = lambda key, default=None: values.get().get(key, default)
         config = types.ModuleType("hermes_cli.config")
         config.load_config_readonly = lambda: {}
+        managed = types.ModuleType("hermes_cli.managed_scope")
+        managed.load_managed_config = lambda: {}
+        secrets.build_profile_secret_scope = lambda owner: {"OMH_HOME": str(owner.parent / (owner.name + "-state"))}
         config.require_readable_config_before_write = lambda *args: {}
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory).resolve()
             modules = {"hermes_constants": constants, "agent.secret_scope": secrets,
-                       "hermes_cli.config": config}
+                       "hermes_cli.config": config, "hermes_cli.managed_scope": managed}
             async def read(label):
                 expected_home, expected_store = root / label, root / (label + "-state")
                 home.set(expected_home)
@@ -95,6 +98,61 @@ class RuntimePathsTests(unittest.TestCase):
             for name, host in (("a", host_a), ("b", host_b)):
                 with patch.object(runtime_paths, "default_hermes_home", return_value=root / name):
                     self.assertEqual(board.handler_identity(args, {"session_id": "session", "task_id": "task"}), host)
+
+
+    def test_untrusted_evidence_paths_cannot_expand_environment(self):
+        import json
+        from omh.plugin_bundle.omh.tools.evidence_tool import omh_evidence_handler
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            with patch.dict("sys.modules", {"hermes_constants": None}), patch.dict("os.environ", {
+                "OMH_HOME": str(root / "state"), "HERMES_HOME": str(root / "profile"),
+                "SYNTHETIC_PATH_SECRET": "SYNTHETIC_NOT_FOR_OUTPUT",
+            }):
+                for field in ("project_root", "workdir"):
+                    for reference in ("$SYNTHETIC_PATH_SECRET", "${SYNTHETIC_PATH_SECRET}",
+                                      "${env:SYNTHETIC_PATH_SECRET}", "%SYNTHETIC_PATH_SECRET%"):
+                        with self.subTest(field=field, reference=reference):
+                            result = omh_evidence_handler({"commands": ["git diff --check"],
+                                "project_root": str(root), field: reference})
+                            self.assertNotIn("SYNTHETIC_NOT_FOR_OUTPUT", result)
+                            self.assertEqual(json.loads(result)["error"],
+                                             "OMH input paths do not support variable references")
+                # Evidence itself remains useful: literal paths still run the
+                # allowlisted local probe, with the same minimal environment.
+                with patch("subprocess.run") as child:
+                    child.return_value = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+                    result = json.loads(omh_evidence_handler({"commands": ["git diff --check"],
+                                                             "project_root": str(root)}))
+                    self.assertTrue(result["all_pass"])
+                    self.assertNotIn("SYNTHETIC_PATH_SECRET", child.call_args.kwargs["env"])
+
+    def test_foreign_scope_is_not_a_profile_binding(self):
+        from omh.plugin_bundle.omh import runtime_paths as paths
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            private, public = root / "private", root / "public"
+            secrets = types.SimpleNamespace(is_multiplex_active=lambda: True,
+                current_secret_scope=lambda: {"OMH_HOME": str(private)},
+                build_profile_secret_scope=lambda home: {"OMH_HOME": str(public)})
+            with patch.dict("sys.modules", {"agent.secret_scope": secrets}):
+                with self.assertRaisesRegex(paths.RuntimeBindingError, "ownership is unverified"):
+                    paths._profile_variable("OMH_HOME", root / "profile")
+                secrets.current_secret_scope = lambda: {"OMH_HOME": str(public)}
+                self.assertEqual(paths._profile_variable("OMH_HOME", root / "profile"), str(public))
+
+    def test_managed_winning_raw_leaf_ignores_shadowed_user_template(self):
+        from omh.plugin_bundle.omh import runtime_paths as paths
+        def config(value):
+            return {"plugins": {"entries": {"omh": {"settings": {"omh_home": value}}}}}
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            managed = config(str(root / "managed"))
+            host = types.SimpleNamespace(require_readable_config_before_write=lambda path: config("$UNAVAILABLE_USER_PATH/state"),
+                                         load_config_readonly=lambda: managed)
+            with patch.dict("sys.modules", {"hermes_cli.config": host,
+                    "hermes_cli.managed_scope": types.SimpleNamespace(load_managed_config=lambda: managed)}):
+                self.assertEqual(paths._configured_home(root / "profile"), root / "managed")
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -35,7 +35,8 @@ class RuntimePathsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory).resolve()
             modules = {"hermes_constants": constants, "agent.secret_scope": secrets,
-                       "hermes_cli.config": config, "hermes_cli.managed_scope": managed}
+                       "hermes_cli.config": config, "hermes_cli.managed_scope": managed,
+                       "agent.runtime_cwd": types.SimpleNamespace(resolve_context_cwd=lambda: None, resolve_agent_cwd=Path.cwd)}
             async def read(label):
                 expected_home, expected_store = root / label, root / (label + "-state")
                 home.set(expected_home)

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -1,0 +1,101 @@
+"""Profile bindings must not borrow a launch profile's runtime state."""
+from __future__ import annotations
+
+import asyncio
+from contextvars import ContextVar
+from pathlib import Path
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+from _local_package import load_local_package
+
+load_local_package()
+from omh.plugin_bundle.omh import runtime_reader
+
+
+class RuntimePathsTests(unittest.TestCase):
+    def test_scoped_readers_do_not_borrow_process_homes(self):
+        home = ContextVar("test_home")
+        values = ContextVar("test_values")
+        constants = types.ModuleType("hermes_constants")
+        constants.get_hermes_home = home.get
+        constants.get_hermes_home_override = home.get
+        secrets = types.ModuleType("agent.secret_scope")
+        secrets.is_multiplex_active = lambda: True
+        secrets.current_secret_scope = values.get
+        secrets.get_secret = lambda key, default=None: values.get().get(key, default)
+        config = types.ModuleType("hermes_cli.config")
+        config.load_config_readonly = lambda: {}
+        config.require_readable_config_before_write = lambda *args: {}
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            modules = {"hermes_constants": constants, "agent.secret_scope": secrets,
+                       "hermes_cli.config": config}
+            async def read(label):
+                expected_home, expected_store = root / label, root / (label + "-state")
+                home.set(expected_home)
+                values.set({"OMH_HOME": str(expected_store)})
+                await asyncio.sleep(0)
+                self.assertEqual(runtime_reader._default_omh_home(), expected_store)
+                self.assertEqual(runtime_reader._default_hermes_home(), expected_home)
+                self.assertEqual(await asyncio.to_thread(runtime_reader._default_omh_home), expected_store)
+            async def run():
+                await asyncio.gather(read("alpha"), read("beta"))
+            with patch.dict("sys.modules", modules), patch.dict("os.environ", {
+                "OMH_HOME": str(root / "launch-state"), "HERMES_HOME": str(root / "launch")
+            }):
+                asyncio.run(run())
+
+
+    def test_standalone_explicit_pairs_and_host_failures(self):
+        import os
+        from omh.plugin_bundle.omh import runtime_paths as paths
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            with patch.dict("sys.modules", {"hermes_constants": None}), patch.dict(os.environ, {
+                "HOME": str(root), "OMH_HOME": str(root / "state"), "HERMES_HOME": str(root / "profile")
+            }):
+                self.assertEqual(paths.resolve_homes(), (root / "state", root / "profile"))
+                self.assertEqual(paths.resolve_homes(root / "shared", root / "other"), (root / "shared", root / "other"))
+                self.assertEqual(paths.resolve_homes("$HERMES_HOME/state", root / "other"), (root / "other/state", root / "other"))
+                for invalid in ("", "   ", [], {}, False, "bad\0path", "$UNBOUND_OMH_TEST_PATH/state"):
+                    with self.subTest(invalid=invalid), self.assertRaises(paths.RuntimeBindingError):
+                        paths.resolve_homes(invalid, root / "other")
+                del os.environ["OMH_HOME"]
+                self.assertEqual(paths.default_omh_home(), root / ".omh")
+            broken = ModuleNotFoundError("missing host dependency", name="host_dependency")
+            with patch.object(paths, "import_module", side_effect=broken):
+                with self.assertRaises(ModuleNotFoundError) as caught:
+                    paths.default_omh_home()
+                self.assertIs(caught.exception, broken)
+
+    def test_same_session_ids_do_not_consume_another_profiles_guards(self):
+        import json
+        from omh.plugin_bundle.omh import agent_board_bridge as board, toolcall_rules as rules
+        from omh.plugin_bundle.omh import runtime_paths
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            for name in ("a", "b"):
+                rule_path = root / name / "rules" / "toolcall-rules.json"
+                rule_path.parent.mkdir(parents=True)
+                rule_path.write_text(json.dumps({"schema_version": rules.TOOLCALL_RULES_SCHEMA_VERSION,
+                    "rules": [{"name": "same-rule", "pattern": "blocked", "message": "Stop", "repeat": "once"}]}))
+            for name in ("a", "b"):
+                with patch.object(runtime_paths, "default_hermes_home", return_value=root / name):
+                    self.assertIsNotNone(rules.toolcall_rule_directive(tool_name="blocked",
+                        tool_input={}, session_id="collision", omh_home=str(root / name)))
+            host_a = board.HostIdentity("session", "task", "call-a")
+            host_b = board.HostIdentity("session", "task", "call-b")
+            args = {"operation": "prepare"}
+            for name, host in (("a", host_a), ("b", host_b)):
+                with patch.object(runtime_paths, "default_hermes_home", return_value=root / name):
+                    board._arm_prepare_call(host, board._input_digest(args))
+            for name, host in (("a", host_a), ("b", host_b)):
+                with patch.object(runtime_paths, "default_hermes_home", return_value=root / name):
+                    self.assertEqual(board.handler_identity(args, {"session_id": "session", "task_id": "task"}), host)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -58,7 +58,8 @@ class RuntimePathsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory).resolve()
             with patch.dict("sys.modules", {"hermes_constants": None}), patch.dict(os.environ, {
-                "HOME": str(root), "OMH_HOME": str(root / "state"), "HERMES_HOME": str(root / "profile")
+                "HOME": str(root), "USERPROFILE": str(root),
+                "OMH_HOME": str(root / "state"), "HERMES_HOME": str(root / "profile")
             }):
                 self.assertEqual(paths.resolve_homes(), (root / "state", root / "profile"))
                 self.assertEqual(paths.resolve_homes(root / "shared", root / "other"), (root / "shared", root / "other"))

--- a/tests/test_runtime_reader_filesystem_faults.py
+++ b/tests/test_runtime_reader_filesystem_faults.py
@@ -235,6 +235,34 @@ class ClassifyingHandlerReachTests(unittest.TestCase):
 
             self.assert_status_read_degradation(payload, "RuntimeError")
 
+    @requires_symlinks
+    def test_either_home_fault_stops_all_scoped_io_before_awareness(self) -> None:
+        from unittest.mock import patch
+        from omh.plugin_bundle.omh.hooks import llm_hooks
+
+        with TemporaryDirectory() as tmp:
+            loop = Path(tmp) / "private-loop"
+            loop.symlink_to(loop)
+            for home_key in ("omh_home", "hermes_home"):
+                for awareness in (False, True):
+                    with self.subTest(home=home_key, awareness=awareness):
+                        homes = {"omh_home": str(Path(tmp) / ".omh"), "hermes_home": str(Path(tmp) / ".hermes")}
+                        homes[home_key] = str(loop)
+                        with (
+                            patch.object(llm_hooks, "record_approval_bypass") as approval,
+                            patch.object(llm_hooks, "read_running_work_board") as board,
+                            patch.object(llm_hooks, "_record_delivery") as delivery,
+                            patch.object(llm_hooks, "observe_plugin_hook_call") as observation,
+                        ):
+                            payload = pre_llm_call(
+                                **homes, user_message="fix the GitHub PR", is_first_turn=True,
+                                include_omh_awareness=awareness,
+                            )
+                        self.assert_status_read_degradation(payload, "RuntimeError")
+                        self.assertNotIn(str(loop), str(payload))
+                        for downstream in (approval, board, delivery, observation):
+                            downstream.assert_not_called()
+
 
 class RoleCatalogProbeTests(unittest.TestCase):
     """The role-catalog probe is deliberately left tolerant."""

--- a/tests/test_runtime_reader_filesystem_faults.py
+++ b/tests/test_runtime_reader_filesystem_faults.py
@@ -233,7 +233,7 @@ class ClassifyingHandlerReachTests(unittest.TestCase):
 
             payload = self.call_pre_llm(loop, Path(tmp) / ".hermes")
 
-            self.assert_status_read_degradation(payload, "RuntimeError")
+            self.assert_status_read_degradation(payload, "RuntimeBindingError")
 
     @requires_symlinks
     def test_either_home_fault_stops_all_scoped_io_before_awareness(self) -> None:
@@ -258,7 +258,7 @@ class ClassifyingHandlerReachTests(unittest.TestCase):
                                 **homes, user_message="fix the GitHub PR", is_first_turn=True,
                                 include_omh_awareness=awareness,
                             )
-                        self.assert_status_read_degradation(payload, "RuntimeError")
+                        self.assert_status_read_degradation(payload, "RuntimeBindingError")
                         self.assertNotIn(str(loop), str(payload))
                         for downstream in (approval, board, delivery, observation):
                             downstream.assert_not_called()

--- a/tests/test_toolcall_rules.py
+++ b/tests/test_toolcall_rules.py
@@ -152,7 +152,7 @@ class LoadAndValidateTest(unittest.TestCase):
         try:
             self.assertEqual(
                 toolcall_rules_path(),
-                self.home / "rules" / "toolcall-rules.json",
+                self.home.resolve() / "rules" / "toolcall-rules.json",
             )
         finally:
             if previous is None:


### PR DESCRIPTION
## Current-head review follow-up

Head: `4339deca27d2967941b022d0d41cd725c169335f`.

Addressed all five Important findings and four Nits from sionic-khope's review of `2e40351e`; the point-by-point response is in the PR conversation. Changes preserve the original profile-isolation goal rather than redesigning it:

- Classify binding faults before hook I/O, and block pre-tool calls when their rules owner cannot be established. Direct reader and rule-error semantics remain explicit.
- Distinguish actual native registration/task scopes from a colocated standalone CLI; probe required host APIs without caching identity. Test ordinary single-owner callbacks as well as routed profiles.
- Reject native model home overrides before home/config resolution or observation. Restore real tool-cycle tests and verify malformed-config/missing-API refusals produce JSON without file changes.
- Compare both literal values and presence of the winning raw/effective configuration leaf. Preserve managed/null precedence.
- Restore trusted standalone observer overrides; document artifact-location defaults, canonical store identity, logical cwd, and intentional blank-home refusal. Reject named-user expansion and classify child binding failures without spawning; tolerate genuinely missing optional memory exports.

### Observed verification for this follow-up

- **Complete local Python 3.11 suite at this exact head: 11,568 tests run, OK, 3 skips.** Clean child environment and synthetic homes; unchanged candidate SHA/tree and clean worktree after execution. The three skips are platform/filesystem-specific, not failed cases silently removed.
- **Complete opt-in actual-Hermes native suite at this head: 74 passed, zero failures, no retries.** Both native test files used the canonical per-file runner against an isolated Hermes source copy. No inference or live platform delivery was performed.
- Independent review covered the effective PR and finite feedback obligations. Its one remaining probe-order finding was fixed, followed by a bounded independent re-review with the original reproductions passing; no Important findings remained in the reviewed scope. The subsequent one-line fixture-only adjustment preserves the static CI inventory and all assertions.
- Static shard planner passed, assigning 11,530 planned IDs exactly once. Planner and unittest-discovery totals are different inventories, not additive test counts.
- Ruff (`src tests tools packaging`), compileall, whitespace and all eight documentation checks passed. Final product sources match the separately built/installed wheel smoke (standalone roots and the real status handler); the only later diff is the CI-planner-compatible test fixture.
- **[Hosted CI run 34703960318](https://github.com/rlaope/oh-my-hermes/actions/runs/34703960318): SUCCESS at `4339deca27d2967941b022d0d41cd725c169335f`. All 13 workflow jobs plus DCO passed**, including both Linux Python versions, both Windows shards, quarantine lanes, distribution on Linux/macOS and the fail-closed aggregate. Previous-head CI remains historical evidence.

The first complete follow-up run exposed a static-planner fixture shape and a local macOS test-environment issue. The fixture was corrected without relaxing the planner; preserving non-secret `TMPDIR` restored the existing macOS alias test. The complete frozen suite was then rerun successfully as recorded above.

No merge, productive installation update, live model/platform delivery or deployment was performed. Historical implementation evidence below stays attributed to its original head.

## Feature Report

### What Changed

Bind OMH's implicit runtime state to the **active Hermes profile**, rather than the gateway process's environment or working directory. The copied plugin and installed package share one uncached root resolver; providers, tools, hooks, optional observers and evidence subprocesses use the same owner binding.

This is an OMH-only fix: **no Hermes core patch, new dependency, global environment switching, or automatic gateway/data migration**. Opened following private maintainer coordination under `SECURITY.md`.

### Why This Exists

Hermes multiplexed gateways switch profile, secret and working-directory context per task. Several OMH components instead used process `OMH_HOME`/`HERMES_HOME`, literal OS-home defaults, or process cwd. Synthetic tests with real Hermes loaders reproduced reads and writes reaching the launch profile's store despite a correctly selected secondary profile.

Principal/audience filtering and store containment operate **after** root selection and do not fix a wrong root. This complements #1511: stable project identity remains intact, and the provider now derives that identity from its bound logical cwd rather than a foreign launch checkout.

**Impact boundary:** no production credential leak or live model disclosure is claimed. Direct provider/tool probes exposed a synthetic private marker; the ordinary native turn-start path cleared that pack before return but still wrote state to the wrong store. Both read and write paths are covered rather than treating empty output as isolation.

### User / Operator Impact

- Correctly configured profiles retain their own OMH/Hermes state when sharing a gateway process.
- Explicitly shared stores and standalone operator overrides remain supported.
- Missing, malformed or unverifiable routed bindings fail explicitly before foreign-store I/O.
- Existing profile settings and scoped legacy `OMH_HOME` bindings are supported; managed configuration keeps native precedence and empty-section semantics.
- Model-facing evidence paths cannot expand arbitrary scoped credential variables.

### How It Works

- A small bundled `runtime_paths` resolver with uncached owner binding selects trusted explicit pairs, effective profile settings and scoped legacy values. Package defaults reuse it; no additional current-profile singleton or ContextVar is introduced.
- Long-lived provider instances bind before availability checks and retain their homes for background work. Anonymous scope values are checked against the native home-owned snapshot when home-only registration could otherwise mix owners.
- Tools, hook journals and optional observer/egress/browser registrations use consistent roots. Stateful session-correlation keys include the relevant owner identity; pure caches are unchanged.
- Trusted configuration expansion is separate from model-facing path validation. Existing command allowlists, `shell=False`, timeouts, secret stripping, admission and integrity checks remain in place.
- Project root/identity uses initialized logical cwd. A bound absent cwd remains unresolved during later rendering instead of invoking the upstream resolver's ambient-cwd fallback. #1511 identity refresh, selector behavior, migration and v3 receipts are preserved.
- Evidence subprocesses receive only the bound non-secret homes in the existing minimal environment.

### Files And Contracts Touched

`src/plugin_bundle/omh/runtime_paths.py`; provider/runtime readers; tool and hook defaults; observer registration and scoped correlation caches; `src/system/paths.py`; operator documentation in `docs/INSTALLATION.md`; standalone unit tests and real-native integration tests under `tests/native/`.

### Affected Surfaces

- [x] Hermes chat or wrapper
- [ ] Codex — no executor-specific implementation or live execution
- [ ] Claude Code — no executor-specific implementation or live execution
- [x] Hermes runtime or handoff
- [ ] Generic executor — no executor dispatch change
- [x] Not executor-specific

## Validation

Prior implementation validation head (historical evidence below): `2e40351ee799f6b30ee6623393030f68cbcfe77c`, based on `e2844979c083aceee417923d39d17f75c9385999` (#1511).

- [x] `uv run --group lint ruff check src tests`
- [x] `PYTHONPATH=tests uv run python -m unittest discover -s tests -v`
- [x] `uv run python -m compileall -q src tests`
- [x] `uv run python -m omh.cli docs workflows --check`
- [x] `uv run python -m omh.cli docs roles --check`
- [x] `uv run python -m omh.cli docs capability-families --check`
- [ ] `uv run python -m omh.cli harness validate` — not run; no harness contract change
- [ ] `uv run python -m omh.cli release checklist --json` — not a release operation
- [ ] `uv run python -m omh.cli release hermes-smoke` — not run; isolated native/bundle smokes below
- [x] `git diff --check`
- [x] `omh --help` — candidate CLI module entry point
- [ ] `omh --omh-home /tmp/omh-smoke --hermes-home /tmp/hermes-smoke release hermes-smoke --install-path setup --omh-command omh --include-command-smoke` — full setup/release smoke not run
- [ ] Relevant workflow-learning review queue smoke — N/A; learning behavior is unchanged
- [x] Relevant dry-run or smoke command — wheel installation and actual copied-plugin bundle/source-byte checks
- [ ] Manual Hermes/TUI check — no interactive session or live platform/model delivery; actual native integration exercised without inference

### Observed Evidence

| Check | Result |
|---|---|
| Complete local unittest suite | **11,547 tests run; OK, 3 skips; no failures/errors** |
| Real-native profile integration | **63 cases passed** |
| Affected standalone selection | **1,684 passed across 64 modules**; overlaps full suite, not an additional total |
| Ruff, compileall, whitespace | Passed |
| Documentation projections | All eight checks passed: workflows, roles, claims, navigation, capability-families, ulw-inventory, ulw-site, chain-table |
| Wheel and copied plugin | Built, installed in isolation, source-byte checks passed |
| Patch application | Applied to the exact base in a disposable clone; resulting tree equals tested tree |
| Independent source reviews | Reported Important findings fixed and rechecked; bounded #1511 integration review found none remaining |

The full suite ran on macOS/Python 3.13.5 in an independent Git clone with a separate strict-editable environment and synthetic homes; tracked source remained unchanged. The skips were Linux dumpability, Windows process cleanup, and a case-collision check unsupported by the host filesystem.

Native tests used Hermes 0.21.2 APIs on macOS/Python 3.11. They cover both plugin/provider loading orders, both profile orders, concurrent task scopes, explicit sharing, ambiguous/missing bindings, partial registration, managed configuration, untrusted inputs, minimal child environments, bound-provider background work, and logical cwd/project identity. Same-basename projects, explicit identities without `.git`, normalized remotes, missing identities and later foreign-profile rendering have positive and negative controls.

To run the opt-in native tests, set `HERMES_SOURCE` to an absolute checkout with the supported native APIs, then from this repository run:

```sh
"$HERMES_SOURCE/scripts/run_tests.sh" \
  "$PWD/tests/native/test_profile_runtime.py" \
  "$PWD/tests/native/test_review_native.py" \
  "--native-source=$HERMES_SOURCE" \
  "--rootdir=$PWD/tests/native"
```

### Not Tested / Not Applicable

The historical validation rows above refer to the prior implementation head. Current-head local/native evidence and hosted-CI status are recorded at the top. Older-host compatibility, live Discord/model delivery, optional live room/browser/egress actions and exhaustive concurrent unload/first-use races remain untested. No external coding executor was started. Ordinary upstream `on_turn_start` pack invalidation is intentionally unchanged; positive correct-store recall is verified through the real queued prefetch path, not claimed as a repair of that separate lifecycle behavior.

## Risk

Shared defaults have broad integration reach. An unconfigured secondary profile or an ambiguous process-expanded template can now fail explicitly rather than inherit another owner's store. Use an absolute profile binding where required; `docs/INSTALLATION.md` explains precedence, sharing and failure behavior. Hosted operation requires the relevant native scope/config APIs; genuinely standalone OMH remains host-independent. Snapshot ownership checks add a native profile snapshot read, not a new global cache or network hydration.

## Compatibility / Rollout

Keep public/private gateway processes separate until the patched package passes the deployment's own checks. This PR does not migrate data, rewrite every profile binding, broaden tool permissions or combine gateways automatically. Explicit same-store configuration still intentionally shares that store and is not an OS sandbox. Existing principal, retention, containment and integrity guards remain necessary and unchanged.

## Release / Claims

- [x] Release-channel impact considered (`stable`, `preview`, or `local`)
- [x] Runtime/native capability claims are backed by evidence or marked as not observed
- [x] Prepared artifacts are not presented as execution, hosted CI, merge or deployment evidence
- [x] Evidence contains only synthetic fixtures, not credentials, transcripts or unrelated private setup data
- [x] Known manual/live gaps are listed above

## Follow-Up

Current-head local/native verification and exact-head hosted CI passed, as recorded above. Review the documented compatibility choices before release. Unrelated memory lifecycle behavior and sandbox test-location portability are intentionally outside this contribution. No automatic merge or production deployment is requested.
